### PR TITLE
Playwright test stability

### DIFF
--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -27,23 +27,23 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await page.locator('div.ProseMirror').fill('First text');
 
   // Wait 3 secs to ensure its saved in da-admin
-  await page.waitForTimeout(3000);
+  await page.waitForTimeout(5000);
 
   // Add some more text
   await page.locator('div.ProseMirror').fill('Versioned text');
-  await page.waitForTimeout(3000);
+  await page.waitForTimeout(5000);
 
   // Create a new stored version called 'myver'
   await page.getByRole('button', { name: 'Versions' }).click();
   await page.locator('button.da-version-btn').click();
   await page.locator('input.da-version-new-input').fill('myver');
   await page.locator('input.da-version-new-input').press('Enter');
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(3000);
   await expect(page.getByText('myver', { exact: false })).toBeVisible();
 
   // Add some more text
   await page.locator('div.ProseMirror').fill('After versioned');
-  await page.waitForTimeout(3000);
+  await page.waitForTimeout(5000);
 
   // Go back to the directory view
   await page.goto(`${ENV}/#/da-sites/da-status/tests`);
@@ -64,7 +64,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await page.waitForURL(`**/da-sites/da-status/tests/${copyFolderName}`);
 
   await page.getByRole('button', { name: 'Paste' }).click();
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(3000);
 
   // go back to the original to rename it
   // Go to the directory view
@@ -82,7 +82,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await page.keyboard.press('Enter');
 
   // Open the renamed page
-  await page.waitForTimeout(2000);
+  await page.waitForTimeout(3000);
   await page.goto(`${pageURL}ren`);
 
   await expect(page.locator('div.ProseMirror')).toContainText('After versioned');

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -26,7 +26,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   // Enter some initial text onto the page
   await page.locator('div.ProseMirror').fill('First text');
 
