### PR TITLE
Fix derived branch name default.

### DIFF
--- a/test/e2e/utils/env.js
+++ b/test/e2e/utils/env.js
@@ -1,5 +1,8 @@
 function getEnv() {
-  const { GITHUB_HEAD_REF: branch = 'main' } = process.env;
+  let { GITHUB_HEAD_REF: branch } = process.env;
+  if (!branch) {
+    branch = 'main';
+  }
   return branch === 'local' ? 'http://localhost:3000' : `https://${branch}--da-live--adobe.hlx.live`;
 }
 

--- a/test/e2e/utils/page.js
+++ b/test/e2e/utils/page.js
@@ -46,10 +46,10 @@ export function getTestSheetURL(testIdentifier, workerInfo) {
  * @returns The age in ms or null if the file name does not match the pattern.
  */
 export function getTestResourceAge(fileName) {
-  const re = /pw-\w+(-t1)*-(\w+)-\w+/;
+  const re = /pw-\w+-(\w+)-\w+/;
   const res = re.exec(fileName);
   if (res) {
-    return parseInt(res[2], 36);
+    return parseInt(res[1], 36);
   }
   return null;
 }


### PR DESCRIPTION
## Description

The branch name is used by the playwright tests to derive the hostname to use. While the current approach works for PRs,  it doesn't work when running the playwright tests on the main branch.

The previous default didn't work if the variable had an empty String as value, in which case it should default to `main`. There was a default in the code, but this doesn't work in this scenario.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
