### PR TITLE
Smart Crops: Insert selected smart crop when single crop is selected

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -240,7 +240,7 @@ export async function openAssets() {
 
             const insertTypeSelection = cropSelectorWrapper.querySelector('.da-dialog-asset-structure-select input:checked');
             const structureConfig = !insertTypeSelection || insertTypeSelection.value === 'single' ? null : JSON.parse(decodeURIComponent(insertTypeSelection.value));
-            const fragment = Fragment.fromArray((structureConfig?.crops || ['original']).map((crop) => createImage(cropSelectorList.querySelector(`[data-name="${crop}"] img`)?.src)));
+            const fragment = Fragment.fromArray((structureConfig?.crops || [cropSelectorList.querySelector('.selected')?.innerText] || ['original']).map((crop) => createImage(cropSelectorList.querySelector(`[data-name="${crop}"] img`)?.src)));
             resetCropSelector();
             view.dispatch(state.tr.insert(state.selection.from, fragment)
               .deleteSelection().scrollIntoView());


### PR DESCRIPTION
This PR ensures that a single selected smart crop is being correctly added to the document.

## Description

Single selected smart crops are being added correctly to the document.

## Related Issue
fixes #614

## Motivation and Context

see description

## How Has This Been Tested?

I developed the JS by using the browsers dev tools override mechanism, injecting my adjusted da-assets.js.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
I was not able to run the test locally and there does not seem to be an existing test for that part of da-live. Please advice how to proceed.
