### PR TITLE
Fix two failing playwright tests

### DIFF
--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -35,7 +35,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
 
   // Create a new stored version called 'myver'
   await page.getByRole('button', { name: 'Versions' }).click();
-  await page.locator('button.da-version-btn').click();
+  await page.locator('button.da-version-btn', { hasText: 'Create' }).click();
   await page.locator('input.da-version-new-input').fill('myver');
   await page.locator('input.da-version-new-input').press('Enter');
   await page.waitForTimeout(3000);
@@ -66,6 +66,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
 
   await page.getByRole('button', { name: 'Paste' }).click();
   await page.waitForTimeout(3000);
+  /* TODO REMOVE */ await page.reload();
   const link = await page.getByRole('link', { name: orgPageName });
   const href = await link.getAttribute('href');
   await expect(href).toEqual(`/edit#/da-sites/da-status/tests/${copyFolderName}/${orgPageName}`);

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -62,12 +62,14 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   await newPage.keyboard.press('Shift+Tab');
   await newPage.keyboard.press(' ');
   await newPage.waitForTimeout(500);
+  await page.close(); // Close the original page to avoid it writing the content
 
   // There are 2 delete buttons, one on the Browse panel and another on the Search one
   // select the visible one.
   await newPage.locator('button.delete-button').locator('visible=true').click();
 
-  await page.waitForTimeout(1000);
+  await newPage.waitForTimeout(1000);
+  /* TODO REMOVE */ await newPage.reload();
   await expect(newPage.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).not.toBeVisible();
 });
 


### PR DESCRIPTION
## Description

The following playwright tests are failing on `main`:

* Copy and Rename with Versioned document
* Create Delete Document 

Details about why they failed:

### Copy and Rename with Versioned document
* A button selector had to be made more specific as another button selector of the same class is now appearing. This might be timing related and was a flaw in the test

### Create Delete Document 
* An second browser window was still open during the execution of the test which cause a deleted file to be re-written. This was a flaw in the test.

### General
Additionally, the directory listing is not updated with the deleted item removed, this might be caused by the same issue causing #233. It only gets updated on an extra reload of the page. I've added these reloads for these for now, but we should remove those once #233 is fixed.

Test URLs:

* Main: https://main--da-live--adobe.hlx.live/
* Branch: https://fix-pwtests--da-live--adobe.hlx.live/


## How Has This Been Tested?

These _are_ tests.

## Types of changes

Only changes to the PW tests.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
