### PR TITLE
Do not enable contentEditable for readonly docs

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -178,11 +178,9 @@ function restoreCursorPosition(view) {
   }
 }
 
-function addSyncedListener(wsProvider) {
+function addSyncedListener(wsProvider, canWrite) {
   const handleSynced = (isSynced) => {
     if (isSynced) {
-      const permissions = document.querySelector('da-title').permissions || [];
-      const canWrite = permissions.some((p) => p === 'write');
       if (canWrite) {
         const pm = document.querySelector('da-content')?.shadowRoot
           .querySelector('da-editor')?.shadowRoot.querySelector('.ProseMirror');
@@ -217,7 +215,7 @@ export default function initProse({ path, permissions }) {
   const canWrite = permissions.some((permission) => permission === 'write');
 
   const wsProvider = new WebsocketProvider(server, roomName, ydoc, opts);
-  addSyncedListener(wsProvider);
+  addSyncedListener(wsProvider, canWrite);
 
   createAwarenessStatusWidget(wsProvider, window);
   registerErrorHandler(ydoc);

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -179,16 +179,20 @@ function restoreCursorPosition(view) {
 }
 
 function addSyncedListener(wsProvider) {
-  let initialContentLoaded = false;
-  wsProvider.on('synced', (isSynced) => {
-    if (isSynced && !initialContentLoaded) {
-      const pm = document.querySelector('da-content')?.shadowRoot
-        .querySelector('da-editor')?.shadowRoot.querySelector('.ProseMirror');
-      if (pm) pm.contentEditable = 'true';
-
-      initialContentLoaded = true;
+  const handleSynced = (isSynced) => {
+    if (isSynced) {
+      const permissions = document.querySelector('da-title').permissions || [];
+      const canWrite = permissions.some((p) => p === 'write');
+      if (canWrite) {
+        const pm = document.querySelector('da-content')?.shadowRoot
+          .querySelector('da-editor')?.shadowRoot.querySelector('.ProseMirror');
+        if (pm) pm.contentEditable = 'true';
+      }
+      wsProvider.off('synced', handleSynced);
     }
-  });
+  };
+
+  wsProvider.on('synced', handleSynced);
 }
 
 export default function initProse({ path, permissions }) {

--- a/test/e2e/tests/authenticated/acl_doc.spec.js
+++ b/test/e2e/tests/authenticated/acl_doc.spec.js
@@ -19,13 +19,11 @@ test('Read-only document directly configured', async ({ page }, workerInfo) => {
   await page.goto(url);
   const editor = page.locator('div.ProseMirror');
   await expect(editor).toHaveText('This is doc_readonly');
-  // TODO: uncomment when https://github.com/adobe/da-live/issues/473 is fixed
-  // await expect(editor, 'Should be readonly').toHaveAttribute('contenteditable', 'false');
+  await expect(editor, 'Should be readonly').toHaveAttribute('contenteditable', 'false');
 
   await editor.pressSequentially('Hello');
-  // TODO: uncomment when https://github.com/adobe/da-live/issues/473 is fixed
-  // await expect(editor, 'The text should not have been updated since its a readonly doc')
-  // .toHaveText('This is doc_readonly');
+  await expect(editor, 'The text should not have been updated since its a readonly doc')
+    .toHaveText('This is doc_readonly');
 
   // This last part of this test that obtains the ':before' part of the h1
   // apparently only works on Chromium, so skip it for other browsers

--- a/test/e2e/tests/authenticated/acl_doc.spec.js
+++ b/test/e2e/tests/authenticated/acl_doc.spec.js
@@ -43,13 +43,11 @@ test('Read-only document indirectly configured', async ({ page }, workerInfo) =>
   await page.goto(url);
   const editor = page.locator('div.ProseMirror');
   await expect(editor).toHaveText('This is doc_onlyread');
-  // TODO: uncomment when https://github.com/adobe/da-live/issues/473 is fixed
-  // await expect(editor, 'Should be readonly').toHaveAttribute('contenteditable', 'false');
+  await expect(editor, 'Should be readonly').toHaveAttribute('contenteditable', 'false');
 
   await editor.pressSequentially('Hello');
-  // TODO: uncomment when https://github.com/adobe/da-live/issues/473 is fixed
-  // await expect(editor, 'The text should not have been updated since its a readonly doc')
-  // .toHaveText('This is doc_onlyread');
+  await expect(editor, 'The text should not have been updated since its a readonly doc')
+    .toHaveText('This is doc_onlyread');
 
   // This last part of this test that obtains the ':before' part of the h1
   // apparently only works on Chromium, so skip it for other browsers


### PR DESCRIPTION
Check the permissions to ensure user has write permissions on the document

Fixes #473

Note that the below urls require you to be logged in with the da-test@adobetest.com user

Before: https://main--da-live--adobe.hlx.live/edit#/da-testautomation/acltest/testdocs/doc_readonly
After: https://ccc473--da-live--adobe.hlx.live/edit#/da-testautomation/acltest/testdocs/doc_readonly