### PR TITLE
Improve library tooltips

### DIFF
--- a/blocks/edit/da-library/da-library.css
+++ b/blocks/edit/da-library/da-library.css
@@ -364,24 +364,48 @@ ul {
   transition: transform .2s ease-in-out;
 }
 
-.da-library-type-group-detail-item button {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  border: none;
-  background: none;
-  padding: 8px 18px;
-  text-align: left;
-  min-height: 50px;
-  box-sizing: border-box;
-  transition: background-color .2s ease-in-out;
+.da-library-type-group-detail-item {
+  button {
+    width: 100%;
+    border: none;
+    background: none;
+    padding: 8px 18px;
+    text-align: left;
+    min-height: 50px;
+    box-sizing: border-box;
+    transition: background-color 0.2s ease-in-out;
+
+    .da-library-item-button-title {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .da-library-item-button-tooltip {
+      display: none;
+      font-size: 14px;
+      margin-top: 8px;
+      background: rgb(0 0 0 / 5%);
+      padding: 6px 10px;
+      border-radius: 6px;
+    }
+
+    &.show-tooltip {
+      .da-library-item-button-tooltip {
+        display: block;
+      }
+    }
+  }
 }
 
 .da-library-type-group-detail-item button:hover,
 .da-library-type-group-detail-item button:focus {
   background-color: #E4F0FF;
   color: #167AF3;
+
+  .da-library-item-button-tooltip {
+    color: #234064;
+  }
 }
 
 .da-library-type-group-detail-item button:focus {
@@ -421,7 +445,7 @@ ul {
 .da-library-icons {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
 }
 
 .info-icon-container {
@@ -429,45 +453,9 @@ ul {
   display: inline-block;
 }
 
-.da-library-icons .info-icon {
-  width: 18px;
-  height: 18px;
-  opacity: 0.6;
-  transition: opacity 0.2s ease;
-}
-
 .da-library-type-group-detail-item button:hover .info-icon,
 .da-library-type-group-detail-item button:focus .info-icon {
   opacity: 1;
-}
-
-.da-library-icons .info-tooltip {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: -45px;
-  background: #2C2C2C;
-  color: white;
-  padding: 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  line-height: 1.4;
-  white-space: normal;
-  min-width: 120px;
-  max-width: 220px;
-  width: max-content;
-  word-wrap: break-word;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
-  pointer-events: none;
-  z-index: 10000;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  margin-bottom: 8px;
-}
-
-.da-library-icons .info-icon-container:hover .info-tooltip {
-  opacity: 1;
-  visibility: visible;
 }
 
 .da-library-type-list-assets {

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -261,6 +261,11 @@ class DaLibrary extends LitElement {
     }
   }
 
+  handleToolTip(e) {
+    e.stopPropagation();
+    e.target.closest('button').classList.toggle('show-tooltip');
+  }
+
   async handleTemplateClick(item) {
     const resp = await daFetch(`${item.value}`);
     if (!resp.ok) return;
@@ -323,22 +328,21 @@ class DaLibrary extends LitElement {
   }
 
   renderBlockItem(item, icon = false) {
+    const hasDesc = item.description?.trim();
     return html`
       <li class="da-library-type-group-detail-item" tabindex="1">
         <button class="${icon ? 'blocks' : ''}" @click=${() => this.handleItemClick(item, true)}>
-          <div>
-            <span class="da-library-group-name">${item.name}</span>
-            <span class="da-library-group-subtitle">${item.variants}</span>
+          <div class="da-library-item-button-title">
+            <div>
+              <span class="da-library-group-name">${item.name}</span>
+              <span class="da-library-group-subtitle">${item.variants}</span>
+            </div>
+            <div class="da-library-icons">
+              ${hasDesc ? html`<svg class="icon" @click=${this.handleToolTip}><use href="#spectrum-InfoOutline"/></svg>` : nothing}
+              <svg class="icon"><use href="#spectrum-ExperienceAdd"/></svg>
+            </div>
           </div>
-          <div class="da-library-icons">
-            ${item.description && item.description.trim() ? html`
-              <div class="info-icon-container">
-                <svg class="icon info-icon"><use href="#spectrum-InfoOutline"/></svg>
-                <div class="info-tooltip">${item.description}</div>
-              </div>
-            ` : ''}
-            <svg class="icon"><use href="#spectrum-ExperienceAdd"/></svg>
-          </div>
+          ${hasDesc ? html`<div class="da-library-item-button-tooltip">${item.description}</div>` : nothing}
         </button>
       </li>`;
   }


### PR DESCRIPTION
## Example
https://libtool--da-live--adobe.hlx.live/edit#/audemars-piguet/arbres-fondationsaudemarspiguet/en

## Release notes

* Make touch friendly - click instead of hover
* Make touch friendly - more spacing from add icon
* Make more consistent with existing UX.
* Toggle-able on & off
* Simplify CSS & JS
* Fix icon showing black on mouse out

Resolves: #566

<img width="1552" height="1012" alt="Screenshot 2025-09-07 at 7 29 47 PM" src="https://github.com/user-attachments/assets/5863b23f-eddb-4cd9-9351-d4311bc17131" />


