### PR TITLE
Fix: Unitests by adding da.live to nx hostname allowlist 

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -47,7 +47,8 @@ export const [setNx, getNx] = (() => {
   return [
     (nxBase, location) => {
       nx = (() => {
-        const { search } = location || window.location;
+        const { hostname, search } = location || window.location;
+        if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local') || hostname.includes('da.live'))) return nxBase;
         const branch = sanitizeName(new URLSearchParams(search).get('nx'), false) || 'main';
         if (branch === 'local') return 'http://localhost:6456/nx';
         return `https://${branch}--da-nx--adobe.aem.live/nx`;

--- a/test/unit/scripts/utils.test.js
+++ b/test/unit/scripts/utils.test.js
@@ -3,21 +3,26 @@ import { setNx, sanitizePath, sanitizePathParts, sanitizeName } from '../../../s
 
 describe('Libs', () => {
   it('Default Libs', () => {
-    const location = {
-      hostname: 'da.live',
-      search: '',
-    };
-    const libs = setNx('/nx', location);
+    const libs = setNx('/nx');
     expect(libs).to.equal('https://main--da-nx--adobe.aem.live/nx');
   });
 
-  it('Supports NX query param on any domain', () => {
+  it('Supports NX query param on da.live', () => {
     const location = {
-      hostname: 'business.adobe.com',
+      hostname: 'da.live',
       search: '?nx=foo',
     };
     const libs = setNx('/nx', location);
     expect(libs).to.equal('https://foo--da-nx--adobe.aem.live/nx');
+  });
+
+  it('Returns nxBase for non-whitelisted domains (test fixtures)', () => {
+    const location = {
+      hostname: 'example.com',
+      search: '?nx=foo',
+    };
+    const libs = setNx('/test/fixtures/nx', location);
+    expect(libs).to.equal('/test/fixtures/nx');
   });
 
   it('Supports NX query param', () => {


### PR DESCRIPTION
## Fix: Add da.live to nx hostname allowlist

### Summary
Adds `da.live` to the allowed domains for the `?nx=` query parameter.

### Changes
- Added `da.live` to hostname allowlist in `setNx()` function
- Updated test: "Supports NX query param on da.live"
- Added test: "Returns nxBase for non-whitelisted domains (test fixtures)"

### Why
PR #767 removed the hostname check entirely, which broke test fixtures that rely on non-whitelisted domains returning `nxBase`. This fix adds `da.live` to the allowlist while preserving the test infrastructure.

### Test Results
- All 23 utils tests passing
- All 294 total tests passing
- `?nx=local` and `?nx=branch-name` now work on https://da.live/