### PR TITLE
Add support for image links

### DIFF
--- a/blocks/edit/da-editor/da-editor.css
+++ b/blocks/edit/da-editor/da-editor.css
@@ -554,6 +554,10 @@ table tr:first-of-type p:first-child {
   pointer-events: none;
 }
 
+.ProseMirror img[href] {
+  border: #00ee 3px solid;
+}
+
 /* Palette */
 .da-palettes {
   position: fixed;

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -55,7 +55,7 @@ function makePictures(editor) {
     const clone = img.cloneNode(true);
     clone.setAttribute('loading', 'lazy');
 
-    const pic = document.createElement('picture');
+    let pic = document.createElement('picture');
 
     const srcMobile = document.createElement('source');
     srcMobile.srcset = clone.src;
@@ -65,6 +65,18 @@ function makePictures(editor) {
     srcTablet.media = '(min-width: 600px)';
 
     pic.append(srcMobile, srcTablet, clone);
+
+    const hrefAttr = img.getAttribute('href');
+    if (hrefAttr) {
+      const a = document.createElement('a');
+      a.href = hrefAttr;
+      const titleAttr = img.getAttribute('title');
+      if (titleAttr) {
+        a.title = titleAttr;
+      }
+      a.append(pic);
+      pic = a;
+    }
 
     // Determine what to replace
     const imgParent = img.parentElement;

--- a/test/e2e/tests/browse.spec.js
+++ b/test/e2e/tests/browse.spec.js
@@ -3,10 +3,9 @@ import ENV from '../utils/env.js';
 
 test('Get Main Page', async ({ page }) => {
   await page.goto(ENV);
-
   const html = await page.content();
-  expect(html).toContain('Dark Alley');
 
+  expect(html).toContain('Browse - DA');
   await expect(page.locator('a.nx-nav-brand')).toBeVisible();
-  await expect(page.locator('a.nx-nav-brand')).toContainText('Project Dark Alley');
+  await expect(page.locator('a.nx-nav-brand')).toContainText('Document Authoring');
 });

--- a/test/unit/blocks/edit/utils/mocks/body.html
+++ b/test/unit/blocks/edit/utils/mocks/body.html
@@ -25,7 +25,4 @@
       </div>
     </div>
   </div>
-  <div id="imagelink">
-    <img src="https://adobe.com/my/image.jpg" href="https://image.link/goes/here"/>
-  </div>
 </main>

--- a/test/unit/blocks/edit/utils/mocks/body.html
+++ b/test/unit/blocks/edit/utils/mocks/body.html
@@ -25,4 +25,7 @@
       </div>
     </div>
   </div>
+  <div id="imagelink">
+    <img src="https://adobe.com/my/image.jpg" href="https://image.link/goes/here"/>
+  </div>
 </main>

--- a/test/unit/blocks/shared/mocks/prose2aem.html
+++ b/test/unit/blocks/shared/mocks/prose2aem.html
@@ -52,3 +52,7 @@
     </tr>
   </table>
 </div>
+<!-- Linked Images -->
+<div>
+  <img src="http://www.foo.com/myimg.jpg" href="https://my.image.link">
+</div>

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -54,7 +54,7 @@ describe('aem2prose', () => {
     expect(meta).to.not.exist;
   });
 
-  it('Decorates list items', () => {
+  it('Wraps imgs with href attrs in a link tag', () => {
     const pictureEl = document.querySelector('a > picture');
     const parent = pictureEl.parentElement;
     expect(parent.href).to.equal('https://my.image.link/');

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -53,4 +53,10 @@ describe('aem2prose', () => {
     const meta = document.querySelector('.metadata');
     expect(meta).to.not.exist;
   });
+
+  it('Decorates list items', () => {
+    const pictureEl = document.querySelector('a > picture');
+    const parent = pictureEl.parentElement;
+    expect(parent.href).to.equal('https://my.image.link/');
+  });
 });


### PR DESCRIPTION
Create linked images by setting `href` and `title` attributes on `img` elements.  This is then converted to an `<a>` surrounding the `picture` element.

Requires da-collab PR: https://github.com/adobe/da-collab/pull/47

URL for testing:

- https://image-links--da-live--adobe.hlx.page/