### PR TITLE
Make the da-assets code cope with multi-sheet configs

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -16,7 +16,13 @@ export async function getRepoId() {
   if (!(repo || owner)) return null;
   const resp = await daFetch(`${DA_ORIGIN}/config/${owner}/${repo}`);
   if (!resp.ok) return null;
-  const json = await resp.json();
+  let json = await resp.json();
+
+  if (json[':type'] === 'multi-sheet') {
+    // If config is a multi-sheet, the data is one level deeper
+    json = json.data;
+  }
+
   const repoConf = json.data.find((conf) => conf.key === 'aem.repositoryId');
   if (!repoConf) return null;
   return repoConf.value;


### PR DESCRIPTION
## Description

The da-assets code looks for the config sheet directly and fails if this is a multi-sheet.

## Related Issue

Fixes: #286 

# How Has This Been Tested?

Locally together with da-collab and da-admin

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
