### PR TITLE
Don't use window.view before it's initialized.

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -100,6 +100,8 @@ export function getSchema() {
 let sendUpdates = false;
 let hasChanged = 0;
 function dispatchTransaction(transaction) {
+  if (!window.view) return;
+
   if (transaction.docChanged) {
     hasChanged += 1;
     sendUpdates = true;
@@ -117,6 +119,7 @@ function setPreviewBody(daPreview, proseEl) {
 function pollForUpdates() {
   const daContent = document.querySelector('da-content');
   const daPreview = daContent.shadowRoot.querySelector('da-preview');
+  if (!window.view) return;
   const proseEl = window.view.root.querySelector('.ProseMirror');
   if (!daPreview) return;
 


### PR DESCRIPTION
## Description

After updating `da-y-wrapper` timing of certain callbacks have changed which lead to #200

`window.view` is used by callbacks given to EditorState and EditorView in their constructors and called before these constructors return. Previously it seems that Prosemirror was making these callbacks later.

## Related Issue

Fixes #200

## Motivation and Context

To be able to regenerate (and extend) da-y-wrapper.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
