### PR TITLE
feat: show save button directly when editing configs

### DIFF
--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -278,6 +278,7 @@ export async function getPreviewStatus({ org, site, pathname }) {
     const json = await aemAdmin(path, 'status', 'GET');
     return json.preview.status === 200;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log(`Could not get preview status for ${path}`, err);
     return null;
   }

--- a/blocks/edit/da-title/da-title.css
+++ b/blocks/edit/da-title/da-title.css
@@ -33,6 +33,7 @@ da-dialog {
   line-height: 16px;
   padding: 5px 14px;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .con-button.blue {
@@ -186,12 +187,48 @@ da-dialog {
   background: #EFEFEF;
 }
 
+.da-title-action {
+  display: none;
+}
+
 .da-title-actions.is-open .da-title-action {
   display: unset;
 }
 
-.da-title-action {
-  display: none;
+.da-title-actions.save-only .da-title-action {
+  display: unset;
+  min-height: 44px;
+}
+
+.da-title-actions.save-only .da-title-action:not(.blue) {
+  background: var(--s2-gray-200);
+  border-color: var(--s2-gray-200);
+  color: var(--s2-gray-700);
+  cursor: default;
+}
+
+.da-title-actions.save-only .da-title-action.is-sending {
+  color: transparent;
+  position: relative;
+  overflow: hidden;
+}
+
+.da-title-actions.save-only .da-title-action.is-sending::after {
+  content: '';
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  background: url('/blocks/edit/img/Smock_Send_18_N.svg') center/22px no-repeat;
+  filter: brightness(0) invert(1);
+  animation: animated-background 1s linear infinite;
+}
+
+.da-title-save-disabled-msg {
+  margin: 8px auto;
+  max-width: 900px;
+  color: var(--s2-gray-700);
+  font-size: 12px;
+  font-style: italic;
 }
 
 .da-title-action-send {

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -14,6 +14,16 @@ import getSheet from '../../shared/sheet.js';
 
 const sheet = await getSheet('/blocks/edit/da-title/da-title.css');
 
+function isSaveOnlyView(details) {
+  if (!details) return false;
+  if (details.view === 'config') return true;
+  return details.view === 'sheet' && details.fullpath?.includes('/.da/');
+}
+
+function isHiddenActionsView(details) {
+  return details?.view === 'edit' && details?.fullpath?.includes('/.da/');
+}
+
 const ICONS = [
   '/blocks/edit/img/Smock_Cloud_18_N.svg',
   '/blocks/edit/img/Smock_CloudDisconnected_18_N.svg',
@@ -37,6 +47,8 @@ export default class DaTitle extends LitElement {
     collabUsers: { attribute: false },
     previewPrefix: { attribute: false },
     livePrefix: { attribute: false },
+    hasChanges: { attribute: false },
+    disableMessage: { attribute: false },
     _actionsVis: { state: true },
     _status: { state: true },
     _fixedActions: { state: true },
@@ -46,16 +58,17 @@ export default class DaTitle extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [sheet];
-    this._actionsVis = [];
     inlinesvg({ parent: this.shadowRoot, paths: ICONS });
-    if (this.details.view === 'sheet') {
-      this.collabStatus = window.navigator.onLine
-        ? 'connected'
-        : 'offline';
+  }
 
-      window.addEventListener('online', () => { this.collabStatus = 'connected'; });
-      window.addEventListener('offline', () => { this.collabStatus = 'offline'; });
-    }
+  disconnectedCallback() {
+    this.removeCollabListeners();
+    super.disconnectedCallback();
+  }
+
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    if (changedProperties.has('details')) this.syncDetailsState();
   }
 
   firstUpdated() {
@@ -68,6 +81,7 @@ export default class DaTitle extends LitElement {
   }
 
   handleError(json, action, icon) {
+    // eslint-disable-next-line no-console
     console.log('handleError', json, action, icon);
     this._status = { ...json.error, action };
     icon.classList.remove('is-sending');
@@ -91,26 +105,43 @@ export default class DaTitle extends LitElement {
   }
 
   async handleAction(action) {
+    if (!this.details) return;
     this.toggleActions();
     this._status = null;
-    const sendBtn = this.shadowRoot.querySelector('.da-title-action-send-icon');
-    sendBtn.classList.add('is-sending');
+
+    const sendBtn = this.shadowRoot.querySelector(
+      this.actionView === 'saveOnly' ? '.da-title-action' : '.da-title-action-send-icon',
+    );
+
+    if (sendBtn) {
+      sendBtn.classList.add('is-sending');
+    }
 
     const { hash } = window.location;
     const pathname = hash.replace('#', '');
 
-    // Only save to DA if it is a sheet or config
-    if (this.details.view === 'sheet') {
+    if (this.details.view === 'sheet' && action === 'save') {
       const dasSave = await saveToDa(pathname, this.sheet);
+      if (sendBtn) sendBtn.classList.remove('is-sending');
       if (!dasSave.ok) return;
+      this.hasChanges = false;
+      return;
     }
-    if (this.details.view === 'config') {
+
+    if (this._isConfigView) {
       const daConfigResp = await saveDaConfig(pathname, this.sheet);
+
+      if (sendBtn) {
+        sendBtn.classList.remove('is-sending');
+      }
+
       if (!daConfigResp.ok) {
         // eslint-disable-next-line no-console
         console.log('Saving configuration failed because:', daConfigResp.status, await daConfigResp.text());
-        return;
+      } else {
+        this.dispatchEvent(new Event('config-saved'));
       }
+      return;
     }
     if (action === 'preview' || action === 'publish') {
       const cdn = await getCdnConfig(pathname);
@@ -141,7 +172,7 @@ export default class DaTitle extends LitElement {
       window.open(`${toOpenInAem}?nocache=${Date.now()}`, toOpenInAem);
     }
     if (this.details.view === 'edit' && action === 'publish') saveDaVersion(pathname);
-    sendBtn.classList.remove('is-sending');
+    if (sendBtn) sendBtn.classList.remove('is-sending');
   }
 
   async handleRoleRequest() {
@@ -189,15 +220,13 @@ export default class DaTitle extends LitElement {
   }
 
   async toggleActions() {
-    // toggle off if already on
-    if (this._actionsVis.length > 0) {
-      this._actionsVis = [];
+    if (this.actionView !== 'full') {
       return;
     }
 
-    // toggle on for config
-    if (this.details.view === 'config') {
-      this._actionsVis = ['save'];
+    // toggle off if already on
+    if ((this._actionsVis || []).length > 0) {
+      this._actionsVis = [];
       return;
     }
 
@@ -217,15 +246,85 @@ export default class DaTitle extends LitElement {
     return !this.permissions.some((permission) => permission === 'write');
   }
 
+  get _isConfigView() {
+    return this.details?.view === 'config';
+  }
+
+  get actionView() {
+    if (isHiddenActionsView(this.details)) return 'hidden';
+    if (isSaveOnlyView(this.details)) return 'saveOnly';
+    return 'full';
+  }
+
+  get visibleActions() {
+    if (this.actionView === 'saveOnly') {
+      return ['save'];
+    }
+    return this._actionsVis || [];
+  }
+
+  syncDetailsState() {
+    this._actionsVis = [];
+    this.syncCollabStatus();
+  }
+
+  syncCollabStatus() {
+    this.removeCollabListeners();
+    if (this.details?.view !== 'sheet') {
+      this.collabStatus = undefined;
+      return;
+    }
+
+    this.collabStatus = window.navigator.onLine
+      ? 'connected'
+      : 'offline';
+
+    this._handleOnline = () => { this.collabStatus = 'connected'; };
+    this._handleOffline = () => { this.collabStatus = 'offline'; };
+    window.addEventListener('online', this._handleOnline);
+    window.addEventListener('offline', this._handleOffline);
+  }
+
+  removeCollabListeners() {
+    if (this._handleOnline) {
+      window.removeEventListener('online', this._handleOnline);
+      this._handleOnline = null;
+    }
+    if (this._handleOffline) {
+      window.removeEventListener('offline', this._handleOffline);
+      this._handleOffline = null;
+    }
+  }
+
   renderActions() {
-    return html`${this._actionsVis.map((action) => html`
+    const isDisabled = !!this.disableMessage || (this.actionView === 'saveOnly' && !this.hasChanges);
+    return html`${this.visibleActions.map((action) => html`
       <button
         @click=${() => this.handleAction(action)}
-        class="con-button blue da-title-action"
-        aria-label="Send">
+        class="con-button da-title-action ${isDisabled ? '' : 'blue'}"
+        aria-label="${action}"
+        ?disabled=${isDisabled}>
         ${action.charAt(0).toUpperCase() + action.slice(1)}
       </button>
     `)}`;
+  }
+
+  renderActionControls() {
+    if (this.actionView === 'hidden') return nothing;
+
+    return html`
+      <div class="da-title-actions ${this._fixedActions ? 'is-fixed' : ''} ${this.actionView === 'full' && this._actionsVis?.length > 0 ? 'is-open' : ''} ${this.actionView === 'saveOnly' ? 'save-only' : ''}">
+        ${this.renderActions()}
+        ${this.actionView === 'saveOnly' ? nothing : html`
+          <button
+            @click=${this.toggleActions}
+            class="con-button blue da-title-action-send"
+            aria-label="Send">
+            <span class="da-title-action-send-icon"></span>
+          </button>
+        `}
+      </div>
+    `;
   }
 
   popover({ target }) {
@@ -279,6 +378,8 @@ export default class DaTitle extends LitElement {
   }
 
   render() {
+    if (!this.details) return nothing;
+
     return html`
       <div class="da-title-inner ${this._readOnly ? 'is-read-only' : ''}">
         <div class="da-title-name">
@@ -290,17 +391,12 @@ export default class DaTitle extends LitElement {
         <div class="da-title-collab-actions-wrapper">
           ${this.collabStatus ? this.renderCollab() : nothing}
           ${this._status ? this.renderError() : nothing}
-          <div class="da-title-actions ${this._fixedActions ? 'is-fixed' : ''} ${this._actionsVis.length > 0 ? 'is-open' : ''}">
-            ${this.renderActions()}
-            <button
-              @click=${this.toggleActions}
-              class="con-button blue da-title-action-send"
-              aria-label="Send">
-              <span class="da-title-action-send-icon"></span>
-            </button>
-          </div>
+          ${this.renderActionControls()}
         </div>
       </div>
+      ${this.disableMessage
+    ? html`<p class="da-title-save-disabled-msg">${this.disableMessage}</p>`
+    : nothing}
       ${this._dialog ? this.renderDialog() : nothing}
     `;
   }

--- a/blocks/shared/da-dialog/da-dialog.css
+++ b/blocks/shared/da-dialog/da-dialog.css
@@ -63,6 +63,13 @@ svg.icon {
     justify-content: space-between;
     align-items: center;
     gap: 12px;
+
+    .da-dialog-footer-right {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
+    }
   
     .da-dialog-footer-message {
       font-style: italic;

--- a/blocks/shared/da-dialog/da-dialog.js
+++ b/blocks/shared/da-dialog/da-dialog.js
@@ -56,7 +56,7 @@ export default class DaDialog extends LitElement {
     return {
       label: 'OK',
       style: 'accent',
-      onClick: this.close(),
+      click: () => this.close(),
     };
   }
 
@@ -93,11 +93,13 @@ export default class DaDialog extends LitElement {
               <slot name="footer-left"></slot>
               <p class="da-dialog-footer-message">${this.message || nothing}</p>
             </div>
-            <slot name="footer-right">
-              <sl-button class="${this._action.style}" @click=${this._action.click} ?disabled=${this._action.disabled}>
-                ${this._action.label}
-              </sl-button>
-            </slot>
+            <div class="da-dialog-footer-right" part="footer-right">
+              <slot name="footer-right">
+                <sl-button class="${this._action.style}" @click=${this._action.click} ?disabled=${this._action.disabled}>
+                  ${this._action.label}
+                </sl-button>
+              </slot>
+            </div>
           </div>
         </div>
       </sl-dialog>

--- a/blocks/sheet/sheet.js
+++ b/blocks/sheet/sheet.js
@@ -3,11 +3,14 @@ import getPathDetails from '../shared/pathDetails.js';
 import { getNx } from '../../scripts/utils.js';
 import '../edit/da-title/da-title.js';
 import { getData } from './utils/index.js';
+import { createConfigStaleMonitor, fetchConfigState } from './utils/config-stale.js';
+import { SHEET_DIRTY_EVENT } from './utils/utils.js';
 
 const { default: getStyle } = await import(`${getNx()}/utils/styles.js`);
 
 const style = await getStyle('/blocks/sheet/da-sheet-panes.css');
-
+const DISABLE_MESSAGE = 'Saving is disabled until the config has been refreshed. If you have unsaved changes that you want to preserve, you can copy them and merge them after refreshing the config.';
+const STALE_DIALOG_MESSAGE = 'The config has been updated. Please refresh to get the latest changes, or ignore to keep your existing edits.';
 class DaSheetPanes extends LitElement {
   static properties = {
     data: { type: Object },
@@ -112,6 +115,103 @@ class DaSheetPanes extends LitElement {
 customElements.define('da-sheet-panes', DaSheetPanes);
 
 let initSheet;
+let configStaleMonitor;
+let staleDialog;
+let staleAbortController;
+
+function removeConfigStaleDialog() {
+  staleDialog?.remove();
+  staleDialog = undefined;
+}
+
+function clearConfigStaleState(daTitle) {
+  daTitle.disableMessage = undefined;
+  removeConfigStaleDialog();
+  staleAbortController?.abort();
+  staleAbortController = undefined;
+}
+
+function stopConfigStaleMonitor() {
+  configStaleMonitor?.stop();
+  configStaleMonitor = undefined;
+}
+
+async function refreshConfigSheet(details, daTitle, daSheet) {
+  const freshData = await getData(details.sourceUrl);
+  daTitle.sheet = await initSheet(daSheet, freshData);
+}
+
+async function showConfigStaleDialog(daTitle, details, daSheet) {
+  removeConfigStaleDialog();
+  await import('../shared/da-dialog/da-dialog.js');
+
+  const dialog = document.createElement('da-dialog');
+  dialog.title = 'Config Updated';
+
+  const content = document.createElement('p');
+  content.textContent = STALE_DIALOG_MESSAGE;
+  dialog.appendChild(content);
+
+  let refreshed = false;
+
+  // treat x, close, escape as ignore
+  dialog.addEventListener('close', () => {
+    if (!refreshed) {
+      daTitle.disableMessage = DISABLE_MESSAGE;
+      configStaleMonitor?.ignore();
+    }
+    removeConfigStaleDialog();
+  });
+
+  const ignoreBtn = document.createElement('sl-button');
+  ignoreBtn.className = 'primary outline';
+  ignoreBtn.textContent = 'Ignore';
+  ignoreBtn.slot = 'footer-right';
+  ignoreBtn.addEventListener('click', () => { dialog.close(); });
+
+  const refreshBtn = document.createElement('sl-button');
+  refreshBtn.className = 'accent';
+  refreshBtn.textContent = 'Refresh';
+  refreshBtn.slot = 'footer-right';
+  refreshBtn.addEventListener('click', async () => {
+    refreshed = true;
+    daTitle.disableMessage = undefined;
+    daTitle.hasChanges = false;
+    await refreshConfigSheet(details, daTitle, daSheet);
+    await configStaleMonitor?.refresh();
+    dialog.close();
+  });
+
+  dialog.appendChild(ignoreBtn);
+  dialog.appendChild(refreshBtn);
+
+  document.body.appendChild(dialog);
+  staleDialog = dialog;
+}
+
+async function configureConfigStaleMonitor(details, daTitle, daSheet) {
+  stopConfigStaleMonitor();
+  clearConfigStaleState(daTitle);
+
+  if (details.view !== 'config') return;
+
+  staleAbortController = new AbortController();
+  const { signal } = staleAbortController;
+
+  const getConfigState = () => fetchConfigState(details.sourceUrl);
+  configStaleMonitor = createConfigStaleMonitor({
+    getConfigState,
+    onStale: () => {
+      showConfigStaleDialog(daTitle, details, daSheet);
+    },
+  });
+
+  daTitle.addEventListener('config-saved', async () => {
+    await configStaleMonitor?.syncBaseline();
+  }, { signal });
+
+  await configStaleMonitor.start();
+}
 
 async function setSheet(details, daTitle, daSheet) {
   daTitle.details = details;
@@ -119,6 +219,7 @@ async function setSheet(details, daTitle, daSheet) {
 
   if (!initSheet) initSheet = (await import('./utils/index.js')).default;
   daTitle.sheet = await initSheet(daSheet);
+  await configureConfigStaleMonitor(details, daTitle, daSheet);
 }
 
 export default async function init(el) {
@@ -148,14 +249,18 @@ export default async function init(el) {
   const versionWrapper = document.createElement('div');
   versionWrapper.classList.add('da-version-wrapper');
   versionWrapper.append(wrapper, daSheetPanes);
+  document.addEventListener(SHEET_DIRTY_EVENT, () => { daTitle.hasChanges = true; });
+  daTitle.addEventListener('config-saved', () => { daTitle.hasChanges = false; });
+
+  el.append(daTitle, versionWrapper);
 
   // Set data against the title & sheet
   setSheet(details, daTitle, daSheet);
 
-  el.append(daTitle, versionWrapper);
-
   window.addEventListener('hashchange', async () => {
+    stopConfigStaleMonitor();
     details = getPathDetails();
+    if (!details) return;
     setSheet(details, daTitle, daSheet);
     daSheetPanes.pathDetails = details;
   });

--- a/blocks/sheet/utils/config-stale.js
+++ b/blocks/sheet/utils/config-stale.js
@@ -1,0 +1,78 @@
+import { daFetch } from '../../shared/utils.js';
+
+export async function fetchConfigState(url) {
+  const resp = await daFetch(url);
+  if (!resp.ok) return null;
+  return JSON.stringify(await resp.json());
+}
+
+export function createConfigStaleMonitor({
+  getConfigState,
+  onStale,
+  intervalMs = 30000,
+  schedule = setInterval,
+  unschedule = clearInterval,
+}) {
+  let baseline;
+  let intervalId;
+  let ignored = false;
+
+  const stop = () => {
+    if (intervalId) {
+      unschedule(intervalId);
+      intervalId = undefined;
+    }
+  };
+
+  const check = async () => {
+    if (ignored) return false;
+
+    const latest = await getConfigState();
+    if (latest === null) return false;
+
+    if (baseline === undefined || baseline === null) {
+      baseline = latest;
+      return false;
+    }
+
+    if (latest !== baseline) {
+      stop();
+      onStale?.();
+      return true;
+    }
+
+    return false;
+  };
+
+  const start = async () => {
+    ignored = false;
+    stop();
+    baseline = await getConfigState();
+    intervalId = schedule(() => {
+      check();
+    }, intervalMs);
+  };
+
+  const ignore = () => {
+    ignored = true;
+    stop();
+  };
+
+  const refresh = async () => {
+    ignored = false;
+    await start();
+  };
+
+  const syncBaseline = async () => {
+    baseline = await getConfigState();
+  };
+
+  return {
+    check,
+    ignore,
+    refresh,
+    start,
+    stop,
+    syncBaseline,
+  };
+}

--- a/blocks/sheet/utils/utils.js
+++ b/blocks/sheet/utils/utils.js
@@ -1,6 +1,7 @@
 import { convertSheets, debounce, saveToDa } from '../../edit/utils/helpers.js';
 
 const DEBOUNCE_TIME = 1000;
+export const SHEET_DIRTY_EVENT = 'sheet-dirty';
 
 export const saveSheets = async (sheets) => {
   document.querySelector('da-sheet-panes').data = convertSheets(sheets);
@@ -19,7 +20,13 @@ export const saveSheets = async (sheets) => {
 const debouncedSaveSheets = debounce(saveSheets, DEBOUNCE_TIME);
 
 export function handleSave(jexcel, view) {
-  if (view !== 'config') {
-    debouncedSaveSheets(jexcel);
+  const daTitle = document.querySelector('da-title');
+  const isDotDaSheet = view === 'sheet' && daTitle?.details?.fullpath?.includes('/.da/');
+
+  if (view === 'config' || isDotDaSheet) {
+    document.dispatchEvent(new Event(SHEET_DIRTY_EVENT));
+    return;
   }
+
+  debouncedSaveSheets(jexcel);
 }

--- a/test/unit/blocks/edit/da-title/da-title.test.js
+++ b/test/unit/blocks/edit/da-title/da-title.test.js
@@ -1,0 +1,93 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+import DaTitle from '../../../../../blocks/edit/da-title/da-title.js';
+
+const nextFrame = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+const DISABLE_MESSAGE = 'Saving is disabled until the config has been refreshed. If you have unsaved changes that you want to preserve, you can copy them and merge them after refreshing the config.';
+
+function createDetails(view, fullpath = '/org/repo/path') {
+  return {
+    view,
+    fullpath,
+    sourceUrl: 'https://da.live/config/org/repo',
+    parent: '/org/repo',
+    parentName: 'repo',
+    name: 'path',
+  };
+}
+
+describe('da-title', () => {
+  let element;
+
+  before(() => {
+    setNx('/test/fixtures/nx', { hostname: 'example.com' });
+  });
+
+  afterEach(() => {
+    element?.remove();
+    element = null;
+  });
+
+  it('uses internal action mode for hidden, save-only, and full views', async () => {
+    element = new DaTitle();
+    document.body.append(element);
+
+    element.details = createDetails('edit', '/org/repo/.da/config.json');
+    await nextFrame();
+    expect(element.actionView).to.equal('hidden');
+    expect(element.shadowRoot.querySelector('.da-title-action-send')).to.not.exist;
+
+    element.details = createDetails('sheet', '/org/repo/data');
+    await nextFrame();
+    expect(element.actionView).to.equal('full');
+    expect(element.shadowRoot.querySelector('.da-title-action-send')).to.exist;
+
+    element.details = createDetails('sheet', '/org/repo/.da/data');
+    await nextFrame();
+    expect(element.actionView).to.equal('saveOnly');
+    expect(element.visibleActions).to.deep.equal(['save']);
+    expect(element.shadowRoot.querySelector('.da-title-action-send')).to.not.exist;
+
+    element.details = createDetails('config', '/org/repo/config');
+    await nextFrame();
+    expect(element.actionView).to.equal('saveOnly');
+    expect(element.visibleActions).to.deep.equal(['save']);
+    expect(element.shadowRoot.querySelector('.da-title-action-send')).to.not.exist;
+  });
+
+  it('renders disable message as an external override reason', async () => {
+    element = new DaTitle();
+    element.details = createDetails('config');
+    element.hasChanges = true;
+    element.disableMessage = DISABLE_MESSAGE;
+    document.body.append(element);
+    await nextFrame();
+
+    const saveButton = element.shadowRoot.querySelector('.da-title-action');
+    const disabledMessage = element.shadowRoot.querySelector('.da-title-save-disabled-msg');
+
+    expect(saveButton).to.exist;
+    expect(saveButton.disabled).to.equal(true);
+    expect(disabledMessage).to.exist;
+    expect(disabledMessage.textContent.trim()).to.equal(DISABLE_MESSAGE);
+  });
+
+  it('keeps save-only actions disabled until there are changes', async () => {
+    element = new DaTitle();
+    element.details = createDetails('config');
+    document.body.append(element);
+    await nextFrame();
+
+    let saveButton = element.shadowRoot.querySelector('.da-title-action');
+    expect(saveButton).to.exist;
+    expect(saveButton.disabled).to.equal(true);
+    expect(saveButton.classList.contains('blue')).to.equal(false);
+
+    element.hasChanges = true;
+    await nextFrame();
+
+    saveButton = element.shadowRoot.querySelector('.da-title-action');
+    expect(saveButton.disabled).to.equal(false);
+    expect(saveButton.classList.contains('blue')).to.equal(true);
+  });
+});

--- a/test/unit/blocks/sheet/utils/config-stale.test.js
+++ b/test/unit/blocks/sheet/utils/config-stale.test.js
@@ -1,0 +1,79 @@
+import { expect } from '@esm-bundle/chai';
+import { createConfigStaleMonitor } from '../../../../../blocks/sheet/utils/config-stale.js';
+
+describe('config stale monitor', () => {
+  it('detects stale config when state changes', async () => {
+    const states = ['old', 'new'];
+    let staleCount = 0;
+
+    const monitor = createConfigStaleMonitor({
+      getConfigState: async () => states[0],
+      onStale: () => { staleCount += 1; },
+      schedule: () => 1,
+      unschedule: () => {},
+    });
+
+    await monitor.start();
+    states.shift();
+
+    const isStale = await monitor.check();
+    expect(isStale).to.equal(true);
+    expect(staleCount).to.equal(1);
+  });
+
+  it('suppresses repeated stale prompts after ignore', async () => {
+    let staleCount = 0;
+
+    const monitor = createConfigStaleMonitor({
+      getConfigState: async () => 'new',
+      onStale: () => { staleCount += 1; },
+      schedule: () => 1,
+      unschedule: () => {},
+    });
+
+    await monitor.start();
+    monitor.ignore();
+    await monitor.check();
+
+    expect(staleCount).to.equal(0);
+  });
+
+  it('refresh clears ignore state and restarts detection', async () => {
+    const states = ['old', 'new', 'new', 'latest'];
+    let staleCount = 0;
+
+    const monitor = createConfigStaleMonitor({
+      getConfigState: async () => states.shift(),
+      onStale: () => { staleCount += 1; },
+      schedule: () => 1,
+      unschedule: () => {},
+    });
+
+    await monitor.start();
+    await monitor.check();
+    expect(staleCount).to.equal(1);
+
+    monitor.ignore();
+    await monitor.refresh();
+
+    const isStale = await monitor.check();
+    expect(isStale).to.equal(true);
+    expect(staleCount).to.equal(2);
+  });
+
+  it('clears scheduled interval on stop', async () => {
+    let clearedId;
+
+    const monitor = createConfigStaleMonitor({
+      getConfigState: async () => 'state',
+      onStale: () => {},
+      schedule: () => 27,
+      unschedule: (id) => { clearedId = id; },
+    });
+
+    await monitor.start();
+    monitor.stop();
+
+    expect(clearedId).to.equal(27);
+  });
+});


### PR DESCRIPTION
## Summary

- Refines `da-title` action behavior by context: hides actions for docs under `/.da/` and allows save only for configs
- Adds config staleness detection with polling and a modal prompt when remote config changes are detected during editing. User can choose to ignore or refresh

**Other changes:**
- Updates the buttons in the component to have a pointer cursor to indicate they're clickable

## Related Issue

Fixes #704 

## How Has This Been Tested?

Tested on locally and on https://i704--da-live--usman-khalid.aem.page

## Screenshots (if appropriate):
<img width="1344" height="571" alt="image" src="https://github.com/user-attachments/assets/e9acb233-69f0-42a1-bf1a-3287ef2d1f5f" />
<img width="1327" height="819" alt="image" src="https://github.com/user-attachments/assets/f9677d12-6c2f-476b-90df-1c844addfd81" />
<img width="1030" height="823" alt="image" src="https://github.com/user-attachments/assets/a843acdd-11d8-4d4d-8e39-21790898f438" />


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
