### PR TITLE
Prevent focus to inactive library panes

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -112,8 +112,10 @@ class DaLibrary extends LitElement {
     const { target } = e;
     const type = target.dataset.libraryName;
     target.closest('.palette-pane').classList.add('backward');
+    target.closest('.palette-pane').inert = true;
     const toShow = this.shadowRoot.querySelector(`[data-library-type="${type}"]`);
     toShow.classList.remove('forward');
+    toShow.inert = false;
     const pluginIframe = toShow.querySelector('iframe');
     if (!pluginIframe) return;
     pluginIframe.src = pluginIframe.dataset.src;
@@ -122,9 +124,11 @@ class DaLibrary extends LitElement {
   handleBack(e) {
     const { target } = e;
     target.closest('.palette-pane').classList.add('forward');
+    target.closest('.palette-pane').inert = true;
     const wrapper = target.closest('.palette-wrapper');
     const previous = wrapper.querySelector('.backward');
     previous.classList.remove('backward');
+    previous.inert = false;
   }
 
   handleCloseSearch() {
@@ -419,7 +423,7 @@ class DaLibrary extends LitElement {
         </div>
         ${this._libraryList.map(
           (library) => html`
-          <div class="palette-pane forward" data-library-type="${library.name}">
+          <div class="palette-pane forward" data-library-type="${library.name}" inert>
             <div class="palette-pane-header">
               <button class="palette-back" @click=${this.handleBack}>Back</button>
               <h2>${library.name}</h2>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Inactive library plugins can gain focus by pressing tab, this change allows only the active pane to gain focus.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/da-live/issues/289
[MWPW-163990](https://jira.corp.adobe.com/browse/MWPW-163990)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When tabbing, users can break the library experience by inadvertently navigating to inactive plugins.
The library is horizontally scrolled and all panes are displayed. 
Adding inert to inactive panes prevents a broken experience.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://inert--da-live--brandon32.aem.page/edit#/aemsites/da-block-collection/demo
1. Open library from edit.
2. Tab past the last plugin.
3. Focus should shift outside the library.

## Screenshots (if appropriate):

Broken experience:
![image](https://github.com/user-attachments/assets/7371f6d7-1222-4996-89ac-dcaedda153b5)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
