### PR TITLE
fix: block description tooltip alignment

### DIFF
--- a/blocks/edit/da-library/da-library.css
+++ b/blocks/edit/da-library/da-library.css
@@ -442,16 +442,18 @@ ul {
 }
 
 .da-library-icons .info-tooltip {
-  position: fixed;
+  position: absolute;
+  top: calc(100% + 8px);
+  right: -45px;
   background: #2C2C2C;
   color: white;
-  padding: 8px 12px;
+  padding: 8px;
   border-radius: 4px;
   font-size: 12px;
   line-height: 1.4;
   white-space: normal;
-  min-width: 200px;
-  max-width: 400px;
+  min-width: 120px;
+  max-width: 220px;
   width: max-content;
   word-wrap: break-word;
   opacity: 0;
@@ -460,7 +462,7 @@ ul {
   pointer-events: none;
   z-index: 10000;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  margin-top: 5px;
+  margin-bottom: 8px;
 }
 
 .da-library-icons .info-icon-container:hover .info-tooltip {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes block description tooltip alignment for cases with more entries added to block library. Currently the description tooltip gets off-aligned. This PR keeps tooltip within the palette to avoid overflow

## Related Issue
#556 

## Motivation and Context
This was found when building library for a customer project. 

## How Has This Been Tested?
https://main--da-live--asthabh23.aem.page/edit#/audemars-piguet/arbres-fondationsaudemarspiguet/en
vs
https://i556--da-live--asthabh23.aem.page/edit#/audemars-piguet/arbres-fondationsaudemarspiguet/en

## Screenshots (if appropriate):

Original:
<img width="704" height="531" alt="Screenshot 2025-09-01 at 11 31 20" src="https://github.com/user-attachments/assets/6c78fada-7682-48ca-b6d4-20d927854aca" />

Updated:
<img width="334" height="204" alt="Screenshot 2025-09-01 at 11 31 59" src="https://github.com/user-attachments/assets/e65308c6-b3dc-4427-9075-ea9bddd15918" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
