### PR TITLE
fix: enable AEM Assets content advisor

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -8,7 +8,7 @@ const { loadStyle } = await import(`${getNx()}/scripts/nexter.js`);
 const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
 const loadScript = (await import(`${getNx()}/utils/script.js`)).default;
 
-const ASSET_SELECTOR_URL = 'https://experience.adobe.com/solutions/CQ-assets-selectors/assets/resources/assets-selectors.js';
+const ASSET_SELECTOR_URL = 'https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/assets-selectors.js';
 
 const fullConfJsons = {};
 const CONFS = {};
@@ -146,6 +146,7 @@ export async function openAssets() {
       imsToken: details.accessToken.token,
       repositoryId: repoId,
       aemTierType,
+      featureSet: ['upload', 'collections', 'detail-panel', 'advisor'],
       onClose: () => assetSelectorWrapper.style.display !== 'none' && dialog.close(),
       handleSelection: async (assets) => {
         const [asset] = assets;


### PR DESCRIPTION
Fix: #788 

* Use new Asset Selector / Content Advisor JS
* enable content advisor via feature set, make sure to keep the default features (upload, details, collections) of the old asset picker as well