### PR TITLE
fix: Read the image alt text from the updated property of DM OpenAPI JSON

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -92,7 +92,9 @@ export async function openAssets() {
         dialog.close();
 
         // eslint-disable-next-line no-underscore-dangle
-        const alt = asset?._embedded?.['http://ns.adobe.com/adobecloud/rel/metadata/asset']?.['dc:description'];
+        const alt = asset?._embedded?.['http://ns.adobe.com/adobecloud/rel/metadata/embedded']?.['dc:description']
+          // eslint-disable-next-line no-underscore-dangle
+          || asset?._embedded?.['http://ns.adobe.com/adobecloud/rel/metadata/embedded']?.['dc:title'];
 
         // eslint-disable-next-line no-underscore-dangle
         const renditionLinks = asset._links['http://ns.adobe.com/adobecloud/rel/rendition'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The image title and description are being passed in `computedMetadata._embedded[http://ns.adobe.com/adobecloud/rel/metadata/embedded]` with update in the DM OpenAPI JSON per https://cq-dev.slack.com/archives/C04RNGXCFD0/p1748325322736029?thread_ts=1747940802.272309&cid=C04RNGXCFD0.

I have updated the code to read from the updated property. Also, added the title as a fallback when the description is not authored  

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/da-live/issues/466

## Motivation and Context

The image alt text authored in the assets is not pulled in the DA pages for the SSB project.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Override the `da-assets.js` file in the Chrome developer tool and tested the fix.

## Screenshots (if appropriate):

<img width="1233" alt="Screenshot 2025-06-05 at 1 35 57 PM" src="https://github.com/user-attachments/assets/00a90a60-d5c7-498c-bb39-71a32e8fcc05" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
