### PR TITLE
fix - Centralise DA Preview Script

### DIFF
--- a/scripts/dapreview.js
+++ b/scripts/dapreview.js
@@ -1,6 +1,4 @@
-import loadPage from './scripts.js';
-
-(function daPreview() {
+export default function daPreview(loadPage) {
   let port2;
 
   async function onMessage(e) {
@@ -27,4 +25,4 @@ import loadPage from './scripts.js';
   }
 
   window.addEventListener('message', initPort);
-}());
+};

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -96,4 +96,14 @@ export default async function loadPage() {
 
   await loadArea();
 };
+
+// Side-effects
+(async function daPreview() {
+  const { searchParams } = new URL(window.location.href);
+  if (searchParams.get('dapreview') === 'on') { 
+    const { default: livePreview } = await import('./dapreview.js');
+    livePreview(loadPage);
+  }
+}());
+
 loadPage();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -54,15 +54,6 @@ function imsCheck(createTag) {
 }
 
 /*
- * Side effects to only run once
- */
-
-(async function daPreview() {
-  const { searchParams } = new URL(window.location.href);
-  if (searchParams.get('dapreview') === 'on') import('./dapreview.js');
-}());
-
-/*
  * ------------------------------------------------------------
  * Edit below at your own risk
  * ------------------------------------------------------------


### PR DESCRIPTION
## Description

Allow the DA Preview script to be loaded from a central source (https://da.live) in all projects.


## Motivation and Context

Be able to change the DA Preview script without needing to update it in all sites.

## How Has This Been Tested?

Manually on: https://central-da-preview--da-live--adobe.hlx.live/edit#/adobe/da-live/test
Manually on: https://main--da-test--andreituicu.hlx.page/test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
