### PR TITLE
#231 Private Sheet Support

### DIFF
--- a/blocks/sheet/index.js
+++ b/blocks/sheet/index.js
@@ -44,6 +44,16 @@ function getSheetData(sheetData) {
 const getColWidths = (colWidths, headers) => colWidths?.map((width) => ({ width: `${width}` }))
   || headers.map(() => ({ width: '300' }));
 
+function getSheet(json, sheetName) {
+  const data = getSheetData(json.data);
+  return {
+    ...SHEET_TEMPLATE,
+    sheetName,
+    data,
+    columns: getColWidths(json[':colWidths'], data[0]),
+  };
+}
+
 export async function getData(url) {
   const resp = await daFetch(url);
   if (!resp.ok) return getDefaultSheet();
@@ -52,33 +62,27 @@ export async function getData(url) {
 
   // Get base data
   const json = await resp.json();
-  const names = json[':names'];
 
   // Single sheet
   if (json[':type'] === 'sheet') {
-    const data = getSheetData(json.data);
-    const dataSheet = {
-      ...SHEET_TEMPLATE,
-      sheetName: 'data',
-      data,
-      columns: getColWidths(json.colWidths, data[0]),
-    };
-
-    sheets.push(dataSheet);
+    sheets.push(getSheet(json, json[':sheetname']));
   }
 
   // Multi sheet
+  const names = json[':names'];
   if (names) {
     names.forEach((sheetName) => {
-      const data = getSheetData(json[sheetName].data);
-      sheets.push({
-        ...SHEET_TEMPLATE,
-        sheetName,
-        data,
-        columns: getColWidths(json[sheetName].colWidths, data[0]),
-      });
+      sheets.push(getSheet(json[sheetName], sheetName));
     });
   }
+
+  const privateSheets = json[':private'];
+  if (privateSheets) {
+    Object.keys(privateSheets).forEach((sheetName) => {
+      sheets.push(getSheet(privateSheets[sheetName], sheetName));
+    });
+  }
+
   return sheets;
 }
 

--- a/blocks/sheet/index.js
+++ b/blocks/sheet/index.js
@@ -65,7 +65,7 @@ export async function getData(url) {
 
   // Single sheet
   if (json[':type'] === 'sheet') {
-    sheets.push(getSheet(json, json[':sheetname']));
+    sheets.push(getSheet(json, json[':sheetname'] || 'data'));
   }
 
   // Multi sheet

--- a/test/unit/blocks/edit/utils/helpers.test.js
+++ b/test/unit/blocks/edit/utils/helpers.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 
-import { aem2prose } from '../../../../../blocks/edit/utils/helpers.js';
+import { aem2prose, saveToDa } from '../../../../../blocks/edit/utils/helpers.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
@@ -37,5 +37,50 @@ describe('aem2prose', () => {
   it('Decorates HRs', () => {
     const hr = document.querySelector('table hr');
     expect(hr).to.exist;
+  });
+});
+
+function createSheet(name, data, columnWidths) {
+  return {
+    name,
+    getData: () => data,
+    getConfig: () => ({ columns: columnWidths.map((w) => ({ width: `${w}` })) }),
+  };
+}
+
+describe('saveToDa', () => {
+  it('Saves sheets', async () => {
+    const mockFetch = async (url, opts) => {
+      const payload = [...opts.body.entries()][0][1];
+      return new Response(payload, { status: 200 });
+    };
+
+    const sheets = [
+      createSheet(
+        'sheet1',
+        [['A', 'B', ''], ['1', '2', ''], ['', '', ''], ['', '', '']],
+        [10, 20, 30],
+      ),
+      createSheet(
+        'sheet2',
+        [['C', 'D', ''], ['3', '4', ''], ['', '', ''], ['', '', '']],
+        [5, 10, 15],
+      ),
+      createSheet(
+        'private-sheet3',
+        [['E', 'F', ''], ['5', '6', ''], ['', '', ''], ['', '', '']],
+        [11, 12, 13],
+      ),
+    ];
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = mockFetch;
+      const resp = await saveToDa('/aemsites/test/sheet1', sheets);
+      const text = await resp.text();
+      expect(text).to.equal('{"sheet1":{"total":1,"limit":1,"offset":0,"data":[{"A":"1","B":"2"}],":colWidths":[10,20]},"sheet2":{"total":1,"limit":1,"offset":0,"data":[{"C":"3","D":"4"}],":colWidths":[5,10]},":names":["sheet1","sheet2"],":version":3,":type":"multi-sheet",":private":{"private-sheet3":{"total":1,"limit":1,"offset":0,"data":[{"E":"5","F":"6"}],":colWidths":[11,12]}}}');
+    } finally {
+      window.fetch = savedFetch;
+    }
   });
 });

--- a/test/unit/blocks/sheet/index.test.js
+++ b/test/unit/blocks/sheet/index.test.js
@@ -90,4 +90,140 @@ describe('Sheets', () => {
       window.fetch = savedFetch;
     }
   });
+
+  it('Test private single sheet', async () => {
+    const json = `
+    {
+      "total": 1,
+      "limit": 1,
+      "offset": 0,
+      "data": [
+        {
+          "single": "1",
+          "sheet": "2",
+          "here": "3"
+        }
+      ],
+      ":colWidths": [10, 20, 30],
+      ":sheetname": "single-sheet",
+      ":type": "sheet",
+      ":private": {
+        "private-sheet": {
+          "total": 1,
+          "limit": 1,
+          "offset": 0,
+          "data": [
+            {
+              "private": "10",
+              "sheet": "20",
+              "here": "30"
+            }
+          ],
+          ":colWidths": [5, 10, 15]
+        }
+      }
+    }
+    `;
+
+    const mockFetch = async (url) => {
+      if (url === 'http://example.com') {
+        return new Response(json, { status: 200 });
+      }
+      return undefined;
+    };
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = mockFetch;
+
+      const sheet = await sh.getData('http://example.com');
+      expect(sheet.length).to.equal(2);
+      expect(sheet[0].sheetName).to.equal('single-sheet');
+      expect(sheet[1].sheetName).to.equal('private-sheet');
+      expect(sheet[0].data).to.deep.equal([['single', 'sheet', 'here'], ['1', '2', '3']]);
+      expect(sheet[1].data).to.deep.equal([['private', 'sheet', 'here'], ['10', '20', '30']]);
+      expect(sheet[0].columns).to.deep.equal([{ width: '10' }, { width: '20' }, { width: '30' }]);
+      expect(sheet[1].columns).to.deep.equal([{ width: '5' }, { width: '10' }, { width: '15' }]);
+    } finally {
+      window.fetch = savedFetch;
+    }
+  });
+
+  it('Test private multi sheet', async () => {
+    const json = `
+      {
+        "sheet1": {
+          "total": 1,
+          "limit": 1,
+          "offset": 0,
+          "data": [
+            {
+              "sheet1": "1",
+              "stuff": "2"
+            }
+          ],
+          ":colWidths": [10, 20]
+        },
+        "sheet2": {
+          "total": 1,
+          "limit": 1,
+          "offset": 0,
+          "data": [
+            {
+              "sheet2": "2",
+              "hello": "world"
+            }
+          ],
+          ":colWidths": [30, 40]
+        },
+        ":names": ["sheet1", "sheet2"],
+        ":version": 3,
+        ":type": "multi-sheet",
+        ":private": {
+          "private-mysheet": {
+            "total": 1,
+            "limit": 1,
+            "offset": 0,
+            "data": [
+              {
+                "this": "1",
+                "is": "2",
+                "private": "3"
+              }
+            ],
+            ":colWidths": [50, 60, 70]
+          }
+        }
+      }
+
+    `;
+
+    const mockFetch = async (url) => {
+      if (url === 'http://example.com') {
+        return new Response(json, { status: 200 });
+      }
+      return undefined;
+    };
+
+    const savedFetch = window.fetch;
+    try {
+      window.fetch = mockFetch;
+
+      const sheet = await sh.getData('http://example.com');
+      expect(sheet.length).to.equal(3);
+      expect(sheet[0].sheetName).to.equal('sheet1');
+      expect(sheet[1].sheetName).to.equal('sheet2');
+      expect(sheet[2].sheetName).to.equal('private-mysheet');
+
+      expect(sheet[0].data).to.deep.equal([['sheet1', 'stuff'], ['1', '2']]);
+      expect(sheet[1].data).to.deep.equal([['sheet2', 'hello'], ['2', 'world']]);
+      expect(sheet[2].data).to.deep.equal([['this', 'is', 'private'], ['1', '2', '3']]);
+
+      expect(sheet[0].columns).to.deep.equal([{ width: '10' }, { width: '20' }]);
+      expect(sheet[1].columns).to.deep.equal([{ width: '30' }, { width: '40' }]);
+      expect(sheet[2].columns).to.deep.equal([{ width: '50' }, { width: '60' }, { width: '70' }]);
+    } finally {
+      window.fetch = savedFetch;
+    }
+  });
 });


### PR DESCRIPTION
Private sheets must be prepended by `private-`

Private sheet data is stored in da-admin under the `:private` property.  This is ignored by helix and not shown in the json that helix serves.

This also saves the single sheet name instead of reverting to `data`.

Note that this will break current users saved column widths since the property is being renamed from `colWidths` to `:colWidths` so that it is not exposed in the helix json.