### PR TITLE
Updated fetchValue() function to handle repo level configuration fall…

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -8,9 +8,14 @@ const { loadStyle } = await import(`${getNx()}/scripts/nexter.js`);
 const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
 const loadScript = (await import(`${getNx()}/utils/script.js`)).default;
 
-const ASSET_SELECTOR_URL = 'https://experience.adobe.com/solutions/CQ-assets-selectors/assets/resources/assets-selectors.js';
+const ASSET_SELECTOR_URL =
+  'https://experience.adobe.com/solutions/CQ-assets-selectors/assets/resources/assets-selectors.js';
 
 const CONFS = {};
+
+async function getMergedConf(owner, repo) {
+  return mergedConf;
+}
 
 async function fetchConf(path) {
   if (CONFS[path]) return CONFS[path];
@@ -27,7 +32,29 @@ async function fetchConf(path) {
 async function fetchValue(path, key) {
   if (CONFS[path]?.[key]) return CONFS[path][key];
 
-  const data = await fetchConf(path);
+  const [repoConf, orgConf] = await Promise.all([
+    fetchConf(`/${owner}/${repo}/`),
+    fetchConf(`/${owner}/`),
+  ]);
+
+  const data = null;
+
+  // Start with organization-level config
+  if (orgConf) {
+    data = {};
+    orgConf.forEach((item) => {
+      data[item.key] = item.value;
+    });
+  }
+
+  // Override with repository-level config
+  if (repoConf) {
+    if (data === null) data = {};
+    repoConf.forEach((item) => {
+      data[item.key] = item.value;
+    });
+  }
+
   if (!data) return null;
 
   const confKey = data.find((conf) => conf.key === key);
@@ -39,23 +66,29 @@ async function fetchValue(path, key) {
 export async function getConfKey(owner, repo, key) {
   if (!(repo || owner)) return null;
   let value = await fetchValue(`/${owner}/${repo}/`, key);
-  if (!value) value = await fetchValue(`/${owner}/`, key);
+
+  // Turned off check for organization level value update as new fetchValue does that internally.
+  // if (!value) value = await fetchValue(`/${owner}/`, key);
+
   return value;
 }
 
 export async function openAssets() {
   const details = await loadIms();
   if (details.anonymous) handleSignIn();
-  if (!(details.accessToken)) return;
+  if (!details.accessToken) return;
 
   const { owner, repo } = getPathDetails();
   const repoId = await getConfKey(owner, repo, 'aem.repositoryId');
 
   // Determine publicly available asset origin
-  const prodOrigin = await getConfKey(owner, repo, 'aem.assets.prod.origin') || `${repoId.replace('author', 'publish')}`;
+  const prodOrigin =
+    (await getConfKey(owner, repo, 'aem.assets.prod.origin')) ||
+    `${repoId.replace('author', 'publish')}`;
 
   // Determine if images should be links
-  const injectLink = (await getConfKey(owner, repo, 'aem.assets.image.type')) === 'link';
+  const injectLink =
+    (await getConfKey(owner, repo, 'aem.assets.image.type')) === 'link';
 
   let dialog = document.querySelector('.da-dialog-asset');
   if (!dialog) {
@@ -79,7 +112,9 @@ export async function openAssets() {
       imsToken: details.accessToken.token,
       repositoryId: repoId,
       aemTierType,
-      onClose: () => { dialog.close(); },
+      onClose: () => {
+        dialog.close();
+      },
       handleSelection: (assets) => {
         const [asset] = assets;
         if (!asset) return;
@@ -91,12 +126,18 @@ export async function openAssets() {
         dialog.close();
 
         // eslint-disable-next-line no-underscore-dangle
-        const alt = asset?._embedded?.['http://ns.adobe.com/adobecloud/rel/metadata/asset']?.['dc:description'];
+        const alt =
+          asset?._embedded?.[
+            'http://ns.adobe.com/adobecloud/rel/metadata/asset'
+          ]?.['dc:description'];
 
-        const src = aemTierType === 'author'
-          ? `https://${prodOrigin}${path}`
-          // eslint-disable-next-line no-underscore-dangle
-          : asset._links['http://ns.adobe.com/adobecloud/rel/rendition'][0].href.split('?')[0];
+        const src =
+          aemTierType === 'author'
+            ? `https://${prodOrigin}${path}`
+            : // eslint-disable-next-line no-underscore-dangle
+              asset._links[
+                'http://ns.adobe.com/adobecloud/rel/rendition'
+              ][0].href.split('?')[0];
 
         const imgObj = { src, style: 'width: 180px' };
         if (alt) imgObj.alt = alt;


### PR DESCRIPTION
…back to org level configuration as fetched

<!--- Provide a general summary of your changes in the Title above -->

## Description

I have updated the fetchValue() function body to fetch both the organization level and repo level configurations which are then merged and returned on call. Repo level configurations as found will be considered as final over organization level configurations.
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/adobe/da-live/issues/422
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> 

## Motivation and Context

As of right now, the org fallback only works if you have no site config. We should inherit on a row basis so that if a site has a single property (aem.assets.link.type) the rest still falls back to org so you don't have to duplicate your repoId, etc.

To solve this as mention in issue #422.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
