### PR TITLE
Redirect JSON files from edit view to sheet view when edited via sidekick to avoid corruption

### DIFF
--- a/blocks/shared/pathDetails.js
+++ b/blocks/shared/pathDetails.js
@@ -121,6 +121,12 @@ export default function getPathDetails(loc) {
   // Split everything up so it can be later used for both DA & AEM
   const pathParts = fullpath.slice(1).toLowerCase().split('/');
 
+  // Redirect JSON files from edit view to sheet view
+  if (editor === 'edit' && fullpath.endsWith('.json')) {
+    window.location.href = `/sheet#${fullpath.slice(0, -5)}`;
+    return null;
+  }
+
   // Determine if folder (trailing slash split to empty string)
   let isFolder = false;
   if (pathParts.slice(-1)[0] === '') {


### PR DESCRIPTION
Redirect JSON files from edit view to sheet view when edited via sidekick to avoid corruption

## Description

- Added detection and redirection for JSON files in edit view
- Prevents sheet corruption by redirecting to sheet view
- Maintains existing path handling patterns

## Related Issue

#456 

Slack discussion : https://cq-dev.slack.com/archives/C08MJQ0Q3GA/p1747400948721079

## Motivation and Context

Customer reported problem, confusing and frustrating customer experience

## How Has This Been Tested?

After the change, http://localhost:3000/edit#/kunwarsaluja/test-da/test-json.json should be redirected to http://localhost:3000/sheet#/kunwarsaluja/test-da/test-json

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
