### PR TITLE
fix(da-library): typo in error message for block preview

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -386,7 +386,7 @@ class DaLibrary extends LitElement {
           data-src="${this._blockPreviewPath}"
           src="${this._blockPreviewPath}"
           @load=${this.handlePreviewLoad}
-          allow="clipboard-write *"></iframe>` : html`<div style="margin: 0 24px">${error || 'This block / template has not been previewed.'}</div>`}
+          allow="clipboard-write *"></iframe>` : html`<div style="margin: 0 24px">${error || 'This block/template has not been previewed.'}</div>`}
       </da-dialog>
     `;
   }


### PR DESCRIPTION
https://www.grammarly.com/blog/punctuation-capitalization/slash/#:~:text=When%20a,alternatives%20between

