### PR TITLE
GH-78 - Personalized collaboration carets

### DIFF
--- a/test/blocks/edit/proseCollab.test.js
+++ b/test/blocks/edit/proseCollab.test.js
@@ -23,6 +23,7 @@ describe('Prose collab', () => {
       clientID: 123,
       getStates: () => awarenessStates,
       on: (n, f) => awarenessOnCalled.push({ n, f }),
+      getLocalState: () => awarenessStates.get(123),
     };
     const wspOnCalled = [];
     const wsp = {
@@ -53,10 +54,10 @@ describe('Prose collab', () => {
     expect(awarenessOnCalled[0].n).to.equal('update');
 
     // The current user
-    const knownUser123 = { user: { name: 'Daffy Duck' } };
+    const knownUser123 = { user: { name: 'Daffy Duck', id: 'daffy' } };
     awarenessStates.set(123, knownUser123);
     // Another known user
-    const knownUser789 = { user: { name: 'Joe Bloggs' } };
+    const knownUser789 = { user: { name: 'Joe Bloggs', id: 'bloggs' } };
     awarenessStates.set(789, knownUser789);
 
     const delta1 = { added: [123], removed: [], updated: [] };


### PR DESCRIPTION
## Description

Individual users get their own caret color and a logged in user only shows up one time in the present indicator.
Anonymous users all have the name Anonymous in their caret which has a different color for each.

<img width="1028" alt="Bildschirmfoto 2024-03-08 um 17 34 55" src="https://github.com/adobe/da-live/assets/410610/82d7d3e2-c132-4873-91ef-b52545a3e83d">

## Related Issue

Resolves: #78 

## Motivation and Context

Right now, all users have the same color for their caret - this makes it hard to see who is doing what. Furthermore, we give anon users a user id which might be confusing. If we combine the two, we can call anon users Anonymous but still have them look different due to their caret color. Finally, at least for logged in users, we should only show them one time in the presents indicator.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
