### PR TITLE
Adding Full Size mode for Library Plugins

### DIFF
--- a/blocks/edit/da-library/da-library.css
+++ b/blocks/edit/da-library/da-library.css
@@ -480,7 +480,8 @@ ul {
 }
 
 /* Plugin Modal */
-.da-dialog-plugin {
+.da-dialog-plugin, 
+.da-fs-dialog-plugin {
   width: calc(100% - 72px);
   height: calc(100% - 72px);
   box-sizing: border-box;

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -124,6 +124,30 @@ class DaLibrary extends LitElement {
       return;
     }
 
+    if (library.experience === 'fullsize-dialog') {
+      let dialog = this.shadowRoot.querySelector('.da-dialog-plugin');
+      if (dialog) dialog.remove();
+
+      dialog = html`
+        <dialog class="da-fs-dialog-plugin">
+          <div class="da-dialog-header">
+            <div class="da-dialog-header-title">
+              <img src="${library.icon}" />
+              <p>${library.name}</p>
+            </div>
+            <button class="primary" @click=${this.handleModalClose}>Close</button>
+          </div>
+          ${this.renderPlugin(library.url, true)}
+        </dialog>
+      `;
+
+      render(dialog, this.shadowRoot);
+
+      this.shadowRoot.querySelector('.da-fs-dialog-plugin').showModal();
+
+      return;
+    }
+
     if (library.experience === 'window') {
       try {
         const { pathname } = new URL(library.url);

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -88,8 +88,13 @@ class DaLibrary extends LitElement {
     if (e.key === 'Escape') closeLibrary();
   }
 
-  handleModalClose() {
+  handleModalClose(e) {
     this.shadowRoot.querySelector('.da-dialog-plugin').close();
+    closeLibrary();
+  }
+
+  handleFullsizeModalClose(e) {
+    this.shadowRoot.querySelector('.da-fs-dialog-plugin').close();
     closeLibrary();
   }
 
@@ -135,7 +140,7 @@ class DaLibrary extends LitElement {
               <img src="${library.icon}" />
               <p>${library.name}</p>
             </div>
-            <button class="primary" @click=${this.handleModalClose}>Close</button>
+            <button class="primary" @click=${this.handleFullsizeModalClose}>Close</button>
           </div>
           ${this.renderPlugin(library.url, true)}
         </dialog>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Providing a new experience option to open the dialogs in the full size

 "experience": "`fullsize-dialog`",

## Related Issue

#270 

## Motivation and Context

This allows to have more real estate for the Dialogs that opened as Library plugin. For instance if developer wants to create a custom Asset Picker , they can use the fullsize-dialog

## How Has This Been Tested?

- After making changes to the da-live in local, pushed the changes to a branch in the fork
- Create a plugin , configured it to be opened as fullsize-dialog 
- Tested both dialog and full size dialog behvior

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e72f2a9d-51e3-46d0-b6bb-7aec7c78e732)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
