### PR TITLE
use data-name instead of text as it does not work for the Original image

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -240,7 +240,7 @@ export async function openAssets() {
 
             const insertTypeSelection = cropSelectorWrapper.querySelector('.da-dialog-asset-structure-select input:checked');
             const structureConfig = !insertTypeSelection || insertTypeSelection.value === 'single' ? null : JSON.parse(decodeURIComponent(insertTypeSelection.value));
-            const fragment = Fragment.fromArray((structureConfig?.crops || [cropSelectorList.querySelector('.selected')?.innerText] || ['original']).map((crop) => createImage(cropSelectorList.querySelector(`[data-name="${crop}"] img`)?.src)));
+            const fragment = Fragment.fromArray((structureConfig?.crops || [cropSelectorList.querySelector('.selected')?.dataset.name] || ['original']).map((crop) => createImage(cropSelectorList.querySelector(`[data-name="${crop}"] img`)?.src)));
             resetCropSelector();
             view.dispatch(state.tr.insert(state.selection.from, fragment)
               .deleteSelection().scrollIntoView());


### PR DESCRIPTION
Adding the Original image for smart crop did not work as the Label is not an exact match of the rendition name. 

## How Has This Been Tested?

Tested with local browser dev tool overwrite.