### PR TITLE
GH-75 - Don't display own user in awareness icon list

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -87,7 +87,7 @@ export default class DaTitle extends LitElement {
   renderCollab() {
     return html`
       <div class="collab-status">
-        ${this.collabUsers && this.collabUsers.length > 1 ? this.renderCollabUsers() : nothing}
+        ${this.collabUsers ? this.renderCollabUsers() : nothing}
         <div class="collab-icon collab-status-cloud collab-status-${this.collabStatus}" data-popup-content="${this.collabStatus}" @click=${this.popover}>
          <svg class="icon"><use href="#${CLOUD_ICONS[this.collabStatus]}"/></svg>
         </div>

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -98,6 +98,9 @@ function handleAwarenessUpdates(wsProvider, daTitle, win) {
     delta.updated.forEach((u) => users.add(u));
     delta.removed.forEach((u) => users.delete(u));
 
+    // Don't show the current user
+    users.delete(wsProvider.awareness.clientID);
+
     const awarenessStates = wsProvider.awareness.getStates();
     const userNames = [...users].map((u) => awarenessStates.get(u)?.user?.name || 'Anonymous');
     daTitle.collabUsers = [...userNames].sort();

--- a/test/blocks/edit/proseCollab.test.js
+++ b/test/blocks/edit/proseCollab.test.js
@@ -20,6 +20,7 @@ describe('Prose collab', () => {
     const awarenessOnCalled = [];
     const awarenessStates = new Map();
     const awareness = {
+      clientID: 123,
       getStates: () => awarenessStates,
       on: (n, f) => awarenessOnCalled.push({ n, f }),
     };
@@ -51,18 +52,25 @@ describe('Prose collab', () => {
     expect(awarenessOnCalled.length).to.equal(1);
     expect(awarenessOnCalled[0].n).to.equal('update');
 
+    // The current user
     const knownUser123 = { user: { name: 'Daffy Duck' } };
     awarenessStates.set(123, knownUser123);
+    // Another known user
     const knownUser789 = { user: { name: 'Joe Bloggs' } };
     awarenessStates.set(789, knownUser789);
-    const delta = {
+
+    const delta1 = { added: [123], removed: [], updated: [] };
+    awarenessOnCalled[0].f(delta1); // Call the callback function
+    expect(daTitle.collabUsers.length).to.equal(0);
+
+    const delta2 = {
       added: [111, 456, 789, 123],
       removed: [456],
       updated: [234],
     };
 
-    awarenessOnCalled[0].f(delta); // Call the callback function
-    expect(daTitle.collabUsers).to.deep.equal(['Anonymous', 'Anonymous', 'Daffy Duck', 'Joe Bloggs']);
+    awarenessOnCalled[0].f(delta2); // Call the callback function
+    expect(daTitle.collabUsers).to.deep.equal(['Anonymous', 'Anonymous', 'Joe Bloggs']);
   });
 
   it('Test YDoc firstUpdate callback', (done) => {


### PR DESCRIPTION
## Description

The current user should not be displayed in the awareness icon list.

## Related Issue

Fixes: #75 

## Motivation and Context

Reduces clutter in the awareness icons list.

## How Has This Been Tested?

Unit test added and also tested manually on Chrome and Firefox.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed (except for the ones that were already failing)
