### PR TITLE
enable sending html from a plugin

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -236,6 +236,11 @@ class DaLibrary extends LitElement {
         const para = window.view.state.schema.text(e.data.details);
         window.view.dispatch(window.view.state.tr.replaceSelectionWith(para));
       }
+      if (e.data.action === 'sendHTML') {
+        const dom = new DOMParser().parseFromString(e.data.details, 'text/html');
+        const nodes = proseDOMParser.fromSchema(window.view.state.schema).parse(dom);
+        window.view.dispatch(window.view.state.tr.replaceSelectionWith(nodes));
+      }
       if (e.data.action === 'closeLibrary') {
         closeLibrary();
       }


### PR DESCRIPTION
Allow sending HTML from a plugin. Must be merged together with https://github.com/da-sites/nexter/pull/20

## Description

To allow inserting blocks from plugins, we need to allow sending HTML from the guest.

## Related Issue

As discussed with @auniverseaway 

## Motivation and Context

The commerce picker plugin needs to be able to send blocks to the editor.



## How Has This Been Tested?

See video above

https://github.com/user-attachments/assets/767129a5-390d-4ff3-be8d-d797d7c56b35

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
