### PR TITLE
Slash menu table edit commands

### DIFF
--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.css
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.css
@@ -90,11 +90,11 @@
 }
 
 .slash-menu-icon.insert-table {
-  background-image: url('/blocks/edit/img/Smock_TableAdd_18_N.svg');
+  background-image: url('/blocks/edit/img/S2_Icon_TableAdd_20_N.svg');
 }
 
 .slash-menu-icon.table-options {
-  background-image: url('/blocks/edit/img/Smock_TableEdit_18_N.svg');
+  background-image: url('/blocks/edit/img/S2_Icon_TableEdit_20_N.svg');
 }
 
 .slash-menu-icon.insert-column-left {
@@ -130,11 +130,11 @@
 }
 
 .slash-menu-icon.edit-hr {
-  background-image: url('/blocks/edit/img/Smock_PageRule_18_N.svg');
+  background-image: url('/blocks/edit/img/S2_Icon_Separator_20_N.svg');
 }
 
 .slash-menu-icon.open-library {
-  background-image: url('/blocks/edit/img/Smock_CCLibrary_18_N.svg');
+  background-image: url('/blocks/edit/img/S2_Icon_CCLibrary_20_N.svg');
 }
 
 .slash-menu-icon.lorem-ipsum {

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.css
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.css
@@ -121,6 +121,14 @@
   background-image: url('/blocks/edit/img/Smock_TableColumnRemoveCenter_18_N.svg');
 }
 
+.slash-menu-icon.merge-cells {
+  background-image: url('/blocks/edit/img/Smock_TableMergeCells_18_N.svg');
+}
+
+.slash-menu-icon.split-cell {
+  background-image: url('/blocks/edit/img/Smock_TableRowSplit_18_N.svg');
+}
+
 .slash-menu-icon.edit-hr {
   background-image: url('/blocks/edit/img/Smock_PageRule_18_N.svg');
 }

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.css
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.css
@@ -93,6 +93,34 @@
   background-image: url('/blocks/edit/img/Smock_TableAdd_18_N.svg');
 }
 
