### PR TITLE
Use the new URL in the browse list for pasted items.

### DIFF
--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -197,8 +197,9 @@ export default class DaBrowse extends LitElement {
       formData.append('destination', item.destination);
       const opts = { method: 'POST', body: formData };
       await daFetch(`${DA_ORIGIN}/copy${item.path}`, opts);
-      item.isChecked = false;
-      this._listItems.unshift(item);
+
+      const pastedItem = { ...item, path: item.destination, isChecked: false };
+      this._listItems.unshift(pastedItem);
       this.requestUpdate();
     }
     this._canPaste = false;

--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -197,6 +197,7 @@ export default class DaBrowse extends LitElement {
       formData.append('destination', item.destination);
       const opts = { method: 'POST', body: formData };
       await daFetch(`${DA_ORIGIN}/copy${item.path}`, opts);
+      item.isChecked = false;
 
       const pastedItem = { ...item, path: item.destination, isChecked: false };
       this._listItems.unshift(pastedItem);

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -65,6 +65,9 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
 
   await page.getByRole('button', { name: 'Paste' }).click();
   await page.waitForTimeout(3000);
+  const link = await page.getByRole('link', { name: orgPageName });
+  const href = await link.getAttribute('href');
+  await expect(href).toEqual(`/edit#/da-sites/da-status/tests/${copyFolderName}/${orgPageName}`);
 
   // go back to the original to rename it
   // Go to the directory view

--- a/test/unit/blocks/browse/da_browse/da_browse.test.js
+++ b/test/unit/blocks/browse/da_browse/da_browse.test.js
@@ -1,0 +1,53 @@
+/*
+    eslint-disable no-underscore-dangle
+*/
+import { expect } from '@esm-bundle/chai';
+
+// This is needed to make a dynamic import work that is indirectly referenced
+// from edit/prose/index.js
+const { setNx } = await import('../../../../../scripts/utils.js');
+setNx('/bheuaark/', { hostname: 'localhost' });
+
+const { default: DaBrowse } = await import('../../../../../blocks/browse/da-browse/da-browse.js');
+
+describe('Browse', () => {
+  it('Pasted item uses the target URL', async () => {
+    const daBrowse = new DaBrowse();
+
+    const fetchedArgs = [];
+    const mockFetch = async (url, opts) => {
+      fetchedArgs.push({ url, opts });
+      return { ok: true };
+    };
+
+    const item = {
+      path: '/myorg/mysite/myroot/srcdir/d1.html',
+      ext: 'html',
+      isChecked: true,
+      name: 'd1',
+    };
+    daBrowse._listItems = [];
+    daBrowse._selectedItems = [item];
+    daBrowse.details = { fullpath: '/myorg/mysite/myroot/destdir' };
+
+    const orgFetch = window.fetch;
+    try {
+      window.fetch = mockFetch;
+      await daBrowse.handlePaste();
+
+      expect(daBrowse._listItems.length).to.equal(1);
+      expect(daBrowse._listItems[0].path).to.equal('/myorg/mysite/myroot/destdir/d1.html');
+      expect(daBrowse._listItems[0].ext).to.equal('html');
+      expect(daBrowse._listItems[0].isChecked).to.be.false;
+      expect(daBrowse._listItems[0].name).to.equal('d1');
+      expect(daBrowse._canPaste).to.be.false;
+
+      expect(fetchedArgs.length).to.equal(1);
+      expect(fetchedArgs[0].url).to.equal('https://admin.da.live/copy/myorg/mysite/myroot/srcdir/d1.html');
+      expect(fetchedArgs[0].opts.body.get('destination')).to.equal('/myorg/mysite/myroot/destdir/d1.html');
+      expect(fetchedArgs[0].opts.method).to.equal('POST');
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
+});

--- a/test/unit/blocks/browse/da_browse/da_browse.test.js
+++ b/test/unit/blocks/browse/da_browse/da_browse.test.js
@@ -4,7 +4,7 @@
 import { expect } from '@esm-bundle/chai';
 
 // This is needed to make a dynamic import work that is indirectly referenced
-// from edit/prose/index.js
+// from da-browse.js
 const { setNx } = await import('../../../../../scripts/utils.js');
 setNx('/bheuaark/', { hostname: 'localhost' });
 


### PR DESCRIPTION
## Description

When pasting a document in a different directory, use the target directory in the item URL. 
Currently the source directory is mistakenly in the URL which means that if you open the document, it opens the one in the source, rather than the copy.

Test URLs:
Before: https://da.live/#/da-sites/da-status/bosschae/sub6
After: https://cpypst--da-live--adobe.hlx.live/#/da-sites/da-status/bosschae/sub6

## Related Issue

Fixes #176

## How Has This Been Tested?

* In the UI
* With new unit tests
* Extended Playwright test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
