### PR TITLE
feat: x-error handling

### DIFF
--- a/blocks/edit/da-title/da-title.css
+++ b/blocks/edit/da-title/da-title.css
@@ -208,16 +208,22 @@ h1 {
   animation: animated-background 1s linear infinite;
 }
 
-.da-title-error-details {
-  background-color: var(--s2-red);
-  padding: 0 6px;
+.da-title-error {
   margin: 0 0 0 24px;
-  border-radius: 4px;
-  color: #FFF;
+  color: #fff;
+  background-color: #d73220;
+  padding: 4px 8px;
+  border-radius: 8px;
+  font-size: 14px;
+
+  p {
+    margin: 0;
+    line-height: 1.3;
+  }
 }
 
 .da-title-action-send.is-error {
-  background-color: var(--s2-red);
+  background-color: #d73220;
 }
 
 @keyframes animated-background {
@@ -257,7 +263,6 @@ img.collab-icon {
   width: 19px;
   height: 19px;
 }
-
 
 div.collab-users {
   display: flex;

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -55,6 +55,17 @@ export default class DaTitle extends LitElement {
 
   handleError(json, action, icon) {
     this._status = { ...json.error, action };
+
+    if (this._status.xerror) {
+      // eslint-disable-next-line no-console
+      console.error('x-error', this._status.xerror);
+
+      // x-error handling
+      if (this._status.xerror.includes('exceeds allowed limit')) {
+        this._status.details = this._status.xerror.split(':').pop().trim();
+      }
+    }
+
     icon.classList.remove('is-sending');
     icon.parentElement.classList.add('is-error');
   }
@@ -189,7 +200,7 @@ export default class DaTitle extends LitElement {
         </div>
         <div class="da-title-collab-actions-wrapper">
           ${this.collabStatus ? this.renderCollab() : nothing}
-          ${this._status ? html`<p class="da-title-error-details">${this._status.message} ${this._status.action}.</p>` : nothing}
+          ${this._status ? html`<p class="da-title-error-details">${this._status.message} ${this._status.action}.${this._status.details ? html`<br>${this._status.details}` : ''}</p>` : nothing}
           <div class="da-title-actions ${this._fixedActions ? 'is-fixed' : ''} ${this._actionsVis ? 'is-open' : ''}">
             ${this.details.view === 'config' ? this.renderSave() : this.renderAemActions()}
             <button

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -55,17 +55,6 @@ export default class DaTitle extends LitElement {
 
   handleError(json, action, icon) {
     this._status = { ...json.error, action };
-
-    if (this._status.xerror) {
-      // eslint-disable-next-line no-console
-      console.error('x-error', this._status.xerror);
-
-      // x-error handling
-      if (this._status.xerror.includes('exceeds allowed limit')) {
-        this._status.details = this._status.xerror.split(':').pop().trim();
-      }
-    }
-
     icon.classList.remove('is-sending');
     icon.parentElement.classList.add('is-error');
   }
@@ -105,12 +94,12 @@ export default class DaTitle extends LitElement {
       const aemPath = this.sheet ? `${pathname}.json` : pathname;
       let json = await saveToAem(aemPath, 'preview');
       if (json.error) {
-        this.handleError(json, action, sendBtn);
+        this.handleError(json, 'preview', sendBtn);
         return;
       }
       if (action === 'publish') json = await saveToAem(aemPath, 'live');
       if (json.error) {
-        this.handleError(json, action, sendBtn);
+        this.handleError(json, 'publish', sendBtn);
         return;
       }
       const { url: href } = action === 'publish' ? json.live : json.preview;
@@ -200,7 +189,12 @@ export default class DaTitle extends LitElement {
         </div>
         <div class="da-title-collab-actions-wrapper">
           ${this.collabStatus ? this.renderCollab() : nothing}
-          ${this._status ? html`<p class="da-title-error-details">${this._status.message} ${this._status.action}.${this._status.details ? html`<br>${this._status.details}` : ''}</p>` : nothing}
+          ${this._status ? html`
+            <div class="da-title-error">
+              <p><strong>${this._status.message} ${this._status.action}.</strong></p>
+              <p>${this._status.details}</p>
+            </div>
+          ` : nothing}
           <div class="da-title-actions ${this._fixedActions ? 'is-fixed' : ''} ${this._actionsVis ? 'is-open' : ''}">
             ${this.details.view === 'config' ? this.renderSave() : this.renderAemActions()}
             <button

--- a/blocks/edit/utils/helpers.js
+++ b/blocks/edit/utils/helpers.js
@@ -98,13 +98,15 @@ export async function saveToAem(path, action) {
   const resp = await daFetch(url, { method: 'POST' });
   // eslint-disable-next-line no-console
   if (!resp.ok) {
-    const { status } = resp;
+    const { status, headers } = resp;
     const message = [401, 403].some((s) => s === status) ? 'Not authorized to' : 'Error during';
+    const xerror = headers.get('x-error');
     return {
       error: {
         status,
         type: 'error',
         message,
+        xerror,
       },
     };
   }

--- a/blocks/edit/utils/helpers.js
+++ b/blocks/edit/utils/helpers.js
@@ -90,6 +90,31 @@ export function aem2prose(doc) {
   });
 }
 
+/* eslint-disable max-len */
+/**
+ * [admin] Unable to preview '.../page.md': source contains large image: error fetching resource at http.../hello: Image 1 exceeds allowed limit of 10.00MB
+ * [admin] Unable to preview '.../doc.pdf': PDF is larger than 10MB: 24.0MB
+ * [admin] Unable to preview '.../video.mp4': MP4 is longer than 2 minutes: 2m 44s
+ * [admin] Unable to preview '.../video.mp4': MP4 has a higher bitrate than 300 KB/s: 494 kilobytes
+ * [admin] not authenticated
+ * [admin] not authorized
+ */
+/* eslint-enable max-len */
+function parseAemError(xError) {
+  if (xError.includes('PDF')) {
+    const [seg1, seg2] = xError.split(': ').slice(-2);
+    return `${seg1}: ${seg2}`;
+  }
+  if (xError.includes('MP4')) {
+    const [seg1] = xError.split(': ').slice(-2);
+    return seg1;
+  }
+  if (xError.includes('Image')) {
+    return xError.split(': ').pop().replace('.00', '');
+  }
+  return xError.replace('[admin] ', '');
+}
+
 export async function saveToAem(path, action) {
   const [owner, repo, ...parts] = path.slice(1).toLowerCase().split('/');
   const aemPath = parts.join('/');
@@ -106,7 +131,7 @@ export async function saveToAem(path, action) {
         status,
         type: 'error',
         message,
-        xerror,
+        details: parseAemError(xerror),
       },
     };
   }


### PR DESCRIPTION
The admin api returns an x-error header with the error. The message is pretty technical and should not be exposed to the author. For known messages, we can create a user friendly error mapping and display it. In any case, a console.error is shown and the list of known error messages should be maintained and increased over time.

Resolves: #558, #569

Test:

- https://xerror--da-live--adobe.hlx.live/edit#/aem-sandbox/block-collection/drafts/alex/test
- just hit preview

## Release notes
* Expose `x-error` header to the author
* Minor sanitization of known messages
* Falls back to full error if unknown pattern

<img width="355" height="114" alt="Screenshot 2025-09-09 at 7 05 41 PM" src="https://github.com/user-attachments/assets/5e31099b-222a-43b7-a11a-1084202a9e04" />

