### PR TITLE
Revert "Use document GUID as prosemirror reference to avoid updating deleted documents"

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -4,7 +4,7 @@ import initProse from './prose/index.js';
 let proseEl;
 let wsProvider;
 
-async function setUI(el, utils, guid) {
+async function setUI(el, utils) {
   const details = getPathDetails();
   if (!details) {
     // el.classList.add('no-url');
@@ -35,7 +35,7 @@ async function setUI(el, utils, guid) {
   }
 
   const { daFetch } = await utils;
-  const { permissions, headers } = await daFetch(details.sourceUrl, { method: 'HEAD' });
+  const { permissions } = await daFetch(details.sourceUrl, { method: 'HEAD' });
   daTitle.permissions = permissions;
   daContent.permissions = permissions;
 
@@ -44,12 +44,7 @@ async function setUI(el, utils, guid) {
     daContent.wsProvider = undefined;
   }
 
-  const docguid = guid ?? headers?.get('x-da-id');
-  ({ proseEl, wsProvider } = initProse({
-    path: details.sourceUrl,
-    permissions,
-    docguid,
-  }, (updatedGuid) => setUI(el, utils, updatedGuid)));
+  ({ proseEl, wsProvider } = initProse({ path: details.sourceUrl, permissions }));
   daContent.proseEl = proseEl;
   daContent.wsProvider = wsProvider;
 }

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -185,7 +185,7 @@ function addSyncedListener(wsProvider) {
   });
 }
 
-export default function initProse({ path, permissions, docguid }, resetFunc) {
+export default function initProse({ path, permissions }) {
   // Destroy ProseMirror if it already exists - GH-212
   if (window.view) delete window.view;
   const editor = document.createElement('div');
@@ -212,30 +212,7 @@ export default function initProse({ path, permissions, docguid }, resetFunc) {
   createAwarenessStatusWidget(wsProvider, window);
   registerErrorHandler(ydoc);
 
-  const guidArray = ydoc.getArray('prosemirror-guids');
-  let curGuid;
-  if (docguid) {
-    curGuid = docguid;
-  } else {
-    curGuid = crypto.randomUUID();
-    guidArray.push([{ ts: Date.now(), guid: curGuid, newDoc: true }]);
-  }
-
-  ydoc.on('update', () => {
-    // If the document has been replaced by a another document (it has been first deleted
-    // and then a new document has been created), reset the window to connect to the new doc.
-    const guids = [...guidArray];
-    if (guids.length === 0) {
-      return;
-    }
-    guids.sort((a, b) => a.ts - b.ts);
-    const latestGuid = guids.pop();
-    if (latestGuid.guid !== curGuid) {
-      resetFunc(latestGuid.guid);
-    }
-  });
-
-  const yXmlFragment = ydoc.getXmlFragment(`prosemirror-${curGuid}`);
+  const yXmlFragment = ydoc.getXmlFragment('prosemirror');
 
   if (window.adobeIMS?.isSignedInUser()) {
     window.adobeIMS.getProfile().then(

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -94,9 +94,6 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   const enteredText = `Some content entered at ${new Date()}`;
   await page.locator('div.ProseMirror').fill(enteredText);
 
-  // Wait for the content to be stored in the backend
-  await page.waitForTimeout(3000);
-
   // Create a second window on the same document
   const page2 = await browser.newPage();
   await page2.goto(url);
@@ -122,16 +119,8 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await list.locator('button.delete-button').locator('visible=true').click();
 
   // Give the second window a chance to update itself
-  await page2.waitForTimeout(3000);
+  await list.waitForTimeout(10000);
 
   // The open window should be cleared out now
   await expect(page2.locator('div.ProseMirror')).not.toContainText(enteredText);
-
-  // Add some text to the second window with the stale document, it should not be saved
-  await page2.locator('div.ProseMirror').fill('Some new content');
-  await page2.waitForTimeout(5000);
-
-  list.reload();
-  // The document should still not be in the list, even though edits were made on the stale doc
-  await expect(list.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).not.toBeVisible();
 });

--- a/test/unit/scripts/utils.test.js
+++ b/test/unit/scripts/utils.test.js
@@ -4,7 +4,7 @@ import { setNx } from '../../../scripts/utils.js';
 describe('Libs', () => {
   it('Default Libs', () => {
     const libs = setNx('/nx');
-    expect(libs).to.equal('https://main--da-nx--adobe.aem.live/nx');
+    expect(libs).to.equal('https://main--nexter--da-sites.aem.live/nx');
   });
 
   it('Does not support NX query param on prod', () => {
@@ -22,7 +22,7 @@ describe('Libs', () => {
       search: '?nx=foo',
     };
     const libs = setNx('/nx', location);
-    expect(libs).to.equal('https://foo--da-nx--adobe.aem.live/nx');
+    expect(libs).to.equal('https://foo--nexter--da-sites.aem.live/nx');
   });
 
   it('Supports local NX query param', () => {


### PR DESCRIPTION
Reverts adobe/da-live#450