### PR TITLE
feat: auto submit form if org and site are provided

### DIFF
--- a/blocks/start/start.css
+++ b/blocks/start/start.css
@@ -162,6 +162,13 @@ div.text-container {
   }
 }
 
+p.error-text {
+  color: #d73220;
+  font-weight: 800;
+  margin: 12px;
+  text-align: center;
+}
+
 div.template-container {
   display: flex;
   justify-content: center;

--- a/blocks/start/start.js
+++ b/blocks/start/start.js
@@ -143,9 +143,16 @@ class DaStart extends LitElement {
     this._loading = true;
     const opts = { method: 'PUT' };
     const resp = await daFetch(e.target.action, opts);
-    if (!resp.ok) return;
-    this.goToNextStep(e);
     this._loading = false;
+    if (!resp.ok) {
+      if (resp.status === 401 || resp.status === 403) {
+        this._errorText = 'You are not authorized to create this site. Check your permissions.';
+      } else {
+        this._errorText = 'The site could not be created. Check the console logs or contact an administrator.';
+      }
+      return;
+    }
+    this.goToNextStep(e);
   }
 
   setTemplate(el) {
@@ -177,6 +184,7 @@ class DaStart extends LitElement {
           </button>
         </form>
         <div class="text-container">
+          <p class="error-text">${this._errorText ? this._errorText : nothing}</p>
           <p>Paste your AEM codebase URL above.</p>
           <p>Don't have one, yet? Pick a template below.</p>
         </div>


### PR DESCRIPTION
When `code-sync` is done, users now end up on `/start`. But first step is useless and they need to click on the Go button. This is not user-friendly. Hitting the Go button fires a request (creates the repo), this needs to happen, that's why a form submit is required (vs going directly on step 2).

I also added some error handling to inform the user if repo could not be created.

Test: http://autogo--da-live--adobe.aem.live/start?org=kptdobe&site=helix-test-v1