### PR TITLE
GH-56 - Drag and drop

### DIFF
--- a/blocks/browse/da-browse/da-browse.css
+++ b/blocks/browse/da-browse/da-browse.css
@@ -265,7 +265,6 @@ input[type="checkbox"] {
 .da-breadcrumb-list-item {
   position: relative;
   display: block;
-  text-transform: uppercase;
   font-size: 16px;
   font-weight: 700;
   cursor: pointer;
@@ -508,13 +507,46 @@ li.da-actions-menu-item button:hover {
 
 /* Empty list */
 .empty-list {
-  border: 1px solid rgb(234, 234, 234);
-  background-color: rgb(248, 248, 248);
+  border: 1px solid rgb(234 234 234);
+  background-color: rgb(248 248 248);
   border-radius: 6px;
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: 400px;
+}
+
+/* Drag & Drop */
+.da-browse-panel {
+  position: relative;
+}
+
+.da-browse-panel.is-dragged-over > * {
+  position: relative;
+  opacity: 0.1;
+}
+
+.da-drop-area {
+  display: none;
+  justify-content: center;
+  align-items: center;
+  border-radius: 6px;
+  background-color: rgb(180 255 175 / 23%);
+  border: 2px dotted rgb(0 194 68);
+  z-index: 1;
+}
+
+.da-drop-area::after {
+  font-size: 24px;
+  font-weight: 700;
+  content: attr(data-message);
+}
+
+.da-browse-panel.is-dragged-over > .da-drop-area {
+  display: flex;
+  opacity: 1;
+  position: absolute;
+  inset: 0;
 }
 
 @media (min-width: 900px) {

--- a/blocks/browse/da-browse/helpers/drag-n-drop.js
+++ b/blocks/browse/da-browse/helpers/drag-n-drop.js
@@ -1,0 +1,112 @@
+import { SUPPORTED_FILES, DA_ORIGIN } from '../../../shared/constants.js';
+import { daFetch } from '../../../shared/utils.js';
+
+const MAX_DEPTH = 1000;
+
+function traverseFolder(entry) {
+  const reader = entry.createReader();
+  // Resolved when the entire directory is traversed
+  return new Promise((resolveDirectory) => {
+    const iterationAttempts = [];
+    const errorHandler = () => {};
+    function readEntries() {
+      // According to the FileSystem API spec, readEntries() must be called until
+      // it calls the callback with an empty array.
+      reader.readEntries((batchEntries) => {
+        if (!batchEntries.length) {
+          // Done iterating this folder
+          resolveDirectory(Promise.all(iterationAttempts));
+        } else {
+          // Add a list of promises for each directory entry. If the entry is itself
+          // a directory, then that promise won't resolve until it is fully traversed.
+          iterationAttempts.push(Promise.all(batchEntries.map((batchEntry) => {
+            if (batchEntry.isDirectory) {
+              return traverseFolder(batchEntry);
+            }
+            return Promise.resolve(batchEntry);
+          })));
+          // Try calling readEntries() again for the same dir, according to spec
+          readEntries();
+        }
+      }, errorHandler);
+    }
+    // Initial call to recursive entry reader function
+    readEntries();
+  });
+}
+
+function packageFile(file, entry) {
+  const { name } = file;
+  let { type } = file;
+
+  // No content type fallback
+  const ext = (file.name || '').split('.').pop();
+  if (!type) type = SUPPORTED_FILES[ext];
+
+  // Check if supported type
+  const isSupported = Object.keys(SUPPORTED_FILES)
+    .some((key) => type === SUPPORTED_FILES[key]);
+  if (!isSupported) return null;
+
+  // Sanitize path
+  const path = entry.fullPath.replaceAll(' ', '-').toLowerCase();
+  return { data: file, name, type, ext, path };
+}
+
+function getFile(entry) {
+  return new Promise((resolve) => {
+    const callback = (file) => { resolve(packageFile(file, entry)); };
+    entry.file(callback);
+  });
+}
+
+export async function getFullEntryList(entries) {
+  const folderEntries = [];
+  const fileEntries = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory) {
+      folderEntries.push(entry);
+    } else {
+      fileEntries.push(entry);
+    }
+  }
+
+  for (const entry of folderEntries) {
+    const traversed = await traverseFolder(entry);
+    fileEntries.push(...traversed.flat(MAX_DEPTH));
+  }
+
+  const files = await Promise.all(fileEntries.map((entry) => getFile(entry)));
+  return files.filter((file) => file);
+}
+
+export async function handleUpload(list, fullpath, file) {
+  const { data, path } = file;
+  const formData = new FormData();
+  formData.append('data', data);
+  const opts = { method: 'POST', body: formData };
+  const postpath = `${fullpath}${path}`;
+
+  try {
+    await daFetch(`${DA_ORIGIN}/source${postpath}`, opts);
+    file.imported = true;
+
+    const [displayName] = path.split('/').slice(1);
+    const [filename, ...rest] = displayName.split('.');
+    const ext = rest.pop();
+    const rejoined = [filename, ...rest].join('.');
+
+    const listHasName = list.some((item) => item.name === rejoined);
+
+    if (listHasName) return null;
+
+    const item = { name: rejoined, path: `${fullpath}/${displayName}` };
+    if (ext) item.ext = ext;
+
+    return item;
+  } catch (e) {
+    console.log(e);
+  }
+  return null;
+}

--- a/blocks/shared/constants.js
+++ b/blocks/shared/constants.js
@@ -1,6 +1,18 @@
 export const CON_ORIGIN = 'https://content.da.live';
 export const AEM_ORIGIN = 'https://admin.hlx.page';
 
+export const SUPPORTED_FILES = {
+  html: 'text/html',
+  jpeg: 'image/jpeg',
+  json: 'application/json',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  mp4: 'video/mp4',
+  pdf: 'application/pdf',
+  svg: 'image/svg+xml',
+};
+
 const DA_ADMIN_ENVS = {
   local: 'http://localhost:8787',
   stage: 'https://stage-admin.da.live',

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -6,16 +6,6 @@ const ALLOWED_TOKEN = ['https://admin.hlx.page', 'https://admin.da.live'];
 
 let imsDetails;
 
-async function setUnauthorized() {
-  const { loadArea } = await import(`${getNx()}/scripts/nexter.js`);
-  const main = document.body.querySelector('main');
-  main.innerHTML = '';
-  const resp = await fetch('/fragments/404.plain.html');
-  if (!resp.ok) return;
-  main.innerHTML = await resp.text();
-  loadArea(main);
-}
-
 export async function initIms() {
   if (imsDetails) return imsDetails;
   const { loadIms } = await import(`${getNx()}/utils/ims.js`);
@@ -39,7 +29,7 @@ export const daFetch = async (url, opts = {}) => {
   const resp = await fetch(url, opts);
   if (resp.status === 401) {
     if (accessToken) {
-      setUnauthorized();
+      window.location = `${window.location.origin}/not-found`;
       return { ok: false };
     }
 

--- a/blocks/sheet/index.js
+++ b/blocks/sheet/index.js
@@ -8,7 +8,7 @@ const loadScript = (await import(`${getNx()}/utils/script.js`)).default;
 const SHEET_TEMPLATE = { minDimensions: [20, 20], sheetName: 'data' };
 
 function resetSheets(el) {
-  el.querySelector('da-sheet-tabs')?.remove();
+  document.querySelector('da-sheet-tabs')?.remove();
   if (!el.jexcel) return;
   delete el.jexcel;
   el.innerHTML = '';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -46,22 +46,15 @@ function loadStyles() {
 }
 
 export default async function loadPage() {
-  // TODO: AEM markup doesn't do colspan in blocks correctly
-  const divs = document.querySelectorAll('div[class] div');
-  divs.forEach((div) => { if (div.innerHTML.trim() === '') div.remove(); });
-
   await loadArea();
 }
-
-// Side-effects
-(async function daPreview() {
-  const { searchParams } = new URL(window.location.href);
-  if (searchParams.get('dapreview') === 'on') {
-    const { default: livePreview } = await import('./dapreview.js');
-    livePreview(loadPage);
-  }
-}());
 
 loadStyles();
 decorateArea();
 loadPage();
+
+// Side-effects
+(async function loadDa() {
+  if (!new URL(window.location.href).searchParams.get('dapreview')) return;
+  import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
+}());

--- a/test/unit/blocks/browse/helpers/helpers.test.js
+++ b/test/unit/blocks/browse/helpers/helpers.test.js
@@ -1,0 +1,84 @@
+import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
+import { getFullEntryList, handleUpload } from '../../../../../blocks/browse/da-browse/helpers/drag-n-drop.js';
+
+const goodEntry = {
+  isDirectory: false,
+  fullPath: '/foo.html',
+  file: (callback) => {
+    const file = new File(
+      ['foo'],
+      'foo.html',
+      { type: 'text/html' },
+    );
+    callback(file);
+  },
+};
+const badEntry = {
+  isDirectory: false,
+  fullPath: '/foo.exe',
+  file: (callback) => {
+    const file = new File(
+      ['foo'],
+      'foo.exe',
+      { type: 'application/x-msdownload' },
+    );
+    callback(file);
+  },
+};
+
+describe('Drag and drop', () => {
+  it('File entry', async () => {
+    const files = await getFullEntryList([goodEntry, badEntry]);
+    expect(files.length).to.equal(1);
+  });
+
+  it('Folder entry', async () => {
+    let read = 0;
+    const folderEntry = {
+      isDirectory: true,
+      fullPath: '/flex',
+      createReader: () => ({
+        readEntries: (callback) => {
+          const arr = read === 0 ? [goodEntry, badEntry] : [];
+          read += 1;
+          callback(arr);
+        },
+      }),
+    };
+    const files = await getFullEntryList([folderEntry]);
+    expect(files.length).to.equal(1);
+  });
+});
+
+describe('Upload and format', () => {
+  const ogFetch = window.fetch;
+
+  beforeEach(() => {
+    window.fetch = stub().returns(
+      new Promise((resolve) => {
+        resolve({ ok: true });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    window.fetch = ogFetch;
+  });
+
+  it('Returns file upload if not already in list', async () => {
+    const fullpath = '/geometrixx';
+    const list = [{ name: 'clever', path: '/geometrixx/clever', ext: 'html' }];
+    const file = new File(['foo'], 'foo.html', { type: 'text/html' });
+    const packagedFile = {
+      data: file,
+      name: file.name,
+      type: file.type,
+      ext: 'html',
+      path: '/foo',
+    };
+
+    const item = await handleUpload(list, fullpath, packagedFile);
+    expect(item).to.exist;
+  });
+});


### PR DESCRIPTION
* Support uploading depths of up to 1000 folders deep
* Supports singular uploads
* Converts all spaces into dashes
* Filters out unsupported file types and extensions
* Supports all major browsers: Chrome, Safari, Firefox, iOS Safari

Resolves: GH-56

## How Has This Been Tested?

* Chrome (Mac & Windows)
* Safari (Mac & iOS)
* Firefox (Mac & Windows)
* Chromium (Linux)

## How to test

Drag any supported file type (or folders with files) to here:
https://dnd--da-live--adobe.aem.page/#/aemsites/da-block-collection/drafts/dnd

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Release notes
* Supports singular uploads
* Support uploading folder depths of up to 1000 deep
* Converts all spaces into dashes
* Filters out unsupported file types and extensions
* Supports all major browsers: Chrome, Safari, Firefox, iOS Safari

<img width="500" alt="Screenshot 2024-05-06 at 10 04 54 AM" src="https://github.com/adobe/da-live/assets/1972095/8f1e392c-5ec8-408b-ac82-2545f77a6ab0">
