### PR TITLE
Playwright tests for ACL functionality

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Install Playwright Browsers
       run: cd test/e2e && npx playwright install --with-deps
     - name: Run Playwright tests
+      env:
+        TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
       run: cd test/e2e && npm run test:all
     - uses: actions/upload-artifact@v4
       if: always()

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.playwright/
+

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -5,6 +5,7 @@
     "test": "playwright test --project=chromium",
     "test:install": "playwright install",
     "test:all": "playwright test --project=chromium --project=firefox # limit to Chromium and FF as webkit currently fails",
+    "test:nonauth": "SKIP_AUTH=true playwright test --project=chromium --project=firefox tests/*.spec.js",
     "test:ui": "playwright test --project=chromium --ui",
     "test:debug": "playwright test --project=chromium --debug",
     "test:report": "playwright show-report"

--- a/test/e2e/playwright.config.js
+++ b/test/e2e/playwright.config.js
@@ -33,19 +33,34 @@ module.exports = defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
+    // Setup project
+    { name: 'setup', testMatch: /.*\.setup\.js/ },
+
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: '.playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
 
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: {
+        ...devices['Desktop Firefox'],
+        storageState: '.playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
 
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: '.playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
 
     /* Test against mobile viewports. */

--- a/test/e2e/tests/auth.setup.js
+++ b/test/e2e/tests/auth.setup.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import fs from 'fs';
+import path from 'path';
+import { test as setup, expect } from '@playwright/test';
+import ENV from '../utils/env.js';
+
+const AUTH_FILE = path.join(__dirname, '../.playwright/.auth/user.json');
+
+/*
+The ACL tests require to be logged in, which is what this setup does.
+It is assumed to be configured as follows, where the current est user is in IMS org
+907136ED5D35CBF50A495CD4 and in its group DA-Test BUT NOT iN DA-Nonexist.
+
+  path groups actions
+  /acltest/testdocs/doc_readwrite 907136ED5D35CBF50A495CD4/DA-Test write
+  /acltest/testdocs/doc_readonly 907136ED5D35CBF50A495CD4 read
+  /acltest/testdocs/doc_noaccess 907136ED5D35CBF50A495CD4/DA-Nonexist write
+  /acltest/testdocs/subdir/+** 907136ED5D35CBF50A495CD4 read
+  /acltest/testdocs/subdir/subdir2/** 907136ED5D35CBF50A495CD4 write
+  /acltest/testdocs/subdir/subdir1/+** 907136ED5D35CBF50A495CD4 write
+  /acltest/testdocs/subdir/subdir2/subdir3 907136ED5D35CBF50A495CD4 read
+*/
+
+// This is executed once to authenticate the user used during the tests.
+setup('Set up authentication', async ({ page }) => {
+  if (fs.existsSync(AUTH_FILE)) {
+    await fs.promises.unlink(AUTH_FILE);
+    console.log('Deleted previous storage stage auth file');
+  }
+
+  if (process.env.SKIP_AUTH) {
+    await fs.promises.writeFile(AUTH_FILE, '{}');
+    console.log('Skipping authentication');
+    return;
+  }
+
+  const url = ENV;
+
+  await page.goto(url);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // The IMS sign in page needs a bit of time to load
+  await page.waitForTimeout(1000);
+  const pwd = process.env.TEST_PASSWORD;
+  if (pwd) {
+    console.log('Password found in environment variable TEST_PASSWORD');
+  } else {
+    throw new Error('Password for authentication needed in environment variable TEST_PASSWORD');
+  }
+  await page.getByLabel('Email address').fill('bosschae+da-test@adobetest.com');
+  await page.getByRole('button', { name: 'Continue', exact: true }).click();
+  await page.getByLabel('Password', { exact: true }).fill(pwd);
+  console.log('Entered password');
+  await page.getByLabel('Continue', { exact: true }).click();
+  await page.getByLabel('Foundation Internal').click();
+  await expect(page.locator('a.nx-nav-brand')).toContainText('Document Authoring');
+
+  await page.context().storageState({ path: AUTH_FILE });
+});

--- a/test/e2e/tests/authenticated/acl_browse.spec.js
+++ b/test/e2e/tests/authenticated/acl_browse.spec.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { test, expect } from '@playwright/test';
+import ENV from '../../utils/env.js';
+import { getTestPageURL, getQuery } from '../../utils/page.js';
+
+test('Read-only directory', async ({ page }) => {
+  const url = `${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir`;
+
+  await page.goto(url);
+  const newButton = page.getByRole('button', { name: 'New' });
+  await expect(newButton).toBeDisabled();
+
+  await expect(page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/subdir/doc_onlyread"]')).toBeVisible();
+  await page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/subdir/doc_onlyread"]').focus();
+
+  // Note this currently does not work on webkit as the checkbox isn't keyboard focusable there
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.press(' ');
+  await page.waitForTimeout(500);
+
+  const tickbox = page.locator('da-list-item').filter({ hasText: 'doc_onlyread' }).locator('label');
+  await expect(tickbox).toBeChecked();
+
+  // There should not be a delete button
+  await expect(page.locator('button.delete-button').locator('visible=true')).toHaveCount(0);
+});
+
+test('Read-write directory', async ({ browser, page }, workerInfo) => {
+  const pageURL = getTestPageURL('acl-browse-edt', workerInfo, '/da-testautomation/acltest/testdocs/subdir/subdir1');
+  const pageName = pageURL.split('/').pop();
+  const browseURL = pageURL.replace(`/${pageName}`, '').replace('/edit#/', '/#/');
+
+  await page.goto(browseURL);
+  const newButton = page.getByRole('button', { name: 'New' });
+  await expect(newButton).toBeEnabled();
+  await newButton.click();
+  await page.locator('button:text("Document")').click();
+  await page.locator('input.da-actions-input').fill(pageName);
+
+  // Cannot just click the 'Create document' button because on Firefox that for some reason gets
+  // overlaid with the 'sign out button', so just press 'space' on it.
+  await page.locator('button:text("Create document")').press(' ');
+  await expect(page.locator('div.ProseMirror')).toBeVisible();
+  await page.locator('div.ProseMirror').fill('test writable doc');
+  await page.waitForTimeout(3000);
+
+  const newPage = await browser.newPage();
+  await newPage.goto(pageURL);
+  // The following assertion has an extended timeout as it might cycle through the login screen
+  // before the document is visible. The login screen doesn't need any input though, it will just
+  // continue with the existing login
+  await newPage.waitForTimeout(3000);
+  await expect(newPage.locator('div.ProseMirror')).toContainText('test writable doc');
+  newPage.close();
+
+  await page.goto(browseURL);
+  await expect(page.locator(`a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir1/${pageName}"]`)).toBeVisible();
+  await page.locator(`a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir1/${pageName}"]`).focus();
+
+  // Note this currently does not work on webkit as the checkbox isn't keyboard focusable there
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.press(' ');
+  await page.waitForTimeout(500);
+
+  const tickbox = page.locator('da-list-item').filter({ hasText: pageName }).locator('label');
+  await expect(tickbox).toBeChecked();
+
+  // There are 2 delete buttons, one on the Browse panel and another on the Search one
+  // select the visible one.
+  await page.locator('button.delete-button').locator('visible=true').click();
+
+  await page.waitForTimeout(1000);
+  await expect(page.locator(`a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir1/${pageName}"]`)).not.toBeVisible();
+});
+
+test('Readonly directory with writeable document', async ({ page }) => {
+  const browseURL = `${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir/subdir2`;
+  await page.goto(browseURL);
+
+  await expect(page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir2/doc_writeable"]')).toBeVisible();
+  await page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir2/doc_writeable"]').focus();
+
+  // Note this currently does not work on webkit as the checkbox isn't keyboard focusable there
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.press(' ');
+  await page.waitForTimeout(500);
+
+  // Check that the expected delete button is there (but don't click it)
+  await expect(page.locator('button.delete-button').locator('visible=true')).toBeVisible();
+
+  // Open the document, this will open an new tab (aka 'popup')
+  const newTabPromise = page.waitForEvent('popup');
+  await page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir2/doc_writeable"]').click();
+  const newTab = await newTabPromise;
+
+  const editor = newTab.locator('div.ProseMirror');
+  await expect(editor).toContainText('This is doc_writeable');
+  await expect(editor).toHaveAttribute('contenteditable', 'true');
+});
+
+test('No access directory should not show anything', async ({ page }) => {
+  await page.goto(`${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir`);
+
+  // In this directory we should be able to see files
+  await expect(page.getByRole('button', { name: 'Name' })).toBeVisible();
+
+  // In this directory we should be able to see nothing
+  await page.goto(`${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs`);
+  // We need to reload the page explicitly because the only thing we changed
+  // was the anchor and that doesn't normally trigger a change
+  await page.reload();
+  await page.waitForTimeout(3000);
+  await expect(page.getByRole('button', { name: 'Name' })).not.toBeVisible();
+});

--- a/test/e2e/tests/authenticated/acl_doc.spec.js
+++ b/test/e2e/tests/authenticated/acl_doc.spec.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { test, expect } from '@playwright/test';
+import ENV from '../../utils/env.js';
+import { getQuery } from '../../utils/page.js';
+
+test('Read-only document directly configured', async ({ page }, workerInfo) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/doc_readonly`;
+
+  await page.goto(url);
+  const editor = page.locator('div.ProseMirror');
+  await expect(editor).toHaveText('This is doc_readonly');
+  await expect(editor, 'Should be readonly').toHaveAttribute('contenteditable', 'false');
+
+  await editor.pressSequentially('Hello');
+  await expect(editor, 'The text should not have been updated since its a readonly doc')
+    .toHaveText('This is doc_readonly');
+
+  // This last part of this test that obtains the ':before' part of the h1
+  // apparently only works on Chromium, so skip it for other browsers
+  if (workerInfo.project.name !== 'chromium') {
+    return;
+  }
+
+  // check the lock icon
+  const h1 = page.locator('h1');
+  const h1Before = await h1.evaluate((element) => window.getComputedStyle(element, ':before'));
+  expect(h1Before.backgroundImage).toContain('LockClosed');
+});
+
+test('Read-only document indirectly configured', async ({ page }, workerInfo) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/subdir/doc_onlyread`;
+
+  await page.goto(url);
+  const editor = page.locator('div.ProseMirror');
+  await expect(editor).toHaveText('This is doc_onlyread');
+  await expect(editor, 'Should be readonly').toHaveAttribute('contenteditable', 'false');
+
+  await editor.pressSequentially('Hello');
+  await expect(editor, 'The text should not have been updated since its a readonly doc')
+    .toHaveText('This is doc_onlyread');
+
+  // This last part of this test that obtains the ':before' part of the h1
+  // apparently only works on Chromium, so skip it for other browsers
+  if (workerInfo.project.name !== 'chromium') {
+    return;
+  }
+
+  // check the lock icon
+  const h1 = page.locator('h1');
+  const h1Before = await h1.evaluate((element) => window.getComputedStyle(element, ':before'));
+  expect(h1Before.backgroundImage).toContain('LockClosed');
+});
+
+test('Read-write document', async ({ page }, workerInfo) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/doc_readwrite`;
+
+  await page.goto(url);
+  const editor = page.locator('div.ProseMirror');
+  await expect(editor).toContainText('This is doc_readwrite');
+  await expect(editor, 'Should be editable').toHaveAttribute('contenteditable', 'true');
+
+  // This last part of this test that obtains the ':before' part of the h1
+  // apparently only works on Chromium, so skip it for other browsers
+  if (workerInfo.project.name !== 'chromium') {
+    return;
+  }
+
+  // check the lock icon
+  const h1 = page.locator('h1');
+  const h1Before = await h1.evaluate((element) => window.getComputedStyle(element, ':before'));
+  expect(h1Before.backgroundImage).not.toContain('LockClosed');
+});
+
+test('No access at all', async ({ page }) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/doc_noaccess`;
+
+  await page.goto(url);
+
+  await expect(page.locator('h1')).toContainText('doc_noaccess');
+  await expect(page.locator('div.ProseMirror'), 'Nothing should be visible').toHaveCount(0);
+});

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -10,25 +10,34 @@
  * governing permissions and limitations under the License.
  */
 import { test, expect } from '@playwright/test';
-import { getTestPageURL } from '../utils/page.js';
+import { getTestPageURL } from '../../utils/page.js';
 
 test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo) => {
-  // Open 2 editors on the same page and edit in both of them
+  // Open 2 editors on the same page and edit in both of them. One editor is logged in,
+  // the other isn't.
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator
 
   const pageURL = getTestPageURL('collab', workerInfo);
-
   await page.goto(pageURL);
+  await expect(page.getByLabel('Open profile menu')).toBeVisible();
+  // Wait a little bit so that the collab awareness has caught up and knows that we are logged in as
+  // 'DA Test User'
+  await page.waitForTimeout(1000);
+  await page.reload();
+
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await page.locator('div.ProseMirror').fill('Entered by user 1');
 
   // Right now there should not be any collab indicators yet
-  await expect(page.locator('div.collab-icon.collab-icon-user[data-popup-content="Anonymous"]')).not.toBeVisible();
+  await expect(page.locator('div.collab-icon.collab-icon-user[data-popup-content="DA Test User"]')).not.toBeVisible();
   await expect(page.locator('span.ProseMirror-yjs-cursor')).not.toBeVisible();
 
-  const page2 = await browser.newPage();
+  // Open a new browser page with an empty storage state. which means its not logged in and
+  // will have an anonymous user
+  const page2 = await browser.newPage({ storageState: {} });
   await page2.goto(pageURL);
+
   await expect(page2.locator('div.ProseMirror')).toBeVisible();
   await expect(page2.locator('div.ProseMirror')).toContainText('Entered by user 1');
 
@@ -38,14 +47,15 @@ test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo)
   await page2.keyboard.type('From user 2');
 
   // Check the little cloud icon for collaborators
