### PR TITLE
feat: Central DA Preview CSS

### DIFF
--- a/blocks/edit/da-preview/da-preview.css
+++ b/blocks/edit/da-preview/da-preview.css
@@ -6,7 +6,6 @@ iframe {
   border: none;
   box-shadow: rgb(181, 181, 181) 0px 0px 20px 0px;
   overflow: hidden;
-  pointer-events: none;
 }
 
 .da-preview-menubar {

--- a/scripts/dapreview.js
+++ b/scripts/dapreview.js
@@ -15,12 +15,9 @@ async function loadCSS(href) {
 
 export default async function daPreview(loadPage) {
   const { origin } = new URL(import.meta.url);
-  const daCSS = new URL('/styles/dapreview.css', origin).toString();
-  await loadCSS(daCSS);
-  console.log('Loaded ', daCSS);
+  await loadCSS(new URL('/styles/dapreview.css', origin).toString());
 
   let port2;
-
   async function onMessage(e) {
     console.log(e.data);
 

--- a/scripts/dapreview.js
+++ b/scripts/dapreview.js
@@ -14,8 +14,11 @@ async function loadCSS(href) {
 }
 
 export default async function daPreview(loadPage) {
+  console.log('Loaded at', import.meta.url);
   const { origin } = import.meta.url;
-  await loadCSS(new URL('/styles/dapreview.css', origin).toString());
+  const daCSS = new URL('/styles/dapreview.css', origin).toString();
+  await loadCSS(daCSS);
+  console.log('Loaded ', daCSS);
 
   let port2;
 

--- a/scripts/dapreview.js
+++ b/scripts/dapreview.js
@@ -14,8 +14,7 @@ async function loadCSS(href) {
 }
 
 export default async function daPreview(loadPage) {
-  console.log('Loaded at', import.meta.url);
-  const { origin } = import.meta.url;
+  const { origin } = new URL(import.meta.url);
   const daCSS = new URL('/styles/dapreview.css', origin).toString();
   await loadCSS(daCSS);
   console.log('Loaded ', daCSS);

--- a/scripts/dapreview.js
+++ b/scripts/dapreview.js
@@ -1,4 +1,22 @@
-export default function daPreview(loadPage) {
+async function loadCSS(href) {
+  return new Promise((resolve, reject) => {
+    if (!document.querySelector(`head > link[href="${href}"]`)) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      link.onload = resolve;
+      link.onerror = reject;
+      document.head.append(link);
+    } else {
+      resolve();
+    }
+  });
+}
+
+export default async function daPreview(loadPage) {
+  const { origin } = import.meta.url;
+  await loadCSS(new URL('/styles/dapreview.css', origin).toString());
+
   let port2;
 
   async function onMessage(e) {

--- a/styles/dapreview.css
+++ b/styles/dapreview.css
@@ -1,0 +1,3 @@
+a[href] {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The purpose of this PR is to:
* Allow a central CSS that's loaded from DA on any project, without the need for projects to do anything.
* Re-enable pointer events for the DA Live Preview iframe so that authors can interact with their blocks
* Disable pointer events just for the links inside of the live preview that have an `href` attribute defined


## How Has This Been Tested?

Manually on: https://central-preview-css--da-live--adobe.hlx.live/edit#/andreituicu/da-test/test


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
