### PR TITLE
fix: assets - Support delivery tier video links

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -94,10 +94,18 @@ export async function openAssets() {
         // eslint-disable-next-line no-underscore-dangle
         const alt = asset?._embedded?.['http://ns.adobe.com/adobecloud/rel/metadata/asset']?.['dc:description'];
 
-        const src = aemTierType === 'author'
-          ? `https://${prodOrigin}${path}`
-          // eslint-disable-next-line no-underscore-dangle
-          : asset._links['http://ns.adobe.com/adobecloud/rel/rendition'][0].href.split('?')[0];
+        // eslint-disable-next-line no-underscore-dangle
+        const renditionLinks = asset._links['http://ns.adobe.com/adobecloud/rel/rendition'];
+        const videoLink = renditionLinks.find((link) => link.href.endsWith('/play'))?.href;
+
+        let src;
+        if (aemTierType === 'author') {
+          src = `https://${prodOrigin}${path}`;
+        } else if (mimetype.startsWith('video/')) {
+          src = videoLink;
+        } else {
+          src = renditionLinks[0]?.href.split('?')[0];
+        }
 
         const imgObj = { src, style: 'width: 180px' };
         if (alt) imgObj.alt = alt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The video links populate as JPGs when the delivery tier is configured for assets.

## Related Issue

#448 

## Motivation and Context

The video links populate as JPGs when the delivery tier is configured for assets. Instead, they should use the correct link from renditions.

## How Has This Been Tested?

Override the da-assets.js from Chrome browser and verified that the correct video link is populated in DA when selected

## Screenshots (if appropriate):
<img width="2539" alt="Screenshot 2025-05-14 at 12 09 13 PM" src="https://github.com/user-attachments/assets/fec91ade-76a1-4444-8fc8-ee1f3653fafe" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
