### PR TITLE
Slash menu improvements

### DIFF
--- a/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
+++ b/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
@@ -4,9 +4,7 @@ function insertAutocompleteText(state, dispatch, text) {
   const { $cursor } = state.selection;
 
   if (!$cursor) return;
-  const from = $cursor.before();
-  const to = $cursor.pos;
-  const tr = state.tr.replaceWith(from, to, state.schema.text(text));
+  const tr = state.tr.insert($cursor.pos, state.schema.text(text));
   dispatch(tr);
 }
 

--- a/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
+++ b/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
@@ -36,6 +36,27 @@ export function processKeyData(data) {
     });
   });
 
+  // values of "all" block are available (thus copied) in all other blocks, if not explicitly set
+  const allBlocks = blockMap.get('all');
+  blockMap.forEach((block, blockName) => {
+    if (blockName === 'all') return;
+    allBlocks.forEach((values, key) => {
+      if (!block.has(key)) {
+        block.set(key, values);
+      }
+    });
+  });
+
+  // the "all" block is also returned as fallback if no values are configured for the queried block
+  const originalGet = blockMap.get.bind(blockMap);
+  blockMap.get = (blockName) => {
+    if (blockMap.has(blockName)) {
+      return originalGet(blockName);
+    }
+
+    return originalGet('all');
+  };
+
   return blockMap;
 }
 

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -11,10 +11,6 @@ function isColorCode(str) {
   return hexColorRegex.test(str) || rgbColorRegex.test(str) || str?.includes('-gradient(');
 }
 
