### PR TITLE
Fix editor reinitialisation triggered by server invalidation

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -179,7 +179,7 @@ export default function initProse({ editor, path }) {
 
   const yXmlFragment = ydoc.getXmlFragment('prosemirror');
   handleYDocUpdates({
-    daTitle, editor, ydoc, path, schema, wsProvider, yXmlFragment, initProse,
+    daTitle, editor, ydoc, path, schema, wsProvider, yXmlFragment, fnInitProse: initProse,
   });
 
   if (window.adobeIMS?.isSignedInUser()) {


### PR DESCRIPTION
## Description

A small mistake caused da-admin initiated invalidation to not fully reinitialise the editor. This PR fixes that issue.

## Related Issue

This is part of #74 

## Motivation and Context

It's a bug fix.

## How Has This Been Tested?

Tested in combinarion with da-collab and da-admin.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
