### PR TITLE
Slash menu - block properties lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ typings/
 
 .DS_Store
 .idea/*
+.cursorrules

--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -1,6 +1,6 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { DA_ORIGIN } from '../../shared/constants.js';
-import { daFetch } from '../../shared/utils.js';
+import { daFetch, getFirstSheet } from '../../shared/utils.js';
 import { getNx } from '../../../scripts/utils.js';
 
 // Components
@@ -61,9 +61,9 @@ export default class DaBrowse extends LitElement {
     if (reFetch) {
       const resp = await daFetch(`${DA_ORIGIN}/config/${this.details.owner}/`);
       if (!resp.ok) return DEF_EDIT;
-      const { data, ':type': type } = await resp.json();
+      const json = await resp.json();
 
-      const rows = type === 'multi-sheet' ? data?.data : data;
+      const rows = getFirstSheet(json);
       this.editorConfs = rows.reduce((acc, row) => {
         if (row.key === 'editor.path') acc.push(row.value);
         return acc;

--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -1,6 +1,6 @@
 import { getNx } from '../../../scripts/utils.js';
 import { DA_ORIGIN } from '../../shared/constants.js';
-import { daFetch } from '../../shared/utils.js';
+import { daFetch, getFirstSheet } from '../../shared/utils.js';
 
 const { loadStyle } = await import(`${getNx()}/scripts/nexter.js`);
 const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
@@ -16,7 +16,7 @@ async function fetchValue(path) {
   if (!resp.ok) return null;
 
   const json = await resp.json();
-  const { data } = json[':type'] === 'multi-sheet' ? Object.keys(json)[0] : json;
+  const data = getFirstSheet(json);
   if (!data) return null;
 
   const repoConf = data.find((conf) => conf.key === 'aem.repositoryId');

--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -2,8 +2,9 @@
 import { DOMParser } from 'da-y-wrapper';
 import { CON_ORIGIN, getDaAdmin } from '../../../shared/constants.js';
 import getPathDetails from '../../../shared/pathDetails.js';
-import { daFetch } from '../../../shared/utils.js';
+import { daFetch, getFirstSheet } from '../../../shared/utils.js';
 import { getRepoId, openAssets } from '../../da-assets/da-assets.js';
+import { fetchKeyAutocompleteData } from '../../prose/plugins/slashMenu/keyAutocomplete.js';
 
 const DA_ORIGIN = getDaAdmin();
 const REPLACE_CONTENT = '<content>';
@@ -66,9 +67,9 @@ async function getDaLibraries(owner, repo) {
   if (!resp.ok) return [];
 
   const json = await resp.json();
-  const blockData = (json[':type'] === 'multi-sheet' ? json.data?.data : json.data) || [];
 
-  return blockData.reduce((acc, item) => {
+  const blockData = getFirstSheet(json);
+  const daLibraries = blockData.reduce((acc, item) => {
     const keySplit = item.key.split('-');
     if (keySplit[0] === 'library') {
       acc.push({
@@ -79,6 +80,13 @@ async function getDaLibraries(owner, repo) {
     }
     return acc;
   }, []);
+
+  const blockJsonUrl = daLibraries.filter((v) => v.name === 'blocks')?.[0]?.sources?.[0];
+  if (blockJsonUrl) {
+    fetchKeyAutocompleteData(blockJsonUrl);
+  }
+
+  return daLibraries;
 }
 
 async function getAemPlugins(owner, repo) {

--- a/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
+++ b/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
@@ -18,10 +18,12 @@ export function processKeyData(data) {
     const blocks = itemBlocks.split(',').map((block) => block.trim());
 
     const values = item.values.toLowerCase().split(',').map((v) => {
-      const val = v.trim();
+      const [label, val] = v.split('=').map((vb) => vb.trim());
+
       return {
-        title: val,
-        command: (state, dispatch) => insertAutocompleteText(state, dispatch, val),
+        title: label,
+        value: val || label,
+        command: (state, dispatch) => insertAutocompleteText(state, dispatch, val || label),
         class: 'key-autocomplete',
       };
     });

--- a/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
+++ b/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
@@ -1,0 +1,60 @@
+import { daFetch, getSheetByIndex } from '../../../../shared/utils.js';
+
+function insertAutocompleteText(state, dispatch, text) {
+  const { $cursor } = state.selection;
+
+  if (!$cursor) return;
+  const from = $cursor.before();
+  const to = $cursor.pos;
+  const tr = state.tr.replaceWith(from, to, state.schema.text(text));
+  dispatch(tr);
+}
+
+export function processKeyData(data) {
+  const blockMap = new Map();
+
+  data?.forEach((item) => {
+    const itemBlocks = item.blocks.toLowerCase().trim();
+    const blocks = itemBlocks.split(',').map((block) => block.trim());
+
+    const values = item.values.toLowerCase().split(',').map((v) => {
+      const val = v.trim();
+      return {
+        title: val,
+        command: (state, dispatch) => insertAutocompleteText(state, dispatch, val),
+        class: 'key-autocomplete',
+      };
+    });
+
+    blocks.forEach((block) => {
+      if (!blockMap.has(block)) {
+        blockMap.set(block, new Map());
+      }
+      blockMap.get(block).set(item.key, values);
+    });
+  });
+
+  return blockMap;
+}
+
+// getKeyAutocomplete only resolves once setKeyAutocomplete is called
+export const [setKeyAutocomplete, getKeyAutocomplete] = (() => {
+  let resolveData;
+  const dataPromise = new Promise((resolve) => {
+    resolveData = resolve;
+  });
+
+  return [
+    (keyMap) => {
+      resolveData(keyMap);
+    },
+    async () => dataPromise,
+  ];
+})();
+
+export async function fetchKeyAutocompleteData(libraryBlockUrl) {
+  const resp = await daFetch(libraryBlockUrl);
+  const json = await resp.json();
+  const keyMap = processKeyData(getSheetByIndex(json, 1));
+  setKeyAutocomplete(keyMap);
+}

--- a/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
+++ b/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
@@ -17,7 +17,7 @@ export function processKeyData(data) {
     const itemBlocks = item.blocks.toLowerCase().trim();
     const blocks = itemBlocks.split(',').map((block) => block.trim());
 
-    const values = item.values.toLowerCase().split(',').map((v) => {
+    const values = item.values.toLowerCase().split('|').map((v) => {
       const [label, val] = v.split('=').map((vb) => vb.trim());
 
       return {

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.css
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.css
@@ -27,7 +27,7 @@
   user-select: none;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
 }
 
 .slash-menu-item:hover,

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -8,7 +8,7 @@ function isColorCode(str) {
   const hexColorRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
   const rgbColorRegex = /^rgba?\(\s*(\d{1,3}\s*,\s*){2}\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/;
 
-  return hexColorRegex.test(str) || rgbColorRegex.test(str);
+  return hexColorRegex.test(str) || rgbColorRegex.test(str) || str?.includes('-gradient(');
 }
 
 function createColorSquare(color) {

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -14,7 +14,7 @@ function isColorCode(str) {
 function createColorSquare(color) {
   return html`
     <div style="display: flex; align-items: center;">
-      <div style="width: 10px; height: 10px; background: ${color}; margin-right: 5px;"></div>
+      <div style="width: 20px; height: 20px; background: ${color}; margin: -5px 5px -5px -5px;"></div>
     </div>
   `;
 }

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -197,14 +197,14 @@ export default class SlashMenu extends LitElement {
     return html`
       <div class="slash-menu-items">
         ${filteredItems.map((item, index) => {
-          const isColor = isColorCode(item.title);
+          const isColor = isColorCode(item.value);
           return html`
             <div
               class="slash-menu-item ${index === this.selectedIndex ? 'selected' : ''}"
               @click=${() => this.handleItemClick(item)}
             >
               ${isColor
-                ? createColorSquare(item.title)
+                ? createColorSquare(item.value)
                 : html`<span class="slash-menu-icon ${item.class || ''}"></span>`}
               <span class="slash-menu-label">
                 ${item.title}

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -14,7 +14,7 @@ function isColorCode(str) {
 function createColorSquare(color) {
   return html`
     <div style="display: flex; align-items: center;">
-      <div style="width: 10px; height: 10px; background-color: ${color}; margin-right: 5px;"></div>
+      <div style="width: 10px; height: 10px; background: ${color}; margin-right: 5px;"></div>
     </div>
   `;
 }

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -13,9 +13,7 @@ function isColorCode(str) {
 
 function createColorSquare(color) {
   return html`
-    <div style="display: flex; align-items: center;">
-      <div style="width: 20px; height: 20px; background: ${color}; margin: -5px 5px -5px -5px;"></div>
-    </div>
+    <div style="width: 24px; height: 24px; background: ${color}; margin-left: -4px;"></div>
   `;
 }
 

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -4,6 +4,21 @@ import getSheet from '../../../../shared/sheet.js';
 
 const sheet = await getSheet('/blocks/edit/prose/plugins/slashMenu/slash-menu.css');
 
+function isColorCode(str) {
+  const hexColorRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+  const rgbColorRegex = /^rgba?\(\s*(\d{1,3}\s*,\s*){2}\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/;
+
+  return hexColorRegex.test(str) || rgbColorRegex.test(str);
+}
+
+function createColorSquare(color) {
+  return html`
+    <div style="display: flex; align-items: center;">
+      <div style="width: 10px; height: 10px; background-color: ${color}; margin-right: 5px;"></div>
+    </div>
+  `;
+}
+
 export default class SlashMenu extends LitElement {
   static properties = {
     items: { type: Array },
@@ -37,6 +52,7 @@ export default class SlashMenu extends LitElement {
   }
 
   hide() {
+    this.dispatchEvent(new CustomEvent('reset-slashmenu'));
     this.visible = false;
     this.command = '';
     this.selectedIndex = 0;
@@ -180,17 +196,21 @@ export default class SlashMenu extends LitElement {
 
     return html`
       <div class="slash-menu-items">
-        ${filteredItems.map((item, index) => html`
-          <div
-            class="slash-menu-item ${index === this.selectedIndex ? 'selected' : ''}"
-            @click=${() => this.handleItemClick(item)}
-          >
-            <span class="slash-menu-icon ${item.class || ''}"></span>
-            <span class="slash-menu-label">
-              ${item.title}
-            </span>
-          </div>
-        `)}
+        ${filteredItems.map((item, index) => {
+          const isColor = isColorCode(item.title);
+          return html`
+            <div
+              class="slash-menu-item ${index === this.selectedIndex ? 'selected' : ''}"
+              @click=${() => this.handleItemClick(item)}
+            >
+              ${isColor
+                ? createColorSquare(item.title)
+                : html`<span class="slash-menu-icon ${item.class || ''}"></span>`}
+              <span class="slash-menu-label">
+                ${item.title}
+              </span>
+            </div>`;
+        })}
       </div>
     `;
   }

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -27,6 +27,8 @@ class SlashMenuView {
     this.menu.addEventListener('reset-slashmenu', () => {
       // reset menu to default items
       this.menu.items = menuItems;
+      this.menu.left = 0;
+      this.menu.top = 0;
     });
   }
 

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -96,3 +96,12 @@ export async function saveToDa({ path, formData, blob, props, preview = false })
   if (!preview) return undefined;
   return aemPreview(path, 'preview');
 }
+
+export const getSheetByIndex = (json, index = 0) => {
+  if (json[':type'] !== 'multi-sheet') {
+    return json.data;
+  }
+  return json[Object.keys(json)[index]]?.data;
+};
+
+export const getFirstSheet = (json) => getSheetByIndex(json, 0);


### PR DESCRIPTION
Uses the block library file to have autocomplete suggestions when in the value column of a key/value table (metadata etc).

## Release notes
Add the ability to spec key / value lookups in the block library.


1. Ability to spec key / value pairs for blocks
2. Expose values in slash menu when left col matches key
3. Exposes swatch if value matches typical swatch patterns.
4. Uses a pipe format `dark-grey=#676767 | light-grey=#EFEFEF`

<img width="650" alt="slash-menu" src="https://github.com/user-attachments/assets/66740ab3-def7-4f69-8fdb-7663f84590d1" />
