### PR TITLE
GH-118 - Improve Auth Support

### DIFF
--- a/blocks/browse/da-orgs/da-orgs.js
+++ b/blocks/browse/da-orgs/da-orgs.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from '../../../deps/lit/lit-core.min.js';
+import { LitElement, html, nothing } from '../../../deps/lit/lit-core.min.js';
 import { getDaAdmin } from '../../shared/constants.js';
 import { daFetch } from '../../shared/utils.js';
 import getSheet from '../../shared/sheet.js';
@@ -20,16 +20,14 @@ function getRandomImg() {
 }
 
 const MOCK_ORGS = [
-  { name: 'adobe', created: '2024-01-09T23:38:05.949Z', img: MOCK_IMGS[0] },
-  { name: 'adobe-experience-league', created: '2024-01-26T01:43:15.286Z', img: MOCK_IMGS[1] },
-  { name: 'adobecom', created: '2023-11-30T06:04:10.008Z', img: MOCK_IMGS[2] },
-  { name: 'aemsites', created: '2024-01-10T17:43:13.390Z', img: MOCK_IMGS[3] },
+  { name: 'aemsites', created: '2024-01-10T17:43:13.390Z', img: MOCK_IMGS[0] },
 ];
 
 export default class DaOrgs extends LitElement {
   static properties = {
     details: { attribute: false },
     _orgs: { state: true },
+    _orgsLoaded: { state: true },
   };
 
   connectedCallback() {
@@ -47,6 +45,7 @@ export default class DaOrgs extends LitElement {
       const img = this._orgs[idx]?.img || getRandomImg();
       return { ...org, img };
     });
+    this._orgsLoaded = true;
   }
 
   formatDate(string) {
@@ -75,7 +74,7 @@ export default class DaOrgs extends LitElement {
               </div>
             </a>
           </li>`)}
-          ${this._orgs.length > 4 ? html`
+          ${this._orgsLoaded ? html`
             <li>
               <a class="da-org new" href="/start">
                 <div class="new-icon">
@@ -84,7 +83,7 @@ export default class DaOrgs extends LitElement {
                 <p class="new-title">Add new</p>
               </a>
             </li>
-          ` : null}
+          ` : nothing}
       </ul>
     `;
   }

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -5,6 +5,7 @@ import getSheet from '../../shared/sheet.js';
 import inlinesvg from '../../shared/inlinesvg.js';
 import { getItems, getLibraryList } from './helpers/helpers.js';
 import { aem2prose } from '../utils/helpers.js';
+import { daFetch } from '../../shared/utils.js';
 
 const sheet = await getSheet('/blocks/edit/da-library/da-library.css');
 
@@ -66,7 +67,7 @@ class DaLibrary extends LitElement {
   }
 
   async handleTemplateClick(item) {
-    const resp = await fetch(`${item.value}`);
+    const resp = await daFetch(`${item.value}`);
     if (!resp.ok) return;
     const text = await resp.text();
     const doc = new DOMParser().parseFromString(text, 'text/html');

--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -2,6 +2,7 @@
 import { DOMParser } from 'da-y-wrapper';
 import { CON_ORIGIN, getDaAdmin } from '../../../shared/constants.js';
 import getPathDetails from '../../../shared/pathDetails.js';
+import { daFetch } from '../../../shared/utils.js';
 
 const DA_ORIGIN = getDaAdmin();
 const REPLACE_CONTENT = '<content>';
@@ -37,7 +38,7 @@ export async function getItems(sources, listType, format) {
   const items = [];
   for (const source of sources) {
     try {
-      const resp = await fetch(source);
+      const resp = await daFetch(source);
       const json = await resp.json();
       if (json.data) {
         items.push(...formatData(json.data, format));
@@ -69,7 +70,7 @@ export async function getLibraryList() {
   currOwner = owner;
   currRepo = repo;
 
-  const resp = await fetch(`${DA_ORIGIN}/source/${owner}/${repo}${DA_CONFIG}`);
+  const resp = await daFetch(`${DA_ORIGIN}/source/${owner}/${repo}${DA_CONFIG}`);
   if (!resp.ok) return [];
 
   const { data } = await resp.json();

--- a/blocks/edit/da-library/helpers/index.js
+++ b/blocks/edit/da-library/helpers/index.js
@@ -1,3 +1,4 @@
+import { daFetch } from '../../../shared/utils.js';
 import { parseDom } from './helpers.js';
 
 const HEADING_NAMES = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
@@ -69,7 +70,7 @@ export async function getBlockVariants(path) {
   const isAemHosted = AEM_ORIGIN.some((aemOrigin) => origin.endsWith(aemOrigin));
   const postfix = isAemHosted ? '.plain.html' : '';
 
-  const resp = await fetch(`${path}${postfix}`);
+  const resp = await daFetch(`${path}${postfix}`);
   if (!resp.ok) return [];
 
   const ul = document.createElement('ul');
@@ -104,7 +105,7 @@ export async function getBlockVariants(path) {
 
 export async function getBlocks(sources) {
   const sourcesData = sources.map(
-    (url) => fetch(url).then((resp) => {
+    (url) => daFetch(url).then((resp) => {
       if (!resp.ok) throw new Error('Something went wrong.');
       return resp.json();
     }).catch(() => {}),

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -1,8 +1,9 @@
-import { getDaAdmin } from './constants.js';
+import { DA_ORIGIN } from './constants.js';
 
 const { getNx } = await import('../../scripts/utils.js');
 
-const DA_ORIGIN = getDaAdmin();
+const ALLOWED_TOKEN = ['https://admin.hlx.page', 'https://admin.da.live'];
+
 let imsDetails;
 
 export async function initIms() {
@@ -21,7 +22,8 @@ export const daFetch = async (url, opts = {}) => {
   opts.headers = opts.headers || {};
   if (localStorage.getItem('nx-ims')) {
     const { accessToken } = await initIms();
-    if (accessToken) opts.headers.Authorization = `Bearer ${accessToken.token}`;
+    const canToken = ALLOWED_TOKEN.some((origin) => url.startsWith(origin));
+    if (accessToken && canToken) opts.headers.Authorization = `Bearer ${accessToken.token}`;
   }
   const resp = await fetch(url, opts);
   if (resp.status === 401) {


### PR DESCRIPTION
1. Only send Access Token to blessed domains.
2. Have library use `daFetch` for anything that may be listed as coming from da-admin.
3. Change `da-orgs` to not pre-populate private orgs and only show new after orgs have been loaded.

Resolves: GH-118

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

https://authfix--da-live--adobe.hlx.live/

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