-  // Wait 3 secs to ensure its saved in da-admin
+  // Wait to ensure its saved in da-admin
   await page.waitForTimeout(5000);
 
   // Add some more text

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -16,7 +16,7 @@ import { getTestFolderURL, getTestPageURL } from '../utils/page.js';
 test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => {
   // This test has a fairly high timeout because it waits for the document to be saved
   // a number of times
-  test.setTimeout(30000);
+  test.setTimeout(60000);
 
   const pageURL = getTestPageURL('copyrename', workerInfo);
   const orgPageName = pageURL.split('/').pop();
@@ -85,6 +85,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await page.waitForTimeout(3000);
   await page.goto(`${pageURL}ren`);
 
+  await page.waitForTimeout(3000);
   await expect(page.locator('div.ProseMirror')).toContainText('After versioned');
   await page.getByRole('button', { name: 'Versions' }).click();
   await page.getByText('myver', { exact: false }).click();

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -13,7 +13,8 @@ import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
 import { getTestResourceAge } from '../utils/page.js';
 
-const MIN_HOURS = 2; // Files are deleted after 2 hours
+// Files are deleted after 2 hours by default
+const MIN_HOURS = process.env.PW_DELETE_HOURS ? Number(process.env.PW_DELETE_HOURS) : 2;
 
 // This test deletes old testing pages that are older than 2 hours
 test('Delete multiple old pages', async ({ page }, workerInfo) => {
@@ -22,7 +23,10 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
     return;
   }
 
-  test.setTimeout(80000);
+  console.log('Deleting test files that are older than', MIN_HOURS, 'hours');
+  // The timeout for this test is long because it may take a while to delete all the files
+  // that are left behind by previous test runs.
+  test.setTimeout(600000);
 
   // Open the directory listing
   await page.goto(`${ENV}/#/da-sites/da-status/tests`);
@@ -74,5 +78,5 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   await page.getByRole('button', { name: 'Delete' }).click();
 
   // Wait for the delete button to disappear which is when we're done
-  await expect(page.getByRole('button', { name: 'Delete' })).not.toBeVisible({ timeout: 60000 });
+  await expect(page.getByRole('button', { name: 'Delete' })).not.toBeVisible({ timeout: 600000 });
 });

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -14,12 +14,13 @@ import ENV from '../utils/env.js';
 import { getTestPageURL } from '../utils/page.js';
 
 test('Update Document', async ({ browser, page }, workerInfo) => {
-  test.setTimeout(15000);
+  test.setTimeout(30000);
 
   const url = getTestPageURL('edit1', workerInfo);
   await page.goto(url);
   await expect(page.locator('div.ProseMirror')).toBeVisible();
 
+  await page.waitForTimeout(3000);
   const enteredText = `[${workerInfo.project.name}] Edited by test ${new Date()}`;
   await page.locator('div.ProseMirror').fill(enteredText);
 
@@ -34,7 +35,7 @@ test('Update Document', async ({ browser, page }, workerInfo) => {
 });
 
 test('Create Delete Document', async ({ browser, page }, workerInfo) => {
-  test.setTimeout(15000);
+  test.setTimeout(30000);
 
   const url = getTestPageURL('edit2', workerInfo);
   const pageName = url.split('/').pop();
@@ -70,7 +71,7 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
 });
 
 test('Change document by switching anchors', async ({ page }, workerInfo) => {
-  test.setTimeout(15000);
+  test.setTimeout(30000);
 
   const url = getTestPageURL('edit3', workerInfo);
   const urlA = `${url}A`;
@@ -78,6 +79,7 @@ test('Change document by switching anchors', async ({ page }, workerInfo) => {
 
   await page.goto(urlA);
   await expect(page.locator('div.ProseMirror')).toBeVisible();
+  await page.waitForTimeout(3000);
 
   await page.locator('div.ProseMirror').fill('before table');
   await page.getByText('Block', { exact: true }).click();
@@ -92,11 +94,11 @@ test('Change document by switching anchors', async ({ page }, workerInfo) => {
   await page.keyboard.type('k 2');
   await page.keyboard.press('Tab');
   await page.keyboard.type('v 2');
-
   await page.waitForTimeout(3000);
 
   await page.goto(urlB);
   await expect(page.locator('div.ProseMirror')).toBeVisible();
+  await page.waitForTimeout(3000);
 
   await page.locator('div.ProseMirror').fill('page B');
   await page.waitForTimeout(3000);

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -65,7 +65,6 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   await expect(newPage.locator('button.delete-button')).toBeVisible();
   await newPage.locator('button.delete-button').click();
 
-  // Wait 1 sec
   await page.waitForTimeout(1000);
   await expect(newPage.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).not.toBeVisible();
 });

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -23,11 +23,12 @@ test('Update Document', async ({ browser, page }, workerInfo) => {
   const enteredText = `[${workerInfo.project.name}] Edited by test ${new Date()}`;
   await page.locator('div.ProseMirror').fill(enteredText);
 
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(3000);
   await page.close();
 
   const newPage = await browser.newPage();
   await newPage.goto(url);
+  await newPage.waitForTimeout(3000);
   await expect(newPage.locator('div.ProseMirror')).toBeVisible();
   await expect(newPage.locator('div.ProseMirror')).toContainText(enteredText);
 });
@@ -92,21 +93,23 @@ test('Change document by switching anchors', async ({ page }, workerInfo) => {
   await page.keyboard.press('Tab');
   await page.keyboard.type('v 2');
 
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(3000);
 
   await page.goto(urlB);
   await expect(page.locator('div.ProseMirror')).toBeVisible();
 
   await page.locator('div.ProseMirror').fill('page B');
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(3000);
 
   await page.goto(urlA);
+  await page.waitForTimeout(3000);
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toContainText('mytable');
   await expect(page.locator('div.ProseMirror')).toContainText('k 2');
   await expect(page.locator('div.ProseMirror')).toContainText('v 2');
 
   await page.goto(urlB);
+  await page.waitForTimeout(3000);
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toContainText('page B');
 });

--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -23,12 +23,12 @@ test('Create Version and Restore from it', async ({ page }, workerInfo) => {
   // Enter some initial text onto the page
   await page.locator('div.ProseMirror').fill('Initial version');
 
-  // Wait 3 secs to ensure its saved in da-admin
-  await page.waitForTimeout(3000);
+  // Wait to ensure its saved in da-admin
+  await page.waitForTimeout(5000);
 
   // Add some more text
   await page.locator('div.ProseMirror').fill('Second version');
-  await page.waitForTimeout(3000);
+  await page.waitForTimeout(5000);
 
   // Create a new stored version called 'ver 1'
   await page.getByRole('button', { name: 'Versions' }).click();
@@ -40,13 +40,13 @@ test('Create Version and Restore from it', async ({ page }, workerInfo) => {
   await page.locator('button.da-versions-close-btn').click();
   await page.locator('div.ProseMirror').fill('Some modifications');
 
-  // Wait 3 secs to ensure its saved
-  await page.waitForTimeout(3000);
+  // Wait to ensure its saved
+  await page.waitForTimeout(5000);
 
   // And add some more text
   await page.locator('div.ProseMirror').fill('Some more modifications');
-  // Wait 3 secs to ensure its saved
-  await page.waitForTimeout(3000);
+  // Wait to ensure its saved
+  await page.waitForTimeout(5000);
 
   // Reload the page and check that the latest changes are there
   await page.reload();


### PR DESCRIPTION
## Description

Stabilize the Playwright tests

## Motivation and Context

Especially in the context of GH actions the PW tests are sometimes flaky.

The GH actions are run in a single core context which means that the browser runtimes run by PW have less cycles to catch up with any changes that are happening asynchronously. To give the browsers a little more time a few extra wait moments have been added to the tests.

## How Has This Been Tested?

These are tests

## Types of changes


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
