### PR TITLE
#38 Live Preview Icons

### DIFF
--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -111,6 +111,15 @@ function removeMetadata(editor) {
   editor.querySelector('.metadata')?.remove();
 }
 
+const iconRegex = /:([a-zA-Z0-9-]+?):/gm; // any alphanumeric character or - surrounded by :
+function parseIcons(editor) {
+  if (!iconRegex.test(editor.innerHTML)) return;
+  editor.innerHTML = editor.innerHTML.replace(
+    iconRegex,
+    (_, iconName) => `<span class="icon icon-${iconName}"></span>`,
+  );
+}
+
 export default function prose2aem(editor, live) {
   editor.removeAttribute('class');
   editor.removeAttribute('contenteditable');
@@ -137,7 +146,10 @@ export default function prose2aem(editor, live) {
 
   convertBlocks(editor);
 
-  if (live) removeMetadata(editor);
+  if (live) {
+    removeMetadata(editor);
+    parseIcons(editor);
+  }
 
   makePictures(editor);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Icons were showing as `:icon-name:` in the preview pane.  This converts the icon strings to icon spans for them to render properly in the preview pane (not to be confused with franklin preview where icons are working).

<!--- Describe your changes in detail -->

## Related Issue

#38 

## Release notes

Support icons (:my-icon:) in live preview.

