### PR TITLE
Focal point table name sanitization

### DIFF
--- a/blocks/edit/prose/plugins/imageFocalPoint.js
+++ b/blocks/edit/prose/plugins/imageFocalPoint.js
@@ -33,7 +33,7 @@ function hasFocalPointData(attrs) {
 function shouldShowFocalPoint(tableName, blocks) {
   if (!tableName || !blocks || blocks.length === 0) return false;
 
-  const tableNameLower = tableName.toLowerCase();
+  const tableNameLower = tableName.toLowerCase().replace(/-/g, ' ');
   return blocks.some((block) => (block.name.toLowerCase() === tableNameLower && block['focal-point'] === 'yes'));
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Remove dashes from block names that use multiple words for names. 
E.g. hero-marquee to hero marquee
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Block names using multiple words seperated by a dash get ignored when enabling the focal point feature on a block.
## How Has This Been Tested?
Browser override feature in dev tools.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
