### PR TITLE
fix: convert underscores to hyphens only in name

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -11,31 +11,34 @@
  */
 export const codeBase = `${import.meta.url.replace('/scripts/utils.js', '')}`;
 
-export function sanitizeName(name, preserveDots = true) {
+export function sanitizeName(name, preserveDots = true, allowUnderscores = true) {
   if (!name) return null;
 
   if (preserveDots && name.indexOf('.') !== -1) {
     return name
       .split('.')
-      .map((part) => sanitizeName(part))
+      .map((part) => sanitizeName(part, true, allowUnderscores))
       .join('.');
   }
+
+  const pattern = allowUnderscores ? /[^a-z0-9_]+/g : /[^a-z0-9]+/g;
 
   return name
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9_]+/g, '-')
+    .replace(pattern, '-')
     .replace(/-$/g, '');
 }
 
 export function sanitizePathParts(path) {
-  return path.slice(1)
+  const parts = path.slice(1)
     .toLowerCase()
-    .split('/')
-    .map((name) => (name ? sanitizeName(name) : ''))
+    .split('/');
+  return parts
+    .map((name, i) => (name ? sanitizeName(name, true, i < parts.length - 1) : ''))
     // remove path traversal parts, and empty strings unless at the end
-    .filter((name, i, parts) => !/^[.]{1,2}$/.test(name) && (name !== '' || i === parts.length - 1));
+    .filter((name, i, filtered) => !/^[.]{1,2}$/.test(name) && (name !== '' || i === filtered.length - 1));
 }
 
 export function sanitizePath(path) {

--- a/test/unit/scripts/utils.test.js
+++ b/test/unit/scripts/utils.test.js
@@ -141,10 +141,16 @@ describe('Libs', () => {
       expect(parts).to.deep.equal(['-folder', '-file']);
     });
 
-    it('Retains underscores', () => {
+    it('Retains underscores in folder segments', () => {
       const path = '/my_folder/file';
       const parts = sanitizePathParts(path);
       expect(parts).to.deep.equal(['my_folder', 'file']);
+    });
+
+    it('Strips underscores from last segment', () => {
+      const path = '/my_folder/My_file';
+      const parts = sanitizePathParts(path);
+      expect(parts).to.deep.equal(['my_folder', 'my-file']);
     });
   });
 });


### PR DESCRIPTION
Prevent names from having underscores as this is not allowed in Edge Delivery.

## Description
Helix allows underscores in paths, but not in names (the last segment of a path). This restores the previous functionality before we centralized sanitization.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

E2E & Unit Tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
