### PR TITLE
Asset Library: Checking for renditionLinks before searching to prevent TypeError

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -98,7 +98,7 @@ export async function openAssets() {
 
         // eslint-disable-next-line no-underscore-dangle
         const renditionLinks = asset._links['http://ns.adobe.com/adobecloud/rel/rendition'];
-        const videoLink = renditionLinks.find((link) => link.href.endsWith('/play'))?.href;
+        const videoLink = renditionLinks?.find((link) => link.href.endsWith('/play'))?.href;
 
         let src;
         if (aemTierType === 'author') {


### PR DESCRIPTION
## Description

Fixing issue with the Asset Library not working for assets without rendition links (like zip files)

## Related Issue

https://github.com/adobe/da-live/issues/481

## Motivation and Context

Since EDS does not support most file types, need the ability to easily link to files like this from the asset selector pulling from AEM Assets

## How Has This Been Tested?

Adjusted da-assets.js in browser to confirm fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
