### PR TITLE
Only show link menu when clicking

### DIFF
--- a/blocks/edit/prose/plugins/linkMenu/linkMenu.js
+++ b/blocks/edit/prose/plugins/linkMenu/linkMenu.js
@@ -66,9 +66,9 @@ class LinkMenuView {
 
     this.view = view;
 
-    const { state } = view;
+    const { state, input } = view;
 
-    if (isOnLink(state) && view.input.lastSelectionOrigin === 'pointer') {
+    if (isOnLink(state) && input?.lastSelectionOrigin === 'pointer') {
       const currentOffset = getLinkOffset(state);
 
       if (!this.menu.visible || currentOffset !== this.lastLinkOffset) {


### PR DESCRIPTION
What it says on the tin. Only show the new link menu when navigating through a click.