### PR TITLE
Add keyboard support for library

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -502,4 +502,3 @@ export default function toggleLibrary() {
   };
   window.addEventListener(CLOSE_DROPDOWNS_EVENT, closePaletteListener);
 }
-

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -1,5 +1,5 @@
 /* eslint-disable indent */
-import { DOMParser as proseDOMParser } from 'da-y-wrapper';
+import { DOMParser as proseDOMParser, TextSelection } from 'da-y-wrapper';
 import {
   LitElement,
   html,
@@ -38,6 +38,11 @@ function closeLibrary() {
   return false;
 }
 
+function scrollToSelection() {
+  const { node } = window.view.domAtPos(window.view.state.selection.anchor);
+  node?.scrollIntoView?.();
+}
+
 // Cache fetched library data
 const libraryListPromise = delay(500).then(() => getLibraryList());
 const data = {
@@ -69,6 +74,8 @@ class DaLibrary extends LitElement {
     inlinesvg({ parent: this.shadowRoot, paths: ICONS });
     this._libraryList = await libraryListPromise;
     window.addEventListener('keydown', this.handleKeydown);
+    this.addEventListener('blur', () => window.view?.focus());
+    this.searchInputRef.value.focus();
   }
 
   disconnectedCallback() {
@@ -141,6 +148,11 @@ class DaLibrary extends LitElement {
       e.preventDefault();
       e.target.parentElement.nextElementSibling?.querySelector('button').focus();
     }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.target.parentElement.nextElementSibling?.querySelector('button').click();
+      this.searchInputRef.value.select();
+    }
   }
 
   handleSearchKeydown(e) {
@@ -158,6 +170,10 @@ class DaLibrary extends LitElement {
         this.searchInputRef.value.focus();
       }
     }
+    if (e.key === 'Enter') {
+      // Allow default and then select the input
+      setTimeout(() => this.searchInputRef.value.select(), 1);
+    }
   }
 
   handleGroupOpen(e) {
@@ -165,9 +181,30 @@ class DaLibrary extends LitElement {
     target.closest('li').classList.toggle('is-open');
   }
 
-  handleItemClick(item) {
+  handleItemClick(item, insertParagraphAfter = false) {
     const { tr } = window.view.state;
-    window.view.dispatch(tr.replaceSelectionWith(item.parsed).scrollIntoView());
+    const insertPos = tr.selection.from;
+
+    let newTr;
+
+    if (insertParagraphAfter) {
+      const paragraph = window.view.state.schema.nodes.paragraph.create();
+        newTr = tr.insert(insertPos, paragraph);
+    }
+
+    newTr = (newTr || tr).replaceSelectionWith(item.parsed);
+    const finalPos = Math.min(insertPos + item.parsed.nodeSize, newTr.doc.content.size);
+
+    window.view.dispatch(
+      newTr
+        .setSelection(TextSelection.create(newTr.doc, finalPos))
+        .scrollIntoView(),
+    );
+
+    if (finalPos === newTr.doc.content.size - 1) {
+      // only scroll down if we're at the end of the document
+      scrollToSelection();
+    }
   }
 
   async handleTemplateClick(item) {
@@ -221,7 +258,7 @@ class DaLibrary extends LitElement {
   renderBlockItem(item, icon = false) {
     return html`
       <li class="da-library-type-group-detail-item" tabindex="1">
-        <button class="${icon ? 'blocks' : ''}" @click=${() => this.handleItemClick(item)}>
+        <button class="${icon ? 'blocks' : ''}" @click=${() => this.handleItemClick(item, true)}>
           <div>
             <span class="da-library-group-name">${item.name}</span>
             <span class="da-library-group-subtitle">${item.variants}</span>
@@ -465,3 +502,4 @@ export default function toggleLibrary() {
   };
   window.addEventListener(CLOSE_DROPDOWNS_EVENT, closePaletteListener);
 }
+


### PR DESCRIPTION
- Cmd-Shift-L Toggles library open/close
- When searching, pressing enter will insert the top search entry
- Blocks are inserted with a blank line after it, and multiple insertions in a row will insert the blocks sequentially
- Going to library then back to doc the cursor will stay where it was in the doc


https://github.com/user-attachments/assets/8df3d111-bd76-496a-9422-c5b10a6410c2

