### PR TITLE
Pass authorization to da-collab

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -82,7 +82,14 @@ export default function initProse({ editor, path }) {
 
   const server = 'wss://collab.da.live';
   const roomName = `https://admin.da.live${new URL(path).pathname}`;
-  const wsProvider = new WebsocketProvider(server, roomName, ydoc);
+
+  const opts = {};
+
+  if (window.adobeIMS.isSignedInUser()) {
+    opts.params = { Authorization: `Bearer ${window.adobeIMS.getAccessToken()?.token}` };
+  }
+
+  const wsProvider = new WebsocketProvider(server, roomName, ydoc, opts);
 
   const yXmlFragment = ydoc.getXmlFragment('prosemirror');
 


### PR DESCRIPTION
With https://github.com/adobe/da-collab/pull/2 da-collab will start accepting authorization headers in the request and subsequently, pass them along to da-admin. Which in turn, is going to accept them as part of an editing session when https://github.com/adobe/da-admin/pull/8 is merged. 

This PR makes da-live pass along the access token (if there is one because the user logged in) to da-collab. It should be merged after the PRs for da-admin and da-collab are merged and deployed.