### PR TITLE
fix: use document GUID as prosemirror reference to avoid updating deleted documents

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -6,7 +6,7 @@ let wsProvider;
 let startPreviewing;
 let stopPreviewing;
 
-async function setUI(el, utils) {
+async function setUI(el, utils, guid) {
   const details = getPathDetails();
   if (!details) return;
 
@@ -36,7 +36,7 @@ async function setUI(el, utils) {
   }
 
   const { daFetch } = await utils;
-  const { permissions } = await daFetch(details.sourceUrl, { method: 'HEAD' });
+  const { permissions, headers } = await daFetch(details.sourceUrl, { method: 'HEAD' });
   daTitle.permissions = permissions;
   daContent.permissions = permissions;
 
@@ -45,12 +45,17 @@ async function setUI(el, utils) {
     daContent.wsProvider = undefined;
   }
 
+  const docGUID = guid ?? headers?.get('x-da-id');
   ({
     proseEl,
     wsProvider,
     startPreviewing,
     stopPreviewing,
-  } = prose.default({ path: details.sourceUrl, permissions }));
+  } = prose.default({
+    path: details.sourceUrl,
+    permissions,
+    docGUID,
+  }, (updatedGuid) => setUI(el, utils, updatedGuid)));
 
   daContent.proseEl = proseEl;
   daContent.wsProvider = wsProvider;

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -196,7 +196,7 @@ function addSyncedListener(wsProvider, canWrite) {
   wsProvider.on('synced', handleSynced);
 }
 
-export default function initProse({ path, permissions }) {
+export default function initProse({ path, permissions, docGUID }, resetFunc) {
   // Destroy ProseMirror if it already exists - GH-212
   if (window.view) delete window.view;
   const editor = document.createElement('div');
@@ -223,7 +223,30 @@ export default function initProse({ path, permissions }) {
   createAwarenessStatusWidget(wsProvider, window);
   registerErrorHandler(ydoc);
 
-  const yXmlFragment = ydoc.getXmlFragment('prosemirror');
+  const guidArray = ydoc.getArray('prosemirror-guids');
+  let curGuid;
+  if (docGUID) {
+    curGuid = docGUID;
+  } else {
+    curGuid = crypto.randomUUID();
+    guidArray.push([{ ts: Date.now(), guid: curGuid, newDoc: true }]);
+  }
+
+  ydoc.on('update', () => {
+    // If the document has been replaced by a another document (it has been first deleted
+    // and then a new document has been created), reset the window to connect to the new doc.
+    const guids = [...guidArray];
+    if (guids.length === 0) {
+      return;
+    }
+    guids.sort((a, b) => a.ts - b.ts);
+    const latestGuid = guids.pop();
+    if (latestGuid.guid !== curGuid) {
+      resetFunc(latestGuid.guid);
+    }
+  });
+
+  const yXmlFragment = ydoc.getXmlFragment(`prosemirror-${curGuid}`);
 
   if (window.adobeIMS?.isSignedInUser()) {
     window.adobeIMS.getProfile().then(

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -100,6 +100,9 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   const enteredText = `Some content entered at ${new Date()}`;
   await page.locator('div.ProseMirror').fill(enteredText);
 
+  // Wait for the content to be stored in the backend
+  await page.waitForTimeout(3000);
+
   // Create a second window on the same document
   const page2 = await browser.newPage();
   await page2.goto(url);
@@ -131,8 +134,16 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await list.locator('sl-button.negative').locator('visible=true').click();
 
   // Give the second window a chance to update itself
-  await list.waitForTimeout(10000);
+  await page2.waitForTimeout(3000);
 
   // The open window should be cleared out now
   await expect(page2.locator('div.ProseMirror')).not.toContainText(enteredText);
+
+  // Add some text to the second window with the stale document, it should not be saved
+  await page2.locator('div.ProseMirror').fill('Some new content');
+  await page2.waitForTimeout(5000);
+
+  list.reload();
+  // The document should still not be in the list, even though edits were made on the stale doc
+  await expect(list.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).not.toBeVisible();
 });


### PR DESCRIPTION
## Description

Store the current prosemirror document in the YDoc under `prosemirror-${guid}` instead of the previous `prosemirror` key. A new prosemirror document gets a new GUID, even if it was stored in the same location as where a previous document used to live. This means that if there was an old editor open somewhere, that is editing a document that has since been deleted, these edits are then ignored.

The property prosemirror-guids contains an array of GUIDs with timestamps. Only the newest timestamp is active, any older guids on that array are not active any more. This array is often scrubbed, so deleted documents on the same location generally don't appear in the prosemirror-guids at all any more.

When creating a fresh new document in the editor, it creates a new GUID for it, using `crypto.randomUUID()` 
When editing an existing document, the GUID of that document is returned from the HEAD request in the x-da-id header. So we can set that to the prosemirror-${guid} in that case.

Requires https://github.com/adobe/da-collab/pull/88
Requires existing open browser DA editors to be refreshed.

## Related Issue

https://github.com/adobe/da-live/issues/378

## How Has This Been Tested?

* Extended Playwright test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
