### PR TITLE
feat: connect/disconnect on window focus/blur

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -121,6 +121,8 @@ function handleAwarenessUpdates(wsProvider, daTitle, win) {
   wsProvider.on('status', (st) => { daTitle.collabStatus = st.status; });
   win.addEventListener('online', () => { daTitle.collabStatus = 'online'; });
   win.addEventListener('offline', () => { daTitle.collabStatus = 'offline'; });
+  win.addEventListener('focus', () => { wsProvider.connect(); });
+  win.addEventListener('blur', () => { wsProvider.disconnect(); });
 }
 
 export function createAwarenessStatusWidget(wsProvider, win) {

--- a/test/unit/blocks/edit/proseCollab.test.js
+++ b/test/unit/blocks/edit/proseCollab.test.js
@@ -35,7 +35,7 @@ describe('Prose collab', () => {
     const daTitle = pi.createAwarenessStatusWidget(wsp, win);
     expect(daTitle).to.equal(dat);
 
-    expect(winEventListeners.length).to.equal(2);
+    expect(winEventListeners.length).to.equal(4);
     const el0 = winEventListeners[0];
     const el1 = winEventListeners[1];
     const elOnline = el0.n === 'online' ? el0 : el1;


### PR DESCRIPTION
DA Durable Objects gets a lot of traffic because of da-collab. While I did not manage to see in the logs if this PR has an effect on DO usage, my intuition tells me that if the websocket gets disconnected when the page is not being edited, this should reduce a lot of traffic.

The `focus` and `blur` events combined with `connect` and `disconnect` works like a charm on Chrome, Safari and Firefox: when leaving the window, disconnect is happening, I see in another editor that user got disconnected and when focusing back in the window, it immediately reconnects and re-sync the file.

To test:
- open https://da.live/edit#/aem-sandbox/block-collection/drafts/alex/test (does not have the fix, helps to stay connected)
- open in another window: https://less-requests--da-live--adobe.aem.live/edit#/aem-sandbox/block-collection/drafts/alex/test
- leave and come back from the second window
- you can see the user going on and off in the first window
- make some change in first window while the user is off
- go back to second window: changes appear!