### PR TITLE
fix: updated icon regex to be smarter and added test cases

### DIFF
--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -132,7 +132,7 @@ function removeMetadata(editor) {
   editor.querySelector('.metadata')?.remove();
 }
 
-const iconRegex = /(?<!https?:\/\/[^\s]*):([a-zA-Z0-9-]+?):/gm; // matches icon pattern but not in URLs
+const iconRegex = /(?<!(?:https?|urn)[^\s<>]*):(#?[a-z_-]+[a-z\d]*):/gi; // matches icon pattern but not in URLs
 function parseIcons(editor) {
   if (!iconRegex.test(editor.innerHTML)) return;
   editor.innerHTML = editor.innerHTML.replace(

--- a/test/unit/blocks/shared/mocks/prose2aem.html
+++ b/test/unit/blocks/shared/mocks/prose2aem.html
@@ -64,4 +64,9 @@
   <p>https://this.url.com/imageid/:aem-id:/image.jpg</p>
   <p>Some text with an icon :foo-bar:</p>
   <p>icon in the middle :bar-baz: of a sentence</p>
+  <p>
+    <p>https://this.dmurl.com/adobe/assets/urn:aaid:aem:9bcee582-164f-424c-82e4-49d0356e9d86/as/sample-asset.jpg?preferwebp=true</p> :arrow-right-bold:
+  </p>
+  <p>:arrow-down:</p>
+  <p>:arrow-right-bold: https://this.dmurl.com/adobe/assets/urn:aaid:aem:9bcee582-164f-424c-82e4-49d0356e9d86/as/sample-asset.jpg?preferwebp=true</p> :arrow-right-bold:
 </div>

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -62,6 +62,6 @@ describe('aem2prose', () => {
 
   it('Wraps icons in span tags', () => {
     const icons = document.querySelectorAll('span.icon');
-    expect(icons.length).to.equal(5);
+    expect(icons.length).to.equal(9);
   });
 });


### PR DESCRIPTION
Before: https://main--da-live--adobe.aem.page/edit#/kunwarsaluja/da-cme/drafts/kunwar/test-doc
After: https://fix-encoding--da-live--amol-anand.aem.page/edit#/kunwarsaluja/da-cme/drafts/kunwar/test-doc

# Description
Updated the regex to only match icons only if they are not in urls. Added more failed test cases and improved the regex to be smarter and in line with helix pipeline as well

# Related Issue
https://github.com/adobe/da-live/issues/385

# How Has This Been Tested?
Tested locally against a project that had this problem.