### PR TITLE
chore: test the IMS spec on branch name

### DIFF
--- a/test/e2e/tests/ims.setup.js
+++ b/test/e2e/tests/ims.setup.js
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('Branch name must respect IMS "spec"', () => {
+  const { GITHUB_HEAD_REF: branch } = process.env;
+  if (branch) {
+    // specs: max 8 alpha numeric characters
+    const specs = /^[a-zA-Z0-9]{1,8}$/;
+    expect(branch).toMatch(specs);
+  }
+});


### PR DESCRIPTION
For the moment, IMS is pretty restrictive and the branch name needs to be short (and only alpha). Adding a test to help devs to know the tests are failing because spec is not respected.