### PR TITLE
Do not add a double slash when rest is empty

### DIFF
--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -317,7 +317,7 @@ export default class DaList extends LitElement {
 
         const date = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-');
         const datename = `${item.name}--${date}${item.ext ? `.${item.ext}` : ''}`;
-        item.destination = `/${org}/${site}/.trash/${rest.join('/')}/${datename}`;
+        item.destination = `/${org}/${site}/.trash/${rest.length > 0 ? `${rest.join('/')}/` : ''}${datename}`;
       }
 
       await this.handleItemAction({ item, type });


### PR DESCRIPTION
When deleting from the top level of a folder, the logic calculating the .trash destination was inserting an extra `/`.