### PR TITLE
Make Slash Menu case-insensitive and space-tolerant

### DIFF
--- a/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
+++ b/blocks/edit/prose/plugins/slashMenu/keyAutocomplete.js
@@ -8,12 +8,17 @@ function insertAutocompleteText(state, dispatch, text) {
   dispatch(tr);
 }
 
+// Normalize strings for slash menu comparison
+export function normalizeForSlashMenu(str) {
+  return str?.toLowerCase().trim().replace(/\s+/g, '-');
+}
+
 export function processKeyData(data) {
   const blockMap = new Map();
 
   data?.forEach((item) => {
     const itemBlocks = item.blocks?.toLowerCase().trim();
-    const blocks = itemBlocks?.split(',').map((block) => block.trim());
+    const blocks = itemBlocks?.split(',').map((block) => normalizeForSlashMenu(block));
 
     if (!blocks) return;
 
@@ -32,7 +37,7 @@ export function processKeyData(data) {
       if (!blockMap.has(block)) {
         blockMap.set(block, new Map());
       }
-      blockMap.get(block).set(item.key, values);
+      blockMap.get(block).set(normalizeForSlashMenu(item.key), values);
     });
   });
 
@@ -52,6 +57,11 @@ export function processKeyData(data) {
   blockMap.get = (blockName) => {
     if (blockMap.has(blockName)) {
       return originalGet(blockName);
+    }
+    // Try normalized block name
+    const normalizedBlockName = normalizeForSlashMenu(blockName);
+    if (blockMap.has(normalizedBlockName)) {
+      return originalGet(normalizedBlockName);
     }
 
     return originalGet('all');

--- a/blocks/edit/prose/plugins/slashMenu/slashMenu.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenu.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { Plugin, PluginKey } from 'da-y-wrapper';
-import { getKeyAutocomplete } from './keyAutocomplete.js';
+import { getKeyAutocomplete, normalizeForSlashMenu } from './keyAutocomplete.js';
 import { getDefaultItems, getTableCellItems, getTableItems } from './slashMenuItems.js';
 import './slash-menu.js';
 
@@ -41,7 +41,8 @@ const getTableName = ($cursor) => {
   const row = $cursor.node(rowDepth);
 
   const firstRowContent = firstRow.child(0).textContent;
-  const tableNameMatch = firstRowContent.match(/^([a-zA-Z0-9_-]+)(?:\s*\([^)]*\))?$/);
+  // Updated regex to allow spaces in table names, which will be normalized later
+  const tableNameMatch = firstRowContent.match(/^([a-zA-Z0-9_\s-]+)(?:\s*\([^)]*\))?$/);
 
   // Only set key value if we're in the second column of a row
   const currentRowFirstColContent = (row.childCount > 1 && cellIndex === 1) ? row.child(0).textContent : null;
@@ -90,8 +91,9 @@ class SlashMenuView {
     const { tableName, keyValue } = getTableName($cursor);
     if (tableName) {
       const keyData = pluginState.autocompleteData?.get(tableName);
-      if (keyData && keyData.get(keyValue)) {
-        this.menu.items = keyData.get(keyValue);
+      const normalizedKey = normalizeForSlashMenu(keyValue);
+      if (keyData && keyData.get(normalizedKey)) {
+        this.menu.items = keyData.get(normalizedKey);
       } else {
         this.menu.items = getTableItems(state);
       }
@@ -104,7 +106,8 @@ class SlashMenuView {
     const { tableName, keyValue } = getTableName($cursor);
     if (tableName) {
       const keyData = pluginState.autocompleteData?.get(tableName);
-      return keyData && keyData.get(keyValue);
+      const normalizedKey = normalizeForSlashMenu(keyValue);
+      return keyData && keyData.get(normalizedKey);
     }
     return false;
   }


### PR DESCRIPTION
The slash menu functionality in DA-Live requires exact case and format matching between DA document content and options sheet configuration, creating a poor user experience for content authors.

## Description

Added case-insensitive and space-tolerant matching to the slash menu functionality to improve usability for content authors.
- Added normalizeForSlashMenu() function that converts strings to lowercase and replaces spaces with dashes while matching
- Enhanced regex pattern to accept spaces in table names (e.g., "Section Metadata")

## Related Issue
https://github.com/adobe/da-live/issues/572

## Motivation and Context

Authors were experiencing frustration with the slash menu because it required exact case and format matching between their DA document content and the options sheet configuration. 

## How Has This Been Tested?
Tested locally on https://da.live/edit#/kunwarsaluja/test-da/education

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Release notes
* Added case-insensitive and space-tolerant matching to the slash menu functionality to improve usability for content authors.
* Added normalizeForSlashMenu() function that converts strings to lowercase and replaces spaces with dashes while matching
* Enhanced regex pattern to accept spaces in table names (e.g., "Section Metadata")

<img width="500" alt="Screenshot 2025-09-11 at 6 25 23 PM" src="https://github.com/user-attachments/assets/b9c85c19-8812-4a20-a18b-7b970a36ac49" />

<img width="500" alt="Screenshot 2025-09-11 at 6 25 38 PM" src="https://github.com/user-attachments/assets/2af62c57-4af6-4c4e-9e53-442fdf229f9c" />