### PR TITLE
fix: Plugins with window experience

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -155,8 +155,10 @@ class DaLibrary extends LitElement {
 
     if (library.experience === 'window') {
       try {
-        const { pathname } = new URL(library.url);
-        window.open(library.url, `${pathname.replaceAll('/', '-')}`);
+        const url = library.sources?.[0] || library.url;
+        if (!url) return;
+        const { pathname } = new URL(url);
+        window.open(url, `${pathname.replaceAll('/', '-')}`);
       } catch {
         console.log('Could not make plugin URL');
       }


### PR DESCRIPTION
fix:  Plugins with window experience now open correctly in new window

## Description

<!--- Describe your changes in detail -->

## Related Issue
#441 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Configure a plugin with 'window' experience
2. Verify it opens correctly in a new window/tab
3. Verify plugins without URLs fail gracefully with warning
4. Ensure other experience types (dialog, fullsize-dialog) continue working as expected

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
