### PR TITLE
fix: wrong status call

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -544,10 +544,8 @@ class DaLibrary extends LitElement {
       try {
         const itemUrl = new URL(getUrl(item));
         path = itemUrl.pathname;
-        if (itemUrl.origin.includes('--')) {
-          const [org, site] = getEdsUrlVars(getUrl(item));
-          path = `/${org}/${site}${itemUrl.pathname}`;
-        }
+        const [org, site] = getEdsUrlVars(getUrl(item));
+        path = `/${org}/${site}${itemUrl.pathname}`;
       } catch {
         item.error = 'Please use a fully qualified url for your library';
       }


### PR DESCRIPTION
We see a lot of 404 going to urls like https://admin.hlx.page/status/source/doe-app-svc/main/da-global/docs/library/templates/transition-to-primary-school

Note the `/status/source` which is an invalid API call. The fix is removing the wrong check, the check is done in the `getEdsUrlVars`.

This is the "preview status check" introduced https://github.com/adobe/da-live/pull/512. Not sure why this is useful... 

