### PR TITLE
fix: update Playwright test to conform to current open-tab behaviour

### DIFF
--- a/test/e2e/tests/authenticated/acl_browse.spec.js
+++ b/test/e2e/tests/authenticated/acl_browse.spec.js
@@ -104,12 +104,8 @@ test('Readonly directory with writeable document', async ({ page }) => {
   // Check that the expected delete button is there (but don't click it)
   await expect(page.locator('button.delete-button').locator('visible=true')).toBeVisible();
 
-  // Open the document, this will open an new tab (aka 'popup')
-  const newTabPromise = page.waitForEvent('popup');
   await page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/subdir/subdir2/doc_writeable"]').click();
-  const newTab = await newTabPromise;
-
-  const editor = newTab.locator('div.ProseMirror');
+  const editor = page.locator('div.ProseMirror');
   await expect(editor).toContainText('This is doc_writeable');
   await expect(editor).toHaveAttribute('contenteditable', 'true');
 });


### PR DESCRIPTION
## Description

Update Playwright test to not expect a new tab to be opened but rather expect the re-use of the current tab, as was introduced in #611

This gets all the Playwright tests green again.

Test: https://pwaclf--da-live--adobe.aem.live

## Related Issue

Fixes: #630

## How Has This Been Tested?

This is just an update to the test.

## Types of changes

Just a change to a Playwright test.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
