### PR TITLE
Fix playwright test 'Empty out open editors on deleted documents'

### DIFF
--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -119,7 +119,7 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await list.locator('button.delete-button').locator('visible=true').click();
 
   // Give the second window a chance to update itself
-  await list.waitForTimeout(3000);
+  await list.waitForTimeout(10000);
 
   // The open window should be cleared out now
   await expect(page2.locator('div.ProseMirror')).not.toContainText(enteredText);

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -11,7 +11,7 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
-import { getTestPageURL, getTestResourceAge } from '../utils/page.js';
+import { getQuery, getTestPageURL, getTestResourceAge } from '../utils/page.js';
 
 // Files are deleted after 2 hours by default
 const MIN_HOURS = process.env.PW_DELETE_HOURS ? Number(process.env.PW_DELETE_HOURS) : 2;
@@ -104,7 +104,7 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await page.close();
 
   const list = await browser.newPage();
-  await list.goto(`${ENV}/#/da-sites/da-status/tests`);
+  await list.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
 
   await list.waitForTimeout(3000);
   await list.reload();

--- a/test/e2e/utils/page.js
+++ b/test/e2e/utils/page.js
@@ -11,10 +11,10 @@
  */
 import ENV from './env.js';
 
-function getQuery() {
+export function getQuery() {
   const { GITHUB_HEAD_REF: branch } = process.env;
   if (branch === 'local') {
-    return '?da-admin=local&da-collab=local';
+    return '?da-admin=local&da-collab=local&da-admin-room=local';
   }
   return '';
 }


### PR DESCRIPTION
## Description

Fixes a failing playwright test

Test URLs:

* Main: https://main--da-live--adobe.hlx.live/
* Branch: https://eedpw--da-live--adobe.hlx.live/

## Motivation and Context

All Playwright tests should be green.

## How Has This Been Tested?

This _is_ a test.


## Types of changes

Just a change to the tests.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
