### PR TITLE
check for asset status and approval target only when author repository is configured

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -86,6 +86,7 @@ export async function openAssets() {
 
   const { owner, repo } = getPathDetails();
   const repoId = await getConfKey(owner, repo, 'aem.repositoryId');
+  const isAuthorRepo = repoId?.startsWith('author');
 
   // Custom publicly available asset origin
   let prodOrigin = await getConfKey(owner, repo, 'aem.assets.prod.origin');
@@ -171,7 +172,9 @@ export async function openAssets() {
           return state.schema.nodes.image.create(imgObj);
         };
 
-        if (dmDeliveryEnabled && activationTarget !== 'delivery' && status !== 'approved') {
+        // Only show the error message if the asset is not approved for delivery
+        // and the repository is an author repository
+        if (dmDeliveryEnabled && isAuthorRepo && activationTarget !== 'delivery' && status !== 'approved') {
           assetSelectorWrapper.style.display = 'none';
           cropSelectorWrapper.style.display = 'block';
           cropSelectorWrapper.innerHTML = '<p class="da-dialog-asset-error">The selected asset is not available because it is not approved for delivery. Please check the status.</p><div class="da-dialog-asset-buttons"><button class="back">Back</button><button class="cancel">Cancel</button></div>';


### PR DESCRIPTION

## Description

The asset JSON response doesn't include `asset._embedded.['http://ns.adobe.com/adobecloud/rel/metadata/asset'] ` when the `delivery-` repository is selected. This has to be checked only for `author-` repository to ensure that the selected image is approved and the Approval Target is set to `delivery`.

## Related Issue

#765 

## Motivation and Context

evidentscientific client couldn't select the images in the asset picker from the delivery repository

## How Has This Been Tested?

I have overwritten the **da-assets.js** from Chrome dev tools and selected an image from the delivery repository and validated that it is being copied to the document in DA

## Screenshots (if appropriate):
<img width="1268" height="1355" alt="Screenshot 2026-02-04 at 4 43 15 PM" src="https://github.com/user-attachments/assets/326e0120-aac5-4b60-ad92-dbae0f09d795" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
