### PR TITLE
add title to edit block sub-menu buttons to get tooltips on hover

### DIFF
--- a/blocks/edit/prose/plugins/menu/menu.js
+++ b/blocks/edit/prose/plugins/menu/menu.js
@@ -216,21 +216,27 @@ function markItem(markType, options) {
   return cmdItem(toggleMark(markType), passedOptions);
 }
 
-function item(label, cmd, css) {
-  return new MenuItem({ label, select: cmd, run: cmd, class: css });
+function item(label, cmd, css, title) {
+  return new MenuItem({
+    label,
+    title: title || label,
+    select: cmd,
+    run: cmd,
+    class: css,
+  });
 }
 
 function getTableMenu() {
   return [
-    item('Insert column before', addColumnBefore, 'addColBefore'),
-    item('Insert column after', addColumnAfter, 'addColumnAfter'),
-    item('Delete column', deleteColumn, 'deleteColumn'),
-    item('Insert row before', addRowBefore, 'addRowBefore'),
-    item('Insert row after', addRowAfter, 'addRowAfter'),
-    item('Delete row', deleteRow, 'deleteRow'),
-    item('Merge cells', mergeCells, 'mergeCells'),
-    item('Split cell', splitCell, 'splitCell'),
-    item('Delete table', deleteTable, 'deleteTable'),
+    item('Insert column before', addColumnBefore, 'addColBefore', 'Insert column before'),
+    item('Insert column after', addColumnAfter, 'addColumnAfter', 'Insert column after'),
+    item('Delete column', deleteColumn, 'deleteColumn', 'Delete column'),
+    item('Insert row before', addRowBefore, 'addRowBefore', 'Insert row before'),
+    item('Insert row after', addRowAfter, 'addRowAfter', 'Insert row after'),
+    item('Delete row', deleteRow, 'deleteRow', 'Delete row'),
+    item('Merge cells', mergeCells, 'mergeCells', 'Merge cells'),
+    item('Split cell', splitCell, 'splitCell', 'Split cell'),
+    item('Delete table', deleteTable, 'deleteTable', 'Delete table'),
   ];
 }
 
@@ -377,7 +383,7 @@ function getMenu(view) {
       class: 'open-library',
     }),
     new Dropdown(editTable, {
-      title: 'Edit text',
+      title: 'Edit block',
       label: 'Edit block',
       class: 'edit-table',
     }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

add title to edit block sub-menu buttons to get tooltips on hover. also fix title on the edit Block button (was "edit text")

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
