### PR TITLE
chore: improve renovate config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:recommended"],
   "branchNameStrict": true,
-  "branchName": "r_{{{packageName}}}_{{version}}",
+  "branchName": "r_{{{packageName}}}",
   "packageRules": [{
       "matchDepTypes": ["devDependencies"],
       "labels": ["ignore-psi-check"], 

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["config:recommended"],
+  "branchPrefix": "renovate_",
+  "branchTopic": "{{{depNameSanitized}}}-{{{newMajor}}}{{#if separateMinorPatch}}{{#if isPatch}}_{{{newMinor}}}{{/if}}{{/if}}_x{{#if isLockfileUpdate}}-lockfile{{/if}}",
+  "packageRules": [{
+      "matchDepTypes": ["devDependencies"],
+      "labels": ["ignore-psi-check"], 
+      "automerge": true
+  }]
+}

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:recommended"],
-  "branchPrefix": "renovate_",
-  "branchTopic": "{{{depNameSanitized}}}-{{{newMajor}}}{{#if separateMinorPatch}}{{#if isPatch}}_{{{newMinor}}}{{/if}}{{/if}}_x{{#if isLockfileUpdate}}-lockfile{{/if}}",
+  "branchNameStrict": true,
+  "branchName": "r_{{{packageName}}}_{{version}}",
   "packageRules": [{
       "matchDepTypes": ["devDependencies"],
       "labels": ["ignore-psi-check"], 


### PR DESCRIPTION
Renovate creates branches with name like `renovate/jspreadsheet-ce-4.x-lockfile`. Our subdomain trick for urls does not like the `/` and the `.` which is an issue for PSI check and the e2e tests (see all tests failing in renovate PRs).

In this PR:
1. simplify the branch name handling (branch name = package name)
2. define the `ignore-psi-check` label for PRs on dev dependencies
3. auto-merge dev dependencies if all tests are green
 
1 - https://github.com/adobe/helix-website has a similar setup and makes thins smooth (more PR but branch name is valid)
2 and 3 are typical boilerplate setup to reduce maintenance on "dev tooling" upgrades.

Test branch: https://renovate-config--da-live--adobe.aem.live/