### PR TITLE
Fix editing multi-sheets

### DIFF
--- a/blocks/sheet/index.js
+++ b/blocks/sheet/index.js
@@ -40,7 +40,7 @@ function getSheetData(sheetData) {
   return [header, ...data];
 }
 
-async function getData(url) {
+export async function getData(url) {
   const resp = await daFetch(url);
   if (!resp.ok) return getDefaultSheet();
 

--- a/blocks/sheet/index.js
+++ b/blocks/sheet/index.js
@@ -51,7 +51,7 @@ async function getData(url) {
   const names = json[':names'];
 
   // Single sheet
-  if (json.data) {
+  if (json[':type'] === 'sheet') {
     const data = getSheetData(json.data);
     const columns = data[0].map(() => ({ width: '300px' }));
     const dataSheet = {

--- a/test/unit/blocks/sheet/index.test.js
+++ b/test/unit/blocks/sheet/index.test.js
@@ -1,0 +1,93 @@
+import { expect } from '@esm-bundle/chai';
+
+// This is needed to make a dynamic import work that is indirectly referenced
+// from blocks/sheet/index.js
+const { setNx } = await import('../../../../scripts/utils.js');
+setNx('/bheuaark/', { hostname: 'localhost' });
+
+const sh = await import('../../../../blocks/sheet/index.js');
+
+describe('Sheets', () => {
+  it('Test single sheet getData', async () => {
+    const json = `
+    {
+      "total": 3,
+      "limit": 3,
+      "offset": 0,
+      "data": [
+        { "Value": "A" },
+        { "Value": "B" },
+        { "Value": "C" }
+      ],
+      ":type": "sheet"
+    }`;
+
+    const mockFetch = async (url) => {
+      if (url === 'http://example.com') {
+        return new Response(json, { status: 200 });
+      }
+      return undefined;
+    };
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = mockFetch;
+
+      const sheet = await sh.getData('http://example.com');
+      expect(sheet.length).to.equal(1);
+      expect(sheet[0].sheetName).to.equal('data');
+      expect(sheet[0].data).to.deep.equal([['Value'], ['A'], ['B'], ['C']]);
+    } finally {
+      window.fetch = savedFetch;
+    }
+  });
+
+  it('Test multiple sheet getData', async () => {
+    const json = `
+    {
+      "data": {
+        "total": 3,
+        "offset": 0,
+        "limit": 3,
+        "data": [
+          { "Tag": "red" },
+          { "Tag": "blue" },
+          { "Tag": "orange" }
+        ]
+      },
+      "md": {
+        "total": 1,
+        "offset": 0,
+        "limit": 1,
+        "data": [{ "Title": "Foo" }]
+      },
+      ":version": 3,
+      ":names": [
+        "data",
+        "md"
+      ],
+      ":type": "multi-sheet"
+    }`;
+
+    const mockFetch = async (url) => {
+      if (url === 'http://example.com') {
+        return new Response(json, { status: 200 });
+      }
+      return undefined;
+    };
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = mockFetch;
+
+      const sheet = await sh.getData('http://example.com');
+      expect(sheet.length).to.equal(2);
+      expect(sheet[0].sheetName).to.equal('data');
+      expect(sheet[0].data).to.deep.equal([['Tag'], ['red'], ['blue'], ['orange']]);
+      expect(sheet[1].sheetName).to.equal('md');
+      expect(sheet[1].data).to.deep.equal([['Title'], ['Foo']]);
+    } finally {
+      window.fetch = savedFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Description

Editing existing multi-sheets (spreadsheets that contain more than 1 sheet) is currently broken. This fixes it.

Test URLs:
Before: https://da.live/sheet#/da-sites/da-status/bosschae/data/tags
After: https://multi-sheet--da-live--adobe.hlx.live/sheet#/da-sites/da-status/bosschae/data/tags

## Related Issue

Fixes: #182

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
