### PR TITLE
Library V1.5

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -118,7 +118,7 @@ class DaLibrary extends LitElement {
             </div>
             <button class="primary" @click=${this.handleModalClose}>Close</button>
           </div>
-          ${this.renderPlugin(library.url, true)}
+          ${this.renderPlugin(library, true)}
         </dialog>
       `;
 
@@ -138,11 +138,11 @@ class DaLibrary extends LitElement {
           <div class="da-dialog-header">
             <div class="da-dialog-header-title">
               <img src="${library.icon}" />
-              <p>${library.name}</p>
+              <p>${library.title || library.name}</p>
             </div>
             <button class="primary" @click=${this.handleFullsizeModalClose}>Close</button>
           </div>
-          ${this.renderPlugin(library.url, true)}
+          ${this.renderPlugin(library, true)}
         </dialog>
       `;
 
@@ -426,7 +426,9 @@ class DaLibrary extends LitElement {
     return searchFor(this._searchStr, data, this);
   }
 
-  renderPlugin(url, preload) {
+  renderPlugin(library, preload) {
+    const url = library.sources?.[0] || library.url;
+
     return html`
       <div class="da-library-type-plugin">
         <iframe
@@ -437,11 +439,10 @@ class DaLibrary extends LitElement {
       </div>`;
   }
 
-  async renderLibrary({ name, sources, url, format }) {
-    // Only plugins have a URL
-    if (url) {
-      return this.renderPlugin(url);
-    }
+  async renderLibrary({ name, sources, url, format, class: className }) {
+    const isPlugin = className.split(' ').some((val) => val === 'is-plugin');
+
+    if (isPlugin) return this.renderPlugin({ sources, url });
 
     if (name === 'blocks') {
       if (!data.blocks) {
@@ -492,7 +493,7 @@ class DaLibrary extends LitElement {
               class="${library.class || library.name} ${library.url ? 'is-plugin' : ''}"
               style="${library.icon ? `background-image: url(${library.icon})` : ''}"
               @click=${(e) => this.handleLibSwitch(e, library)}>
-              <span class="library-type-name">${library.name}</span>
+              <span class="library-type-name">${library.title || library.name}</span>
             </button>
           </li>`,
         )}

--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 import { DOMParser } from 'da-y-wrapper';
-import { CON_ORIGIN, getDaAdmin } from '../../../shared/constants.js';
+import { getDaAdmin } from '../../../shared/constants.js';
 import getPathDetails from '../../../shared/pathDetails.js';
 import { daFetch, getFirstSheet } from '../../../shared/utils.js';
 import { getConfKey, openAssets } from '../../da-assets/da-assets.js';
@@ -9,20 +9,19 @@ import { fetchKeyAutocompleteData } from '../../prose/plugins/slashMenu/keyAutoc
 const DA_ORIGIN = getDaAdmin();
 const REPLACE_CONTENT = '<content>';
 const DA_CONFIG = '/.da/config.json';
+const DA_PLUGINS = [
+  'blocks',
+  'templates',
+  'aem-assets',
+  'icons',
+  'placeholders',
+];
+
+const ref = new URLSearchParams(window.location.search).get('ref') || 'main';
 
 export function parseDom(dom) {
   const { schema } = window.view.state;
   return DOMParser.fromSchema(schema).parse(dom);
-}
-
-function fixAssets(json) {
-  return json.reduce((acc, item) => {
-    if (item.ext) {
-      const parsed = window.view.state.schema.nodes.image.create({ src: `${CON_ORIGIN}${item.path}` });
-      acc.push({ ...item, path: `${CON_ORIGIN}${item.path}`, parsed });
-    }
-    return acc;
-  }, []);
 }
 
 function formatData(data, format) {
@@ -38,6 +37,12 @@ function formatData(data, format) {
   }, []);
 }
 
+function calculateClass(title) {
+  const lowerName = title.trim().replaceAll(' ', '-').toLowerCase();
+  const isDaPlugin = DA_PLUGINS.some((plugin) => plugin === lowerName);
+  return `${lowerName}${isDaPlugin ? '' : ' is-plugin'}`;
+}
+
 export async function getItems(sources, listType, format) {
   const items = [];
   for (const source of sources) {
@@ -46,8 +51,6 @@ export async function getItems(sources, listType, format) {
       const json = await resp.json();
       if (json.data) {
         items.push(...formatData(json.data, format));
-      } else if (listType === 'media') {
-        items.push(...fixAssets(json));
       } else {
         items.push(...json);
       }
@@ -74,6 +77,7 @@ async function getDaLibraries(owner, repo) {
     if (keySplit[0] === 'library') {
       acc.push({
         name: keySplit[1],
+        class: keySplit[1],
         sources: item.value.replaceAll(' ', '').split(','),
         format: item.format,
       });
@@ -90,7 +94,6 @@ async function getDaLibraries(owner, repo) {
 }
 
 async function getAemPlugins(owner, repo) {
-  const ref = new URLSearchParams(window.location.search).get('ref') || 'main';
   const origin = ref === 'local' ? 'http://localhost:3000' : `https://${ref}--${repo}--${owner}.aem.live`;
   const confUrl = ref === 'local' ? 'http://localhost:3000/tools/sidekick/config.json' : `https://admin.hlx.page/sidekick/${owner}/${repo}/${ref}/config.json`;
   const resp = await daFetch(confUrl);
@@ -105,6 +108,7 @@ async function getAemPlugins(owner, repo) {
       acc.push({
         name: plugin.title,
         icon: plugin.icon,
+        class: `${plugin.title.toLowerCase().replaceAll(' ', '-')} is-plugin`,
         experience: plugin.experience || 'inline',
         url,
       });
@@ -123,6 +127,75 @@ async function getAssetsPlugin(owner, repo) {
   };
 }
 
+function getIsPluginAllowed(plugRef) {
+  const pluginRef = plugRef || 'main';
+
+  // Always return true if pluginRef is main
+  if (pluginRef === 'main') return true;
+
+  // Allow all branches on dev
+  if (ref === 'dev') return true;
+
+  // Allow if pluginRef matches query param ref
+  if (pluginRef === ref) return true;
+
+  return false;
+}
+
+function calculateSources(org, repo, sheetPath) {
+  return sheetPath.split(',').map((path) => {
+    const trimmed = path.trim();
+
+    // If not relative, just return it.
+    if (!trimmed.startsWith('/')) return trimmed;
+
+    // Calculate the ref origin...
+
+    // If dev, the source is localhost
+    if (ref === 'dev') return `http://localhost:3000${path}`;
+
+    // Fallback to the ref in search param (defaults to main)
+    return `https://${ref}--${repo}--${org}.aem.live${path}`;
+  });
+}
+
+async function getConfigLibraries(org, repo) {
+  const resp = await daFetch(`${DA_ORIGIN}/config/${org}/${repo}/`);
+  if (!resp.ok) return null;
+  const { library } = await resp.json();
+  if (!library) return null;
+  return library.data.reduce((acc, plugin) => {
+    const allowed = getIsPluginAllowed(plugin.ref);
+    if (allowed) {
+      const libPlugin = {
+        title: plugin.title.trim(),
+        name: plugin.title.trim().toLowerCase().replaceAll(' ', '-'),
+        class: calculateClass(plugin.title),
+        sources: calculateSources(org, repo, plugin.path),
+        ref: plugin.ref || 'main',
+        experience: plugin.experience || 'inline',
+      };
+      if (plugin.format) libPlugin.format = plugin.format;
+      if (plugin.icon) libPlugin.icon = plugin.icon;
+      acc.push(libPlugin);
+    }
+    return acc;
+  }, []);
+}
+
+function mergeLibrary(da, assets) {
+  // Attempt to push after templates
+  let pushAfter = da.findIndex((library) => library.name === 'templates');
+  // Attempt to push after blocks
+  if (pushAfter === -1) pushAfter = da.findIndex((library) => library.name === 'blocks');
+  if (pushAfter !== -1) {
+    da.splice(pushAfter + 1, 0, assets);
+  } else {
+    // Give up and push to the end of DA libraries
+    da.push(assets);
+  }
+}
+
 export async function getLibraryList() {
   const { owner, repo } = getPathDetails();
   if (!owner || !repo) return [];
@@ -135,26 +208,23 @@ export async function getLibraryList() {
   currOwner = owner;
   currRepo = repo;
 
-  const daLibraries = getDaLibraries(owner, repo);
+  // Attempt config-based library
   const aemAssets = getAssetsPlugin(owner, repo);
+  const confLibrary = getConfigLibraries(owner, repo);
+  const [assets, library] = await Promise.all([aemAssets, confLibrary]);
+  if (library) {
+    if (assets) mergeLibrary(library, assets);
+    return library;
+  }
+
+  // Fallback to file-based libary
+  const daLibraries = getDaLibraries(owner, repo);
   const aemPlugins = getAemPlugins(owner, repo);
 
-  const [da, assets, aem] = await Promise.all([daLibraries, aemAssets, aemPlugins]);
+  const [da, aem] = await Promise.all([daLibraries, aemPlugins]);
 
-  if (assets) {
-    // Attempt to push after templates
-    let pushAfter = da.findIndex((library) => library.name === 'templates');
-    // Attempt to push after blocks
-    if (pushAfter === -1) pushAfter = da.findIndex((library) => library.name === 'blocks');
-    if (pushAfter !== -1) {
-      da.splice(pushAfter + 1, 0, assets);
-    } else {
-      // Give up and push to the end of DA libraries
-      da.push(assets);
-    }
-  }
-  libraries = [...da, ...aem];
-  return libraries;
+  if (assets) mergeLibrary(da, assets);
+  return [...da, ...aem];
 }
 
 export function andMatch(inputStr, targetStr) {


### PR DESCRIPTION
* Change library from Sidekick config to DA config.
* Library is backwards compatible with SK configs.

## Other notes
* `/.da/config` is now deprecated.
* Library is now configured in `https://da.live/config#/{{org}}/{{site}}/`.
* Library owns the `library` sheet.
* Each row is considered a "plugin" w/ blocks, templates, placeholders, and icons being OOTB plugins provided by DA.
* AEM Assets is still be configured in the `data` sheet. Still org or site based.
* Plugins have the following properties:
    * title
    * path (can be comma separated for blocks and templates)
    * format (used by placeholders and icons)
    * ref - `{{branch-name}}` `dev` - Where is the plugin allowed to show up. Defaults to main.
    * icon - The URL to the icon. PNG recommended unless CORs are open for the URL.
    * experience - `inline`, `dialog`, `fullsize-dialog`. Defaults to inline.