### PR TITLE
Issues/436

### DIFF
--- a/blocks/browse/da-list-item/da-list-item.js
+++ b/blocks/browse/da-list-item/da-list-item.js
@@ -96,11 +96,17 @@ export default class DaListItem extends LitElement {
   handleChecked(e) {
     this.isChecked = !this.isChecked;
     const opts = {
-      detail: { checked: this.isChecked, shiftKey: e.shiftKey },
+      detail: { checked: this.isChecked, shiftKey: e?.shiftKey ?? false },
       bubbles: true,
       composed: true,
     };
     const event = new CustomEvent('checked', opts);
+    this.dispatchEvent(event);
+  }
+
+  notifyRenamed(oldPath) {
+    const opts = { detail: { path: this.path, name: this.name, date: this.date, oldPath } };
+    const event = new CustomEvent('renamecompleted', opts);
     this.dispatchEvent(event);
   }
 
@@ -145,6 +151,7 @@ export default class DaListItem extends LitElement {
         // Uncheck the item and bubble up state
         this.handleChecked();
         this.updateAEMStatus();
+        this.notifyRenamed(oldPath);
       } else {
         this.setStatus('There was an error. Refresh and try again.', 'error');
       }

--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -138,6 +138,20 @@ export default class DaList extends LitElement {
     this.requestUpdate();
   }
 
+  handleRenameCompleted(e) {
+    const { oldPath, path, name, date } = e.detail;
+    const index = this._listItems.findIndex((lItem) => lItem.path === oldPath);
+    if (index < 0) return;
+
+    const item = this._listItems[index];
+
+    item.path = path;
+    item.name = name;
+    item.lastModified = date;
+
+    this._listItems[index] = item;
+  }
+
   wait(milliseconds) {
     return new Promise((r) => {
       setTimeout(r, milliseconds);
@@ -395,6 +409,7 @@ export default class DaList extends LitElement {
           role="listitem"
           @checked=${(e) => this.handleItemChecked(e, item, idx)}
           @onstatus=${({ detail }) => this.setStatus(detail.text, detail.description, detail.type)}
+          @renamecompleted=${(e) => this.handleRenameCompleted(e)}
           allowselect="${this.select ? true : nothing}"
           ischecked="${item.isChecked ? true : nothing}"
           rename="${item.rename ? true : nothing}"


### PR DESCRIPTION
## Description

Fixes a bug when copy/pasting items, that the parent is not aware that the child was renamed.

This led to the wrong items being deleted, copied, etc after copy/pasting.

Fixes #436 
