### PR TITLE
Make sure el.content exists

### DIFF
--- a/blocks/edit/prose/plugins/sectionPasteHandler.js
+++ b/blocks/edit/prose/plugins/sectionPasteHandler.js
@@ -114,19 +114,21 @@ export default function sectionPasteHandler(schema) {
           } else {
             const newParaCont = [];
 
-            for (const pc of el.content) {
-              if (pc.type !== 'text') {
-                newParaCont.push(pc);
-              } else if (pc.text.trim() === '---') {
-                closeParagraph(newParaCont, newContent);
+            if (el.content) {
+              for (const pc of el.content) {
+                if (pc.type !== 'text') {
+                  newParaCont.push(pc);
+                } else if (pc.text.trim() === '---') {
+                  closeParagraph(newParaCont, newContent);
 
-                newContent.push({ type: 'horizontal_rule' });
-              } else {
-                newParaCont.push(pc);
+                  newContent.push({ type: 'horizontal_rule' });
+                } else {
+                  newParaCont.push(pc);
+                }
               }
-            }
 
-            closeParagraph(newParaCont, newContent);
+              closeParagraph(newParaCont, newContent);
+            }
           }
         }
 


### PR DESCRIPTION
Sometimes when pasting entire documents from Word, there are empty paragraphs with no content.  This would cause an error:
```
Uncaught TypeError: el.content is not iterable
    at H.transformPasted (sectionPasteHandler.js:117:33)
```

This in turn would bork the pasting and cause base64uploader to not replace data:image src urls.  That in turn would make Edge Delivery fail when attempting to serve the content.