### PR TITLE
feat: webp convert and b64 inline

### DIFF
--- a/blocks/edit/prose/plugins/imageDrop.js
+++ b/blocks/edit/prose/plugins/imageDrop.js
@@ -1,7 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
 import { Plugin, TextSelection } from 'da-y-wrapper';
-import getPathDetails from '../../../shared/pathDetails.js';
-import { daFetch } from '../../../shared/utils.js';
 
 const FPO_IMG_URL = 'https://content.da.live/auniverseaway/da/assets/fpo.svg';
 const SUPPORTED_FILES = ['image/svg+xml', 'image/png', 'image/jpeg', 'image/gif'];
@@ -24,26 +22,29 @@ export default function imageDrop(schema) {
 
             const { $from } = view.state.selection;
 
-            const details = getPathDetails();
-            const url = `${details.origin}/source${details.parent}/.${details.name}/${file.name}`;
+            const image = new Image();
+            image.onload = () => {
+              const canvas = document.createElement('canvas');
+              canvas.width = image.naturalWidth;
+              canvas.height = image.naturalHeight;
+              canvas.getContext('2d').drawImage(image, 0, 0);
+              canvas.toBlob((blob) => {
+                const myImage = new File([blob], file.name, { type: blob.type });
+                const reader = new FileReader();
+                reader.readAsDataURL(myImage);
+                reader.onloadend = () => {
+                  const base64 = reader.result;
+                  // eslint-disable-next-line max-len
+                  const fpoSelection = TextSelection.create(view.state.doc, $from.pos - 1, $from.pos);
+                  const ts = view.state.tr.setSelection(fpoSelection);
+                  const img = schema.nodes.image.create({ src: base64 });
+                  const tr = ts.replaceSelectionWith(img).scrollIntoView();
+                  view.dispatch(tr);
+                };
+              }, 'image/webp');
+            };
 
-            const formData = new FormData();
-            formData.append('data', file);
-            const opts = { method: 'PUT', body: formData };
-            const resp = await daFetch(url, opts);
-            if (!resp.ok) return;
-            const json = await resp.json();
-
-            // Create a doc image to pre-download the image before showing it.
-            const docImg = document.createElement('img');
-            docImg.addEventListener('load', () => {
-              const fpoSelection = TextSelection.create(view.state.doc, $from.pos - 1, $from.pos);
-              const ts = view.state.tr.setSelection(fpoSelection);
-              const img = schema.nodes.image.create({ src: json.source.contentUrl });
-              const tr = ts.replaceSelectionWith(img).scrollIntoView();
-              view.dispatch(tr);
-            });
-            docImg.src = json.source.contentUrl;
+            image.src = URL.createObjectURL(file);
           });
         },
       },


### PR DESCRIPTION
POC - instead of uploading an image to DA:
- client side convert it to webp
- base 64 inline it in the image tag

Image is then "bundled" into the HTML, which solves all references issues (folder rename, page copy to a different folder...)

Only remaining ugly part is: ideally on preview image is uploaded to media bus (instead of staying an inline base 64).

Test: https://inline--da-live--adobe.aem.live/
Upload an image to document and preview.

