### PR TITLE
perf: parallelize HEAD request and WebSocket connection on document load

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -1,14 +1,41 @@
+import { Y, WebsocketProvider } from 'da-y-wrapper';
 import getPathDetails from '../shared/pathDetails.js';
-import { daFetch } from '../shared/utils.js';
+import { daFetch, getAuthToken } from '../shared/utils.js';
+import { COLLAB_ORIGIN, DA_ORIGIN } from '../shared/constants.js';
 
 import './da-title/da-title.js';
 import './da-content/da-content.js';
 
+let prosePromise;
 let prose;
-let proseEl;
-let wsProvider;
 
-export async function checkDoc(path) {
+async function createConnection(path) {
+  const ydoc = new Y.Doc();
+
+  const server = COLLAB_ORIGIN;
+  const roomName = `${DA_ORIGIN}${new URL(path).pathname}`;
+
+  const opts = {
+    protocols: ['yjs'],
+    connect: true,
+  };
+
+  const token = await getAuthToken();
+  if (token) {
+    opts.protocols.push(token);
+  }
+
+  const provider = new WebsocketProvider(server, roomName, ydoc, opts);
+
+  // Increase the max backoff time to 30 seconds. If connection error occurs,
+  // the socket provider will try to reconnect quickly at the beginning
+  // (exponential backoff starting with 100ms) and then every 30s.
+  provider.maxBackoffTime = 30000;
+
+  return { wsProvider: provider, ydoc };
+}
+
+async function checkDoc(path) {
   return daFetch(path, { method: 'HEAD' });
 }
 
@@ -20,52 +47,65 @@ async function createDoc(path) {
   return daFetch(path, opts);
 }
 
+function initArea(areaName, details, el) {
+  let areaEl = document.querySelector(areaName);
+  if (!areaEl) {
+    areaEl = document.createElement(areaName);
+    areaEl.details = details;
+    el.append(areaEl);
+  } else {
+    areaEl.details = details;
+  }
+  return areaEl;
+}
+
 async function setUI(el) {
   const details = getPathDetails();
   if (!details) return;
 
+  // Start HEAD check and WebSocket connection in parallel
+  const headPromise = checkDoc(details.sourceUrl);
+  const wsPromise = createConnection(details.sourceUrl);
+
   document.title = `Edit ${details.name} - DA`;
 
-  // Title area
-  let daTitle = document.querySelector('da-title');
-  if (!daTitle) {
-    daTitle = document.createElement('da-title');
-    daTitle.details = details;
-    el.append(daTitle);
-  } else {
-    daTitle.details = details;
+  if (!prosePromise) {
+    prosePromise = import('./prose/index.js');
   }
+
+  const daTitle = initArea('da-title', details, el);
 
   // Lazily load prose after the title has been added to DOM.
-  if (!prose) prose = await import('./prose/index.js');
+  if (!prose) prose = await prosePromise;
 
-  // Content area
-  let daContent = document.querySelector('da-content');
-  if (!daContent) {
-    daContent = document.createElement('da-content');
-    daContent.details = details;
-    el.append(daContent);
-  } else {
-    daContent.details = details;
-  }
-
-  let resp = await checkDoc(details.sourceUrl);
-  if (resp.status === 404) resp = await createDoc(details.sourceUrl);
-
-  const { permissions } = resp;
-
-  daTitle.permissions = resp.permissions;
-  daContent.permissions = resp.permissions;
+  const daContent = initArea('da-content', details, el);
 
   if (daContent.wsProvider) {
     daContent.wsProvider.disconnect({ data: 'Client navigation' });
     daContent.wsProvider = undefined;
   }
 
-  ({
+  const resp = await headPromise;
+
+  let permissions;
+  if (resp.status === 404) {
+    const createResp = await createDoc(details.sourceUrl);
+    permissions = createResp.permissions;
+  } else {
+    permissions = resp.permissions;
+  }
+
+  daTitle.permissions = permissions;
+  daContent.permissions = permissions;
+
+  const {
     proseEl,
     wsProvider,
-  } = prose.default({ path: details.sourceUrl, permissions }));
+  } = await prose.default({
+    path: details.sourceUrl,
+    permissions,
+    wsPromise,
+  });
 
   daContent.proseEl = proseEl;
   daContent.wsProvider = wsProvider;

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -21,16 +21,23 @@ export async function initIms() {
   }
 }
 
+export async function getAuthToken() {
+  if (!localStorage.getItem('nx-ims')) {
+    return null;
+  }
+  const ims = await initIms();
+  return ims?.accessToken?.token || null;
+}
+
 export const daFetch = async (url, opts = {}) => {
   opts.headers = opts.headers || {};
-  let accessToken;
-  if (localStorage.getItem('nx-ims')) {
-    ({ accessToken } = await initIms());
+  const accessToken = await getAuthToken();
+  if (accessToken) {
     const canToken = ALLOWED_TOKEN.some((origin) => new URL(url).origin === origin);
-    if (accessToken && canToken) {
-      opts.headers.Authorization = `Bearer ${accessToken.token}`;
+    if (canToken) {
+      opts.headers.Authorization = `Bearer ${accessToken}`;
       if (AEM_ORIGINS.some((origin) => new URL(url).origin === origin)) {
-        opts.headers['x-content-source-authorization'] = `Bearer ${accessToken.token}`;
+        opts.headers['x-content-source-authorization'] = `Bearer ${accessToken}`;
       }
     }
   }


### PR DESCRIPTION
Starts HEAD check, and WebSocket in parallel.
Start prose module import slightly sooner.

(LCP calculated as avg of 10 tries)

Before LCP: 1.10
https://main--da-live--adobe.aem.live/edit#/aem-sandbox/block-collection/drafts/ccc/main

After LCP 0.75
https://parrcon--da-live--adobe.aem.live/edit#/aem-sandbox/block-collection/drafts/ccc/main