-  await expect(page2.locator('div.collab-icon.collab-icon-user[data-popup-content="Anonymous"]')).toBeVisible();
+  await page.waitForTimeout(2000); // give it some time to appear
+  await expect(page2.locator('div.collab-icon.collab-icon-user[data-popup-content="DA Test User"]')).toBeVisible();
 
   // Check the cursor for collaborator
   await expect(page2.locator('span.ProseMirror-yjs-cursor')).toBeVisible();
-  await expect(page2.locator('span.ProseMirror-yjs-cursor')).toContainText('Anonymous');
+  await expect(page2.locator('span.ProseMirror-yjs-cursor')).toContainText('DA Test User');
   const text2 = await page2.locator('div.ProseMirror').innerText();
   const text2Idx = text2.indexOf('From user 2Entered by user 1');
-  const cursor2Idx = text2.indexOf('Anonymous');
+  const cursor2Idx = text2.indexOf('DA Test User');
   expect(text2Idx).toBeGreaterThanOrEqual(0);
   expect(cursor2Idx).toBeGreaterThanOrEqual(0);
   expect(cursor2Idx).toBeGreaterThan(text2Idx);

--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -60,7 +60,9 @@ test('Create Version and Restore from it', async ({ page }, workerInfo) => {
   // expliticly create a version for.
   const audit = await page.locator('.da-version-entry.is-audit');
   await audit.click();
-  await expect(audit).toContainText('anonymous');
+
+  const expectedUser = process.env.SKIP_AUTH ? 'anonymous' : 'bosschae+da-test@adobetest.com';
+  await expect(audit).toContainText(expectedUser);
 
   // Select 'ver 1' and restore it
   await page.getByText('ver 1', { exact: false }).click();

--- a/test/e2e/utils/env.js
+++ b/test/e2e/utils/env.js
@@ -3,7 +3,17 @@ function getEnv() {
   if (!branch) {
     branch = 'main';
   }
-  return branch === 'local' ? 'http://localhost:3000' : `https://${branch}--da-live--adobe.hlx.live`;
+  let { GITHUB_REPOSITORY_OWNER: owner } = process.env;
+  if (!owner) {
+    owner = 'adobe';
+  }
+  if (branch === 'local') {
+    return 'http://localhost:3000';
+  }
+  if (branch === 'main' && owner === 'adobe') {
+    return 'https://da.live';
+  }
+  return `https://${branch}--da-live--${owner}.aem.live`;
 }
 
 const ENV = (() => getEnv())();

--- a/test/e2e/utils/page.js
+++ b/test/e2e/utils/page.js
@@ -14,17 +14,17 @@ import ENV from './env.js';
 export function getQuery() {
   const { GITHUB_HEAD_REF: branch } = process.env;
   if (branch === 'local') {
-    return '?da-admin=local&da-collab=local&da-admin-room=local';
+    return '?da-admin=local&da-collab=local';
   }
   return '';
 }
 
 const QUERY = getQuery();
 
-function getTestURL(type, testIdentifier, workerInfo) {
+function getTestURL(type, testIdentifier, workerInfo, dir = '/da-sites/da-status/tests') {
   const dateStamp = Date.now().toString(36);
   const pageName = `pw-${testIdentifier}-${dateStamp}-${workerInfo.project.name}`;
-  return `${ENV}/${type}${QUERY}#/da-sites/da-status/tests/${pageName}`;
+  return `${ENV}/${type}${QUERY}#${dir}/${pageName}`;
 }
 
 /**
@@ -32,10 +32,11 @@ function getTestURL(type, testIdentifier, workerInfo) {
  *
  * @param {string} testIdentifier - A identifier for the test
  * @param {object} workerInfo - workerInfo as passed in by Playwright
+ * @param {string} dir - The directory to use (optional)
  * @returns {string} The URL for the test page.
  */
-export function getTestPageURL(testIdentifier, workerInfo) {
-  return getTestURL('edit', testIdentifier, workerInfo);
+export function getTestPageURL(testIdentifier, workerInfo, dir) {
+  return getTestURL('edit', testIdentifier, workerInfo, dir);
 }
 
 /**
@@ -43,10 +44,11 @@ export function getTestPageURL(testIdentifier, workerInfo) {
  *
  * @param {string} testIdentifier - A identifier for the test
  * @param {object} workerInfo - workerInfo as passed in by Playwright
+ * @param {string} dir - The directory to use (optional)
  * @returns {string} The URL for the test page.
  */
-export function getTestFolderURL(testIdentifier, workerInfo) {
-  return getTestURL('', testIdentifier, workerInfo);
+export function getTestFolderURL(testIdentifier, workerInfo, dir) {
+  return getTestURL('', testIdentifier, workerInfo, dir);
 }
 
 /**


### PR DESCRIPTION
## Description

These tests log into IMS as a 'DA Test User' and use the https://github.com/da-testautomation/acltest site/repository for their tests.
The login is happening once at the start of the tests and then this context is used for all the Playwright tests.
The `da-testautomation` org has ACL configuration for the tests in its `permissions` sheet.

Also updated the collab tests to use an actually logged in user rather than 2 Anonymous users.

Test URLs:

* Main: https://main--da-live--adobe.aem.live/
* Branch: https://pwacl3--da-live--adobe.aem.live/


## How Has This Been Tested?

These _are_ tests.


## Types of changes

Just changes to the e2e Playwright tests.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
