### PR TITLE
prevent img tag generation for non-image assets

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -86,7 +86,7 @@ export async function openAssets() {
         const format = asset['aem:formatName'];
         if (!format) return;
         const { path } = asset;
-        const mimetype = asset['mimetype'] || asset['dc:format'];
+        const mimetype = asset.mimetype || asset['dc:format'];
         const { view } = window;
         const { state } = view;
         dialog.close();

--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -86,6 +86,7 @@ export async function openAssets() {
         const format = asset['aem:formatName'];
         if (!format) return;
         const { path } = asset;
+        const mimetype = asset['mimetype'] || asset['dc:format'];
         const { view } = window;
         const { state } = view;
         dialog.close();
@@ -102,7 +103,8 @@ export async function openAssets() {
         if (alt) imgObj.alt = alt;
 
         let fpo;
-        if (injectLink) {
+        // ensure assets not supported by the MediaBus are added as links
+        if (!mimetype || !mimetype.toLowerCase().startsWith('image/') || injectLink) {
           const para = document.createElement('p');
           const link = document.createElement('a');
           link.href = src;


### PR DESCRIPTION
For assets which are not images links should be generated instead of the img tag.

The change was tested by locally replacing the da-assets.js file fith the changes via the browser dev tools. I was still able to insert images via the asset selector, all other mimetypes resulted in links.