### PR TITLE
test: wait a little on created new pages

### DIFF
--- a/test/e2e/tests/authenticated/acl_browse.spec.js
+++ b/test/e2e/tests/authenticated/acl_browse.spec.js
@@ -52,6 +52,8 @@ test('Read-write directory', async ({ browser, page }, workerInfo) => {
   await page.locator('button:text("Create document")').press(' ');
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
+  // The new page needs a moment to be ready
+  await page.waitForTimeout(2000);
   await page.locator('div.ProseMirror').fill('test writable doc');
   await page.waitForTimeout(3000);
 

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -23,8 +23,7 @@ test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo)
   await expect(page.getByLabel('Open profile menu')).toBeVisible();
   // Wait a little bit so that the collab awareness has caught up and knows that we are logged in as
   // 'DA Testuser'
-  await page.waitForTimeout(1000);
-  await page.reload();
+  await page.waitForTimeout(2000);
 
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -97,6 +97,7 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
 
+  await page.waitForTimeout(2000);
   const enteredText = `Some content entered at ${new Date()}`;
   await page.locator('div.ProseMirror').fill(enteredText);
 
@@ -131,8 +132,8 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await list.locator('sl-button.negative').locator('visible=true').click();
 
   // Give the second window a chance to update itself
-  await list.waitForTimeout(10000);
+  await list.waitForTimeout(5000);
 
   // The open window should be cleared out now
-  await expect(page2.locator('div.ProseMirror')).not.toContainText(enteredText);
+  await expect(page2.locator('div.ProseMirror')).not.toBeVisible();
 });


### PR DESCRIPTION
## Description

A recent change requires a moment before entering text in a brand new document. If you enter text in the first second of the new doc being open this text is discarded. 
This is likely not an issue in practice, but the Playwright tests are quick and now they need to wait a little for their content to be accepted.

This PR makes the Playwright tests green again.

Test url: https://pwfix1--da-live--adobe.aem.live/

## How Has This Been Tested?

These are updates to the tests themselves,

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
