### PR TITLE
Helix 5

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -17,10 +17,10 @@ export const [setNx, getNx] = (() => {
     (nxBase, location) => {
       nx = (() => {
         const { hostname, search } = location || window.location;
-        if (!(hostname.includes('.hlx.') || hostname.includes('local'))) return nxBase;
+        if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local'))) return nxBase;
         const branch = new URLSearchParams(search).get('nx') || 'main';
         if (branch === 'local') return 'http://localhost:6456/nx';
-        return branch.includes('--') ? `https://${branch}.hlx.live/nx` : `https://${branch}--nexter--da-sites.hlx.live/nx`;
+        return branch.includes('--') ? `https://${branch}.aem.live/nx` : `https://${branch}--nexter--da-sites.aem.live/nx`;
       })();
       return nx;
     }, () => nx,

--- a/test/unit/scripts/utils.test.js
+++ b/test/unit/scripts/utils.test.js
@@ -4,7 +4,7 @@ import { setNx } from '../../../scripts/utils.js';
 describe('Libs', () => {
   it('Default Libs', () => {
     const libs = setNx('/nx');
-    expect(libs).to.equal('https://main--nexter--da-sites.hlx.live/nx');
+    expect(libs).to.equal('https://main--nexter--da-sites.aem.live/nx');
   });
 
   it('Does not support NX query param on prod', () => {
@@ -22,7 +22,7 @@ describe('Libs', () => {
       search: '?nx=foo',
     };
     const libs = setNx('/nx', location);
-    expect(libs).to.equal('https://foo--nexter--da-sites.hlx.live/nx');
+    expect(libs).to.equal('https://foo--nexter--da-sites.aem.live/nx');
   });
 
   it('Supports local NX query param', () => {
@@ -40,6 +40,6 @@ describe('Libs', () => {
       search: '?nx=awesome--nx--forkedowner',
     };
     const libs = setNx('/nx', location);
-    expect(libs).to.equal('https://awesome--nx--forkedowner.hlx.live/nx');
+    expect(libs).to.equal('https://awesome--nx--forkedowner.aem.live/nx');
   });
 });


### PR DESCRIPTION
## Test URLs

### Org
https://hfive--da-live--adobe.aem.live/

### Browse
https://hfive--da-live--adobe.aem.live/#/da-sites/xsc-wknd-commerce

### Edit
https://hfive--da-live--adobe.aem.live/edit#/da-sites/xsc-wknd-commerce/index

### Sheet
https://hfive--da-live--adobe.aem.live/sheet#/da-sites/xsc-wknd-commerce/placeholders

### Config
https://hfive--da-live--adobe.aem.live/config#/da-sites/xsc-wknd-commerce/ (empty config)

### Media
https://hfive--da-live--adobe.aem.live/media#/da-sites/xsc-wknd-commerce/images/adventures/adobe-stock-australia.jpg

## Release notes
## Helix 5 support
Dark Alley will now be powered using `aem.page` and `aem.live`.