-function isPng(str) {
-  return str?.startsWith('https') && str?.endsWith('.png');
-}
-
 function createColorSquare(color) {
   return html`
     <div style="width: 24px; height: 24px; background: ${color}; margin-left: -4px;"></div>
@@ -202,8 +198,7 @@ export default class SlashMenu extends LitElement {
       <div class="slash-menu-items">
         ${filteredItems.map((item, index) => {
           const isColor = isColorCode(item.value);
-          const hasBuiltinIcon = rules.find((rule) => rule.cssText.startsWith(`.slash-menu-icon.${item.class}`));
-          const hasCustomIcon = isPng(item.value);
+          const hasIcon = rules.find((rule) => rule.cssText.startsWith(`.slash-menu-icon.${item.class}`));
 
           return html`
             <div
@@ -211,8 +206,7 @@ export default class SlashMenu extends LitElement {
               @click=${() => this.handleItemClick(item)}
             >
               ${isColor ? createColorSquare(item.value) : ''}
-              ${hasBuiltinIcon ? html`<span class="slash-menu-icon ${item.class}"></span>` : ''}
-              ${hasCustomIcon ? html`<span class="slash-menu-icon" style='background-image: url("${item.value}")'></span>` : ''}
+              ${hasIcon ? html`<span class="slash-menu-icon ${item.class}"></span>` : ''}
               <span class="slash-menu-label">
                 ${item.title}
               </span>

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -11,6 +11,10 @@ function isColorCode(str) {
   return hexColorRegex.test(str) || rgbColorRegex.test(str) || str?.includes('-gradient(');
 }
 
+function isPng(str) {
+  return str?.startsWith('https') && str?.endsWith('.png');
+}
+
 function createColorSquare(color) {
   return html`
     <div style="width: 24px; height: 24px; background: ${color}; margin-left: -4px;"></div>
@@ -192,14 +196,14 @@ export default class SlashMenu extends LitElement {
       return '';
     }
 
-    const rules = [...sheet.rules];
+    const rules = [...sheet.cssRules];
 
     return html`
       <div class="slash-menu-items">
         ${filteredItems.map((item, index) => {
           const isColor = isColorCode(item.value);
-
-          const hasIcon = rules.find((rule) => rule.cssText.startsWith(`.slash-menu-icon.${item.class}`));
+          const hasBuiltinIcon = rules.find((rule) => rule.cssText.startsWith(`.slash-menu-icon.${item.class}`));
+          const hasCustomIcon = isPng(item.value);
 
           return html`
             <div
@@ -207,7 +211,8 @@ export default class SlashMenu extends LitElement {
               @click=${() => this.handleItemClick(item)}
             >
               ${isColor ? createColorSquare(item.value) : ''}
-              ${hasIcon ? html`<span class="slash-menu-icon ${item.class}"></span>` : ''}
+              ${hasBuiltinIcon ? html`<span class="slash-menu-icon ${item.class}"></span>` : ''}
+              ${hasCustomIcon ? html`<span class="slash-menu-icon" style='background-image: url("${item.value}")'></span>` : ''}
               <span class="slash-menu-label">
                 ${item.title}
               </span>

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -192,18 +192,22 @@ export default class SlashMenu extends LitElement {
       return '';
     }
 
+    const rules = [...sheet.rules];
+
     return html`
       <div class="slash-menu-items">
         ${filteredItems.map((item, index) => {
           const isColor = isColorCode(item.value);
+
+          const hasIcon = rules.find((rule) => rule.cssText.startsWith(`.slash-menu-icon.${item.class}`));
+
           return html`
             <div
               class="slash-menu-item ${index === this.selectedIndex ? 'selected' : ''}"
               @click=${() => this.handleItemClick(item)}
             >
-              ${isColor
-                ? createColorSquare(item.value)
-                : html`<span class="slash-menu-icon ${item.class || ''}"></span>`}
+              ${isColor ? createColorSquare(item.value) : ''}
+              ${hasIcon ? html`<span class="slash-menu-icon ${item.class}"></span>` : ''}
               <span class="slash-menu-label">
                 ${item.title}
               </span>

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -188,6 +188,7 @@ export default function slashMenu() {
             const { tableName, keyValue } = getTableName($cursor);
             if (tableName) {
               const keyData = pluginState.autocompleteData?.get(tableName);
+              console.log(pluginState.autocompleteData)
               if (keyData) {
                 const values = keyData.get(keyValue);
                 if (values) {

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -86,6 +86,15 @@ class SlashMenuView {
     }
   }
 
+  cellHasMenuItems(pluginState, $cursor) {
+    const { tableName, keyValue } = getTableName($cursor);
+    if (tableName) {
+      const keyData = pluginState.autocompleteData?.get(tableName);
+      return keyData && keyData.get(keyValue);
+    }
+    return false;
+  }
+
   update(view) {
     if (!view) return;
 
@@ -100,8 +109,7 @@ class SlashMenuView {
     }
 
     const textBefore = $cursor.parent.textContent.slice(0, $cursor.parentOffset);
-    const { tableName } = getTableName($cursor);
-    if (!tableName && !textBefore?.startsWith('/')) {
+    if (!this.cellHasMenuItems(slashMenuKey.getState(state), $cursor) && !textBefore?.startsWith('/')) {
       if (this.menu.visible) this.hide();
       return;
     }

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -78,13 +78,10 @@ class SlashMenuView {
     const { tableName, keyValue } = getTableName($cursor);
     if (tableName) {
       const keyData = pluginState.autocompleteData?.get(tableName);
-      if (keyData) {
-        const values = keyData.get(keyValue);
-        if (values) {
-          this.menu.items = values;
-        } else {
-          this.menu.items = menuItems;
-        }
+      if (keyData && keyData.get(keyValue)) {
+        this.menu.items = keyData.get(keyValue);
+      } else {
+        this.menu.items = menuItems;
       }
     }
   }

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -4,7 +4,7 @@ import { getKeyAutocomplete } from './keyAutocomplete.js';
 import menuItems from './slashMenuItems.js';
 import './slash-menu.js';
 
-const SLASH_COMMAND_REGEX = /^\/(([^/\s]+(?:\s+[^/\s]+)*)\s*([^/\s]*))?$/;
+const SLASH_COMMAND_REGEX = /\/(([^/\s]+(?:\s+[^/\s]+)*)\s*([^/\s]*))?$/;
 const slashMenuKey = new PluginKey('slashMenu');
 
 function extractArgument(title, command) {
@@ -100,7 +100,8 @@ class SlashMenuView {
     }
 
     const textBefore = $cursor.parent.textContent.slice(0, $cursor.parentOffset);
-    if (!textBefore?.startsWith('/')) {
+    const { tableName } = getTableName($cursor);
+    if (!tableName && !textBefore?.startsWith('/')) {
       if (this.menu.visible) this.hide();
       return;
     }

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -14,97 +14,6 @@ function extractArgument(title, command) {
     : undefined;
 }
 
-class SlashMenuView {
-  constructor(view) {
-    this.view = view;
-    this.menu = document.createElement('slash-menu');
-    this.menu.items = menuItems || [];
-
-    this.menu.addEventListener('item-selected', (e) => {
-      this.selectItem(e.detail);
-    });
-
-    this.menu.addEventListener('reset-slashmenu', () => {
-      // reset menu to default items
-      this.menu.items = menuItems;
-      this.menu.left = 0;
-      this.menu.top = 0;
-    });
-  }
-
-  update(view) {
-    if (!view) return;
-
-    this.view = view;
-
-    const { state } = view;
-    const { $cursor } = state.selection;
-
-    if (!$cursor) {
-      this.hide();
-      return;
-    }
-
-    const textBefore = $cursor.parent.textContent.slice(0, $cursor.parentOffset);
-    if (!textBefore?.startsWith('/')) {
-      if (this.menu.visible) this.hide();
-      return;
-    }
-
-    const match = textBefore.match(SLASH_COMMAND_REGEX);
-    if (match) {
-      const showSlashMenu = slashMenuKey?.getState(state)?.showSlashMenu;
-      if (!this.menu.visible || showSlashMenu) {
-        const coords = this.view.coordsAtPos($cursor.pos);
-
-        const viewportCoords = {
-          left: coords.left + window.pageXOffset,
-          bottom: coords.bottom + window.pageYOffset,
-        };
-
-        this.menu.show(viewportCoords);
-      }
-
-      this.menu.command = match[1] || '';
-    } else if (this.menu.visible) {
-      this.menu.command = '';
-      this.hide();
-    }
-  }
-
-  selectItem(detail) {
-    const { item } = detail;
-    const { state, dispatch } = this.view;
-    const { $cursor } = state.selection;
-    if (!$cursor) return;
-
-    // Delete the slash command and any arguments
-    const deleteFrom = $cursor.pos - (this.menu.command.length + 1);
-    const deleteTo = $cursor.pos;
-    const tr = state.tr.delete(deleteFrom, deleteTo);
-    const newState = state.apply(tr);
-
-    const argument = extractArgument(item.title, this.menu.command);
-
-    dispatch(tr);
-    item.command(newState, dispatch, argument);
-
-    this.hide();
-  }
-
-  handleKeyDown(event) {
-    return this.menu.handleKeyDown(event);
-  }
-
-  hide() {
-    this.menu.hide();
-  }
-
-  destroy() {
-    this.menu.remove();
-  }
-}
-
 // Get the table name if the cursor is in a table cell
 const getTableName = ($cursor) => {
   const { depth } = $cursor;
@@ -147,6 +56,110 @@ const getTableName = ($cursor) => {
   return false;
 };
 
+class SlashMenuView {
+  constructor(view) {
+    this.view = view;
+    this.menu = document.createElement('slash-menu');
+    this.menu.items = menuItems || [];
+
+    this.menu.addEventListener('item-selected', (e) => {
+      this.selectItem(e.detail);
+    });
+
+    this.menu.addEventListener('reset-slashmenu', () => {
+      // reset menu to default items
+      this.menu.items = menuItems;
+      this.menu.left = 0;
+      this.menu.top = 0;
+    });
+  }
+
+  updateSlashMenuItems(pluginState, $cursor) {
+    const { tableName, keyValue } = getTableName($cursor);
+    if (tableName) {
+      const keyData = pluginState.autocompleteData?.get(tableName);
+      if (keyData) {
+        const values = keyData.get(keyValue);
+        if (values) {
+          this.menu.items = values;
+        } else {
+          this.menu.items = menuItems;
+        }
+      }
+    }
+  }
+
+  update(view) {
+    if (!view) return;
+
+    this.view = view;
+
+    const { state } = view;
+    const { $cursor } = state.selection;
+
+    if (!$cursor) {
+      this.hide();
+      return;
+    }
+
+    const textBefore = $cursor.parent.textContent.slice(0, $cursor.parentOffset);
+    if (!textBefore?.startsWith('/')) {
+      if (this.menu.visible) this.hide();
+      return;
+    }
+
+    const match = textBefore.match(SLASH_COMMAND_REGEX);
+    if (match) {
+      this.updateSlashMenuItems(slashMenuKey.getState(state), $cursor);
+      const coords = this.view.coordsAtPos($cursor.pos);
+
+      const viewportCoords = {
+        left: coords.left + window.pageXOffset,
+        bottom: coords.bottom + window.pageYOffset,
+      };
+
+      this.menu.show(viewportCoords);
+
+      this.menu.command = match[1] || '';
+    } else if (this.menu.visible) {
+      this.menu.command = '';
+      this.hide();
+    }
+  }
+
+  selectItem(detail) {
+    const { item } = detail;
+    const { state, dispatch } = this.view;
+    const { $cursor } = state.selection;
+    if (!$cursor) return;
+
+    // Delete the slash command and any arguments
+    const deleteFrom = $cursor.pos - (this.menu.command.length + 1);
+    const deleteTo = $cursor.pos;
+    const tr = state.tr.delete(deleteFrom, deleteTo);
+    const newState = state.apply(tr);
+
+    const argument = extractArgument(item.title, this.menu.command);
+
+    dispatch(tr);
+    item.command(newState, dispatch, argument);
+
+    this.hide();
+  }
+
+  handleKeyDown(event) {
+    return this.menu.handleKeyDown(event);
+  }
+
+  hide() {
+    this.menu.hide();
+  }
+
+  destroy() {
+    this.menu.remove();
+  }
+}
+
 export default function slashMenu() {
   let pluginView = null;
 
@@ -177,33 +190,6 @@ export default function slashMenu() {
     },
     props: {
       handleKeyDown(editorView, event) {
-        const { state } = editorView;
-        const pluginState = slashMenuKey.getState(state);
-
-        if (event.key === '/') {
-          const { $cursor } = state.selection;
-
-          // Check if we're at start of empty line
-          if ($cursor?.parentOffset === 0 && $cursor?.parent?.textContent === '') {
-            const { tableName, keyValue } = getTableName($cursor);
-            if (tableName) {
-              const keyData = pluginState.autocompleteData?.get(tableName);
-              console.log(pluginState.autocompleteData)
-              if (keyData) {
-                const values = keyData.get(keyValue);
-                if (values) {
-                  pluginView.menu.items = values;
-                }
-              }
-            }
-
-            const tr = state.tr.setMeta(slashMenuKey, { showSlashMenu: true });
-            editorView.dispatch(tr);
-            return false;
-          }
-          return false;
-        }
-
         if (pluginView?.menu.visible) {
           if (['ArrowUp', 'ArrowDown', 'Enter', 'Escape'].includes(event.key)) {
             event.preventDefault();


### PR DESCRIPTION
Covers 4 separate slash menu improvements

## Description

1. DA - Slash menu - Do not show swatch if its not a color
2. DA - Slash menu - Implement ALL keyword
3. DA - Slash menu - If a slash is already present, re-lookup the options
4. DA - Slash menu - Allow multiple selections if author is in a matching column

https://github.com/user-attachments/assets/fde3c01e-39e7-4383-86ed-608c2deb93c9

## Release notes
Additional slash menu support for commerce use cases: segmentation picking, styles, etc.

1. Do not show swatch if its not a color
2. Implement ALL keyword
3. If a slash is already present, re-lookup the options
4. Allow multiple selections if author is in a matching column

Please see PR for full video demo.
