### PR TITLE
fix: disable action buttons during resource creation to prevent resource duplication

### DIFF
--- a/blocks/browse/da-new/da-new.css
+++ b/blocks/browse/da-new/da-new.css
@@ -51,7 +51,8 @@ button {
   transition: outline-offset .2s;
 }
 
-.da-actions-new-button:disabled {
+.da-actions-new-button:disabled,
+.da-actions-button:disabled {
   color: var(--s2-gray-700);
   background-color: transparent;
   outline-color: var(--s2-gray-700);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I noticed an issue with the new resource creation flow. When I select a resource type (like folder or media) and click the action button multiple times (e.g., create folder or upload), it creates multiple instances of the resource. A potential fix could be to disable the action button until the creation process is complete.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/da-live/issues/545

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->



<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested? (Screenshots)
Before: https://main--da-live--ajullal.aem.page/
After: https://disable-in-progress-buttons--da-live--ajullal.aem.page/


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before:
![Bug](https://github.com/user-attachments/assets/e51822f2-cbfd-4d8e-a9cc-c31249c8043e)

After:
![fix](https://github.com/user-attachments/assets/c4cdd2d9-8250-48b9-9262-771a485e201e)


