### PR TITLE
Fix self drag dont close drag overlay

### DIFF
--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -244,9 +244,17 @@ export default class DaList extends LitElement {
   async drop(e) {
     e.preventDefault();
     const items = e.dataTransfer?.items;
-    if (!items) return;
+    if (!items) {
+      this.shadowRoot.querySelector('.da-browse-panel').classList.remove('is-dragged-over');
+      return;
+    }
 
-    const entries = [...items].map((item) => item.webkitGetAsEntry());
+    const entries = [...items].map((item) => item.webkitGetAsEntry()).filter((x) => x);
+    if (!entries.length) {
+      this.shadowRoot.querySelector('.da-browse-panel').classList.remove('is-dragged-over');
+      return;
+    }
+
     const makeBatches = (await import(`${getNx()}/utils/batch.js`)).default;
     const { getFullEntryList, handleUpload } = await import('./helpers/drag-n-drop.js');
     this._dropFiles = await getFullEntryList(entries);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Drag of existing docs lead to that drag overlay dont close and error apears in console

**Fix**
Darg of existing docs lead to nothing and close the overlay


https://github.com/user-attachments/assets/89e3717d-dc49-4576-8a7f-770f8f56510e



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
