### PR TITLE
Enable custom DynamicMedia paths

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -95,7 +95,7 @@ export async function openAssets() {
 
   prodOrigin = prodOrigin || `${repoId.replace('author', dmDeliveryEnabled ? 'delivery' : 'publish')}`;
 
-  const getBaseDmUrl = (asset) => `https://${prodOrigin}/adobe/assets/${asset['repo:id']}`;
+  const getBaseDmUrl = (asset) => `https://${prodOrigin}${prodOrigin.includes('/') ? '' : '/adobe/assets/'}${asset['repo:id']}`;
 
   const getAssetUrl = (asset, name = asset.name) => {
     if (!dmDeliveryEnabled) {


### PR DESCRIPTION
Check for a slash in the `aem.assets.prod.origin` config to enable custom DynamicMedia paths.

If a custom prod origin is set up for DM until now the host needed to contain the default DM API root path "/adobe/assets/". With this PR as soon as `aem.assets.prod.origin` contains a slash that default path is skipped and gives the liberty to define a custom root.

## Motivation and Context

Our client has custom DM URLs like https://custom.domain/media/urn:aaid:aem:xxxxxxxxxx/as/beautiful.jpg. Note that it is missing the "/adobe/assets/" part which is typically part of the URL if using https://delivery-... URLs.

## How Has This Been Tested?

I tested via Developer Tools overwrite and on https://dmpath--da-live--adobe.aem.live/.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
