### PR TITLE
fix: support da admin source urls in library

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -544,6 +544,13 @@ class DaLibrary extends LitElement {
       try {
         const itemUrl = new URL(getUrl(item));
         path = itemUrl.pathname;
+
+        // DA Admin Flavored URLs
+        if (itemUrl.origin.endsWith('admin.da.live') && path.startsWith('/source')) {
+          path = path.replace('/source', '');
+        }
+
+        // AEM Flavored URLs
         if (itemUrl.origin.includes('--')) {
           const [org, site] = getEdsUrlVars(getUrl(item));
           path = `/${org}/${site}${itemUrl.pathname}`;


### PR DESCRIPTION
DA Flavored URLs are `admin.da.live/source`. The `/source` part was not being properly removeed.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