+.slash-menu-icon.table-options {
+  background-image: url('/blocks/edit/img/Smock_TableEdit_18_N.svg');
+}
+
+.slash-menu-icon.insert-column-left {
+  background-image: url('/blocks/edit/img/Smock_TableColumnAddLeft_18_N.svg');
+}
+
+.slash-menu-icon.insert-column-right {
+  background-image: url('/blocks/edit/img/Smock_TableColumnAddRight_18_N.svg');
+}
+
+.slash-menu-icon.insert-row-before {
+  background-image: url('/blocks/edit/img/Smock_TableRowAddTop_18_N.svg');
+}
+
+.slash-menu-icon.insert-row-after {
+  background-image: url('/blocks/edit/img/Smock_TableRowAddBottom_18_N.svg');
+}
+
+.slash-menu-icon.delete-row {
+  background-image: url('/blocks/edit/img/Smock_TableRowRemoveCenter_18_N.svg');
+}
+
+.slash-menu-icon.delete-column {
+  background-image: url('/blocks/edit/img/Smock_TableColumnRemoveCenter_18_N.svg');
+}
+
 .slash-menu-icon.edit-hr {
   background-image: url('/blocks/edit/img/Smock_PageRule_18_N.svg');
 }

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -109,8 +109,8 @@ export default class SlashMenu extends LitElement {
 
     // calculate submenu position
     const selectedItem = this.shadowRoot.querySelector('.slash-menu-item.selected');
-    const topOffset = selectedItem ? selectedItem.offsetTop : 0;
-    const width = selectedItem ? selectedItem.offsetWidth : 0;
+    const topOffset = selectedItem?.offsetTop ?? 0;
+    const width = selectedItem?.offsetWidth ?? 0;
     submenuElement.show({ top: this.top + topOffset, left: this.left + width });
     submenuElement.focus();
   }

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -257,7 +257,8 @@ export default class SlashMenu extends LitElement {
             <div
               class="slash-menu-item ${index === this.selectedIndex ? 'selected' : ''}"
               @mouseenter=${() => { this.selectedIndex = index; }}
-              @click=${() => this.handleItemClick(item)}
+              @mousedown=${(e) => { e.preventDefault(); /* prevent close before click handler */ }}
+              @click=${() => { this.handleItemClick(item); }}
             >
               ${isColor ? createColorSquare(item.value) : ''}
               ${hasIcon ? html`<span class="slash-menu-icon ${item.class}"></span>` : ''}

--- a/blocks/edit/prose/plugins/slashMenu/slash-menu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slash-menu.js
@@ -47,6 +47,7 @@ export default class SlashMenu extends LitElement {
     this.visible = true;
     this.left = coords.left;
     this.top = coords.top || (coords.bottom + 5);
+    this.showSubmenu();
     this.requestUpdate();
   }
 
@@ -99,20 +100,27 @@ export default class SlashMenu extends LitElement {
     return this.shadowRoot.querySelector('.submenu slash-menu');
   }
 
+  showSubmenu() {
+    const submenuElement = this.getSubmenuElement();
+    const items = this.getSubmenuItems();
+    if (!submenuElement || !items) return;
+
+    submenuElement.items = items;
+
+    // calculate submenu position
+    const selectedItem = this.shadowRoot.querySelector('.slash-menu-item.selected');
+    const topOffset = selectedItem ? selectedItem.offsetTop : 0;
+    const width = selectedItem ? selectedItem.offsetWidth : 0;
+    submenuElement.show({ top: this.top + topOffset, left: this.left + width });
+    submenuElement.focus();
+  }
+
   updated(changedProperties) {
     if (changedProperties.has('left') || changedProperties.has('top')) {
       this.updatePosition();
     }
     if (changedProperties.has('selectedIndex')) {
-      const submenu = this.getSubmenuElement();
-      if (submenu) {
-        submenu.items = this.getSubmenuItems();
-        const selectedItem = this.shadowRoot.querySelector('.slash-menu-item.selected');
-        const topOffset = selectedItem ? selectedItem.offsetTop : 0;
-        const width = selectedItem ? selectedItem.offsetWidth : 0;
-        submenu.show({ top: this.top + topOffset, left: this.left + width });
-        submenu.focus();
-      }
+      this.showSubmenu();
     }
   }
 

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { Plugin, PluginKey } from 'da-y-wrapper';
 import { getKeyAutocomplete } from './keyAutocomplete.js';
-import { getItems } from './slashMenuItems.js';
+import {getDefaultItems, getTableItems} from './slashMenuItems.js';
 import './slash-menu.js';
 
 const SLASH_COMMAND_REGEX = /\/(([^/\s]+(?:\s+[^/\s]+)*)\s*([^/\s]*))?$/;
@@ -58,7 +58,7 @@ class SlashMenuView {
   constructor(view) {
     this.view = view;
     this.menu = document.createElement('slash-menu');
-    this.menu.items = getItems() || [];
+    this.menu.items = getDefaultItems() || [];
 
     this.menu.addEventListener('item-selected', (e) => {
       this.selectItem(e.detail);
@@ -66,7 +66,7 @@ class SlashMenuView {
 
     this.menu.addEventListener('reset-slashmenu', () => {
       // reset menu to default items
-      this.menu.items = getItems();
+      this.menu.items = getDefaultItems();
       this.menu.left = 0;
       this.menu.top = 0;
     });
@@ -79,8 +79,10 @@ class SlashMenuView {
       if (keyData && keyData.get(keyValue)) {
         this.menu.items = keyData.get(keyValue);
       } else {
-        this.menu.items = getItems(true);
+        this.menu.items = getTableItems();
       }
+    } else {
+      this.menu.items = getDefaultItems();
     }
   }
 
@@ -114,6 +116,7 @@ class SlashMenuView {
 
     const match = textBefore.match(SLASH_COMMAND_REGEX);
     if (match) {
+      console.log('update slash menu items')
       this.updateSlashMenuItems(slashMenuKey.getState(state), $cursor);
       const coords = this.view.coordsAtPos($cursor.pos);
 

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { Plugin, PluginKey } from 'da-y-wrapper';
 import { getKeyAutocomplete } from './keyAutocomplete.js';
-import menuItems from './slashMenuItems.js';
+import { getItems } from './slashMenuItems.js';
 import './slash-menu.js';
 
 const SLASH_COMMAND_REGEX = /\/(([^/\s]+(?:\s+[^/\s]+)*)\s*([^/\s]*))?$/;
@@ -38,13 +38,11 @@ const getTableName = ($cursor) => {
   const cellIndex = $cursor.index(tableCellDepth - 1);
   const row = $cursor.node(rowDepth);
 
-  // Only proceed if we're in the second column
-  if (!(row.childCount > 1 && cellIndex === 1)) return false;
-
   const firstRowContent = firstRow.child(0).textContent;
   const tableNameMatch = firstRowContent.match(/^([a-zA-Z0-9_-]+)(?:\s*\([^)]*\))?$/);
 
-  const currentRowFirstColContent = row.child(0).textContent;
+  // Only set key value if we're in the second column of a row
+  const currentRowFirstColContent = (row.childCount > 1 && cellIndex === 1) ? row.child(0).textContent : null;
 
   if (tableNameMatch) {
     return {
@@ -60,7 +58,7 @@ class SlashMenuView {
   constructor(view) {
     this.view = view;
     this.menu = document.createElement('slash-menu');
-    this.menu.items = menuItems || [];
+    this.menu.items = getItems() || [];
 
     this.menu.addEventListener('item-selected', (e) => {
       this.selectItem(e.detail);
@@ -68,7 +66,7 @@ class SlashMenuView {
 
     this.menu.addEventListener('reset-slashmenu', () => {
       // reset menu to default items
-      this.menu.items = menuItems;
+      this.menu.items = getItems();
       this.menu.left = 0;
       this.menu.top = 0;
     });
@@ -81,7 +79,7 @@ class SlashMenuView {
       if (keyData && keyData.get(keyValue)) {
         this.menu.items = keyData.get(keyValue);
       } else {
-        this.menu.items = menuItems;
+        this.menu.items = getItems(true);
       }
     }
   }
@@ -200,16 +198,7 @@ export default function slashMenu() {
           if (['ArrowUp', 'ArrowDown', 'Enter', 'Escape'].includes(event.key)) {
             event.preventDefault();
             event.stopPropagation();
-
-            if (event.key === 'Enter') {
-              const filteredItems = pluginView.menu.getFilteredItems();
-              const selectedItem = filteredItems[pluginView.menu.selectedIndex];
-              if (selectedItem) {
-                pluginView.selectItem({ item: selectedItem });
-              }
-            } else {
-              pluginView.menu.handleKeyDown(event);
-            }
+            pluginView.menu.handleKeyDown(event);
             return true;
           }
         }

--- a/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
@@ -124,18 +124,15 @@ const tableItems = [
   },
 ];
 
-export const getItems = (isTable = false) => {
-  if (isTable) {
-    return [
-      {
-        title: 'Edit Block',
-        submenu: tableItems,
-        class: 'table-options',
-      },
-      ...items.filter((item) => !item.excludeFromTable),
-    ];
-  }
+export const getTableItems = () => ([
+  {
+    title: 'Edit Block',
+    submenu: tableItems,
+    class: 'table-options',
+  },
+  ...items.filter((item) => !item.excludeFromTable),
+]);
+
+export const getDefaultItems = () => {
   return items;
 };
-
-export default items;

--- a/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
@@ -1,4 +1,14 @@
-import { setBlockType, wrapIn, wrapInList } from 'da-y-wrapper';
+import {
+  setBlockType,
+  wrapIn,
+  wrapInList,
+  addColumnBefore,
+  addColumnAfter,
+  addRowAfter,
+  addRowBefore,
+  deleteColumn,
+  deleteRow,
+} from 'da-y-wrapper';
 import openLibrary from '../../../da-library/da-library.js';
 import insertTable from '../../table.js';
 import { insertSectionBreak } from '../menu.js';
@@ -60,6 +70,7 @@ const items = [
     title: 'Section break',
     command: insertSectionBreak,
     class: 'edit-hr',
+    excludeFromTable: true,
   },
   {
     title: 'Lorem ipsum',
@@ -71,6 +82,7 @@ const items = [
     title: 'Table',
     command: insertTable,
     class: 'insert-table',
+    excludeFromTable: true,
   },
   {
     title: 'Library',
@@ -78,5 +90,52 @@ const items = [
     class: 'open-library',
   },
 ];
+
+const tableItems = [
+  {
+    title: 'Add Column After',
+    command: addColumnAfter,
+    class: 'insert-column-right',
+  },
+  {
+    title: 'Add Column Before',
+    command: addColumnBefore,
+    class: 'insert-column-left',
+  },
+  {
+    title: 'Add Row After',
+    command: addRowAfter,
+    class: 'insert-row-after',
+  },
+  {
+    title: 'Add Row Before',
+    command: addRowBefore,
+    class: 'insert-row-before',
+  },
+  {
+    title: 'Delete Row',
+    command: deleteRow,
+    class: 'delete-row',
+  },
+  {
+    title: 'Delete Column',
+    command: deleteColumn,
+    class: 'delete-column',
+  },
+];
+
+export const getItems = (isTable = false) => {
+  if (isTable) {
+    return [
+      {
+        title: 'Edit Block',
+        submenu: tableItems,
+        class: 'table-options',
+      },
+      ...items.filter((item) => !item.excludeFromTable),
+    ];
+  }
+  return items;
+};
 
 export default items;

--- a/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
@@ -8,6 +8,8 @@ import {
   addRowBefore,
   deleteColumn,
   deleteRow,
+  mergeCells,
+  splitCell,
 } from 'da-y-wrapper';
 import openLibrary from '../../../da-library/da-library.js';
 import insertTable from '../../table.js';
@@ -122,17 +124,31 @@ const tableItems = [
     command: deleteColumn,
     class: 'delete-column',
   },
+  {
+    title: 'Split Cell',
+    command: splitCell,
+    class: 'split-cell',
+  },
 ];
 
-export const getTableItems = () => ([
+export const getTableItems = (state) => ([
   {
     title: 'Edit Block',
-    submenu: tableItems,
+    // prevent showing unavailable options.
+    // item.command(state) does not commit the command, but returns whether it's available.
+    submenu: tableItems.filter((item) => item.command(state)),
     class: 'table-options',
   },
   ...items.filter((item) => !item.excludeFromTable),
 ]);
 
-export const getDefaultItems = () => {
-  return items;
-};
+export const getTableCellItems = (state) => ([
+  {
+    title: 'Merge Cells',
+    command: mergeCells,
+    class: 'merge-cells',
+    enabled: mergeCells(state),
+  },
+].filter((x) => x.enabled !== false));
+
+export const getDefaultItems = () => items;


### PR DESCRIPTION
The slash menu allows editing blocks (remove row, add row, etc).

Still missing:

- [x] Merge cells
- [x] Styling to match new sidebar icons

https://github.com/user-attachments/assets/4aedeac5-be09-4e7a-a818-f4216d92eef8

## Release notes

* Adds edit table items to slash menu.

<img width="450" alt="Screenshot 2025-03-14 at 9 31 56 AM" src="https://github.com/user-attachments/assets/0d8ed8a5-d536-40f9-9b91-e1d9cb7d5206" />


