### PR TITLE
chore: add Playwright tests for auth versionlist

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,3 +29,9 @@ jobs:
         name: playwright-report
         path: test/e2e/playwright-report/
         retention-days: 30
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: screenshots
+        path: test/e2e/.playwright/shots/
+        retention-days: 30

--- a/test/e2e/tests/auth.setup.js
+++ b/test/e2e/tests/auth.setup.js
@@ -21,6 +21,8 @@ The ACL tests require to be logged in, which is what this setup does.
 It is assumed to be configured as follows, where the current est user is in IMS org
 907136ED5D35CBF50A495CD4 and in its group DA-Test BUT NOT iN DA-Nonexist.
 
+The configuration in https://da.live/config#/da-testautomation/ should be as follows:
+
   path groups actions
   /acltest/testdocs/doc_readwrite 907136ED5D35CBF50A495CD4/DA-Test write
   /acltest/testdocs/doc_readonly 907136ED5D35CBF50A495CD4 read
@@ -29,6 +31,8 @@ It is assumed to be configured as follows, where the current est user is in IMS 
   /acltest/testdocs/subdir/subdir2/** 907136ED5D35CBF50A495CD4 write
   /acltest/testdocs/subdir/subdir1/+** 907136ED5D35CBF50A495CD4 write
   /acltest/testdocs/subdir/subdir2/subdir3 907136ED5D35CBF50A495CD4 read
+  /acltest/testdocs/dir-readwrite/+** 907136ED5D35CBF50A495CD4/DA-Test write
+  /acltest/testdocs/dir-readonly/+** 907136ED5D35CBF50A495CD4/DA-Test read
 */
 
 // This is executed once to authenticate the user used during the tests.
@@ -47,6 +51,10 @@ setup('Set up authentication', async ({ page }) => {
   const url = ENV;
 
   await page.goto(url);
+  await page.waitForTimeout(3000);
+
+  await fs.promises.mkdir(path.join(__dirname, '../.playwright/shots'), { recursive: true });
+  await page.screenshot({ path: path.join(__dirname, '../.playwright/shots/auth-before.png') });
   await page.getByRole('button', { name: 'Sign in' }).click();
 
   // The IMS sign in page needs a bit of time to load

--- a/test/e2e/tests/authenticated/acl_versions.spec.js
+++ b/test/e2e/tests/authenticated/acl_versions.spec.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { test, expect } from '@playwright/test';
+import ENV from '../../utils/env.js';
+import { getQuery } from '../../utils/page.js';
+
+test('Can read versions of read-write document', async ({ page }) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/dir-readwrite/doc-rw`;
+
+  await page.goto(url);
+  const editor = page.locator('div.ProseMirror');
+  await expect(editor).toHaveText('This is v2');
+
+  await page.getByRole('button', { name: 'Versions' }).click();
+
+  // find v1 and check it
+  await page.getByText('v1').click();
+  await page.locator('li').filter({ hasText: 'v1' }).getByRole('button').click();
+
+  const versionPreview = page.locator('div.da-version-preview > div.ProseMirror > div');
+  await expect(versionPreview).toHaveText('Initial version');
+
+  // check that the restore button is enabled
+  await expect(page.locator('da-editor').getByRole('button', { name: 'Restore' })).toBeEnabled();
+});
+
+test('Cannot read versions of read-only document', async ({ page }) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/dir-readonly/doc-r`;
+
+  await page.goto(url);
+  const editor = page.locator('div.ProseMirror');
+  await expect(editor).toHaveText('We have v2 here');
+
+  await page.getByRole('button', { name: 'Versions' }).click();
+
+  // find v1 and check it
+  await page.getByText('version 1').click();
+  await page.locator('li').filter({ hasText: 'version 1' }).getByRole('button').click();
+
+  const versionPreview = page.locator('div.da-version-preview > div.ProseMirror > div');
+  await expect(versionPreview).toHaveText('We have v1 here');
+
+  // check the restore button is disabled, as it's a readonly page
+  await expect(page.locator('da-editor').getByRole('button', { name: 'Restore' })).toBeDisabled();
+});
+
+test('Cannot access versions of no-access document', async ({ page }) => {
+  const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/dir-noaccess/doc-nope`;
+
+  await page.goto(url);
+
+  // The page should not be visible at all
+  await expect(page.locator('div.ProseMirror')).toHaveCount(0);
+});


### PR DESCRIPTION
## Description

Add playwright tests that exercise versions on protected documents.

Test: https://aclver2-da-live--adobe.aem.live/

## Related Issue

Fixes #590

## How Has This Been Tested?

There _are_ tests.

## Types of changes

Just some new tests.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
