### PR TITLE
feat: log out user if not authorized

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -36,7 +36,7 @@ async function setUI(el, utils) {
   }
 
   const { daFetch } = await utils;
-  const { permissions } = await daFetch(details.sourceUrl, { method: 'HEAD' });
+  const { permissions = [] } = await daFetch(details.sourceUrl, { method: 'HEAD' });
   daTitle.permissions = permissions;
   daContent.permissions = permissions;
 

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -225,7 +225,6 @@ export default function initProse({ path, permissions }) {
   const wsProvider = new WebsocketProvider(server, roomName, ydoc, opts);
   wsProvider.on('connection-error', async () => {
     await logOut();
-    wsProvider.disconnect();
   });
 
   addSyncedListener(wsProvider, canWrite);

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -135,12 +135,11 @@ export function createAwarenessStatusWidget(wsProvider, win) {
 }
 
 function registerErrorHandler(ydoc) {
-  ydoc.on('update', async () => {
+  ydoc.on('update', () => {
     const errorMap = ydoc.getMap('error');
     if (errorMap && errorMap.size > 0) {
-      const str = JSON.stringify(errorMap);
       // eslint-disable-next-line no-console
-      console.log('Error from server', str);
+      console.log('Error from server', JSON.stringify(errorMap));
       errorMap.clear();
     }
   });

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -142,9 +142,6 @@ function registerErrorHandler(ydoc) {
       // eslint-disable-next-line no-console
       console.log('Error from server', str);
       errorMap.clear();
-      if (str.includes('403 - Forbidden') || str.includes('401 - Unauthorized')) {
-        await logOut();
-      }
     }
   });
 }

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -25,6 +25,7 @@ export async function logOut() {
   imsDetails = null;
   const { handleSignOut } = await import(`${getNx()}/utils/ims.js`);
   handleSignOut();
+  window.location.reload();
 }
 
 export const daFetch = async (url, opts = {}) => {
@@ -53,11 +54,8 @@ export const daFetch = async (url, opts = {}) => {
       }
       // eslint-disable-next-line no-console
       console.warn('You need to sign in because you are not authorized to access this page', url);
-      const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
-      await loadIms();
-      handleSignIn();
-      // wait 1 second to let ims do its things
-      await new Promise((resolve) => { setTimeout(resolve, 1000); });
+      // try a clean log out and let ims do its thing
+      await logOut();
     }
   }
 

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -23,8 +23,12 @@ export async function initIms() {
 
 export async function logOut() {
   imsDetails = null;
-  const { handleSignOut } = await import(`${getNx()}/utils/ims.js`);
-  handleSignOut();
+  try {
+    const { handleSignOut } = await import(`${getNx()}/utils/ims.js`);
+    handleSignOut();
+  } catch {
+    // do nothing
+  }
   window.location.reload();
 }
 
@@ -54,8 +58,11 @@ export const daFetch = async (url, opts = {}) => {
       }
       // eslint-disable-next-line no-console
       console.warn('You need to sign in because you are not authorized to access this page', url);
-      // try a clean log out and let ims do its thing
-      await logOut();
+      const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
+      await loadIms();
+      handleSignIn();
+      // wait 1 second to let ims do its things
+      await new Promise((resolve) => { setTimeout(resolve, 1000); });
     }
   }
 

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -56,6 +56,8 @@ export const daFetch = async (url, opts = {}) => {
       const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
       await loadIms();
       handleSignIn();
+      // wait 1 second to let ims do its things
+      await new Promise((resolve) => { setTimeout(resolve, 1000); });
     }
   }
 

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -21,6 +21,12 @@ export async function initIms() {
   }
 }
 
+export async function logOut() {
+  imsDetails = null;
+  const { handleSignOut } = await import(`${getNx()}/utils/ims.js`);
+  handleSignOut();
+}
+
 export const daFetch = async (url, opts = {}) => {
   opts.headers = opts.headers || {};
   let accessToken;


### PR DESCRIPTION
Fix https://github.com/adobe/da-live/issues/563

Session might expire or user can be logged out for some reason but still continue to author. Editor does not detect this case and still allow user to edit for an infinite time (until page reload).

Test: https://kickout--da-live--adobe.aem.live/

- Sign in to a project
- Open a page for authoring
- Open a new tab with the explorer and sign out
- Go back to editor, make edits. Reload will happen after one or 2s and force user to sign-in again. Minimal changes are lost.