### PR TITLE
feat: increase backoff time

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -186,12 +186,6 @@ function handleAwarenessUpdates(wsProvider, daTitle, win, path) {
 
   wsProvider.on('status', (st) => { daTitle.collabStatus = st.status; });
 
-  wsProvider.on('connection-error', () => {
-    // if a connection error occurs, increase the max backoff time to 30 seconds
-    // the socket provider will try to reconnect quickly at the beginning
-    // (exponential backoff starting with 100ms) and then every 30s.
-    wsProvider.maxBackoffTime = 30000;
-  });
   wsProvider.on('connection-close', async () => {
     const resp = await checkDoc(path);
     if (resp.status === 404) {
@@ -300,6 +294,12 @@ export default function initProse({ path, permissions }) {
   const canWrite = permissions.some((permission) => permission === 'write');
 
   const wsProvider = new WebsocketProvider(server, roomName, ydoc, opts);
+
+  // Increase the max backoff time to 30 seconds. If connection error occurs,
+  // the socket provider will try to reconnect quickly at the beginning
+  // (exponential backoff starting with 100ms) and then every 30s.
+  wsProvider.maxBackoffTime = 30000;
+
   addSyncedListener(wsProvider, canWrite);
 
   createAwarenessStatusWidget(wsProvider, window, path);


### PR DESCRIPTION
If collab responds with a 500, the websocket provider has logic (see https://github.com/yjs/y-websocket/blob/master/src/y-websocket.js#L158-L168) to retry connecting every 2.5s. (even quicker at the really beginning "exponential backoff starting with 100ms").

For a corrupted document or if collab is really broken and if someone has a document opened in a tab, this means one request every 2.5s.... infinitely. 

My proposal here: increase the backoff time. In the first millis / seconds of the first error, this will have no impact, ws provider will try quickly to reconnect. But on the longer run, it will try only every 30s. This will still allow for the client to recover if collab or underlying problem gets fixed.