### PR TITLE
Add option for https://localhost

### DIFF
--- a/test/e2e/utils/env.js
+++ b/test/e2e/utils/env.js
@@ -10,6 +10,9 @@ function getEnv() {
   if (branch === 'local') {
     return 'http://localhost:3000';
   }
+  if (branch === 'local-https') {
+    return 'https://localhost';
+  }
   if (branch === 'main' && owner === 'adobe') {
     return 'https://da.live';
   }


### PR DESCRIPTION
Only affects e2e test locally.   Just don't use `local-https` as your branch name.