### PR TITLE
Use document GUID as prosemirror reference to avoid updating deleted documents

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -4,7 +4,7 @@ import initProse from './prose/index.js';
 let proseEl;
 let wsProvider;
 
-async function setUI(el, utils) {
+async function setUI(el, utils, guid) {
   const details = getPathDetails();
   if (!details) {
     // el.classList.add('no-url');
@@ -35,7 +35,7 @@ async function setUI(el, utils) {
   }
 
   const { daFetch } = await utils;
-  const { permissions } = await daFetch(details.sourceUrl, { method: 'HEAD' });
+  const { permissions, headers } = await daFetch(details.sourceUrl, { method: 'HEAD' });
   daTitle.permissions = permissions;
   daContent.permissions = permissions;
 
@@ -44,7 +44,12 @@ async function setUI(el, utils) {
     daContent.wsProvider = undefined;
   }
 
-  ({ proseEl, wsProvider } = initProse({ path: details.sourceUrl, permissions }));
+  const docguid = guid ?? headers?.get('x-da-id');
+  ({ proseEl, wsProvider } = initProse({
+    path: details.sourceUrl,
+    permissions,
+    docguid,
+  }, (updatedGuid) => setUI(el, utils, updatedGuid)));
   daContent.proseEl = proseEl;
   daContent.wsProvider = wsProvider;
 }

--- a/test/unit/scripts/utils.test.js
+++ b/test/unit/scripts/utils.test.js
@@ -4,7 +4,7 @@ import { setNx } from '../../../scripts/utils.js';
 describe('Libs', () => {
   it('Default Libs', () => {
     const libs = setNx('/nx');
-    expect(libs).to.equal('https://main--nexter--da-sites.aem.live/nx');
+    expect(libs).to.equal('https://main--da-nx--adobe.aem.live/nx');
   });
 
   it('Does not support NX query param on prod', () => {
@@ -22,7 +22,7 @@ describe('Libs', () => {
       search: '?nx=foo',
     };
     const libs = setNx('/nx', location);
-    expect(libs).to.equal('https://foo--nexter--da-sites.aem.live/nx');
+    expect(libs).to.equal('https://foo--da-nx--adobe.aem.live/nx');
   });
 
   it('Supports local NX query param', () => {


### PR DESCRIPTION
## Description

Store the current prosemirror document in the YDoc under `prosemirror-${guid}` instead of the previous `prosemirror` key.
A new prosemirror document gets a new GUID, even if it was stored in the same location as where a previous document used to live. This means that if there was an old editor open somewhere, that is editing a document that has since been deleted, these edits are then ignored.

The property `prosemirror-guids` contains an array of GUIDs with timestamps. Only the newest timestamp is active, any older guids on that array are not active any more. This array is often scrubbed, do deleted documents on the same location often don't appear in the `prosemirror-guids` at all any more.

When creating a fresh new document in the editor, create a new GUID for it, using `crypto.randomUUID()`
When editing an existing document, the GUID of that document is returned from the HEAD request in the `x-da-id` header. So we can set that to the `prosemirror-${guid}` in that case.

Requires: https://github.com/adobe/da-admin/pull/135 and https://github.com/adobe/da-collab/pull/69
Also requires existing open browser DA editors to be refreshed.

## Related Issue

Fixes: #378

## How Has This Been Tested?

Locally with da-collab and da-live


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
