### PR TITLE
Do not let editor insert &nbsp; chars

### DIFF
--- a/blocks/edit/da-editor/da-editor.css
+++ b/blocks/edit/da-editor/da-editor.css
@@ -81,6 +81,7 @@
   border-radius: 10px;
   z-index: 1;
   overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .ProseMirror-focused {


### PR DESCRIPTION
From goog ai:
>Automatic & nbsp ; insertion: Browsers often automatically insert & nbsp ; in certain situations within contenteditable elements, particularly when handling consecutive spaces or spaces at the beginning or end of lines, to ensure visible spacing where a regular space might otherwise collapse. For example, some browsers might convert two consecutive spaces into &nbsp; to prevent them from being treated as a single space.

Applying `white-space: pre-wrap` forces the browser to leave whitespace alone in the editor.

This does have the side-effect of having the browser not wrap lines at hypens in words and in general has slightly different word wrap behavior.

There is a new `white-space-collapse` option currently only available on Firefox that may do exactly what we want (do not insert nbsp for spaces, but also don't mess with how word-wrap works):
`white-space-collapse: break-spaces;`

see https://developer.mozilla.org/en-US/docs/Web/CSS/white-space-collapse#break-spaces