### PR TITLE
fix: Rename Table to Block in slashmenu

### DIFF
--- a/blocks/edit/prose/plugins/menu/menu.js
+++ b/blocks/edit/prose/plugins/menu/menu.js
@@ -236,7 +236,7 @@ function getTableMenu() {
     tableItem('Delete row', deleteRow, 'deleteRow'),
     tableItem('Merge cells', mergeCells, 'mergeCells'),
     tableItem('Split cell', splitCell, 'splitCell'),
-    tableItem('Delete table', deleteTable, 'deleteTable'),
+    tableItem('Delete block', deleteTable, 'deleteTable'),
   ];
 }
 

--- a/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
+++ b/blocks/edit/prose/plugins/slashMenu/slashMenuItems.js
@@ -81,7 +81,7 @@ const items = [
     argument: true,
   },
   {
-    title: 'Table',
+    title: 'Block',
     command: insertTable,
     class: 'insert-table',
     excludeFromTable: true,


### PR DESCRIPTION
Fix: #786

Also rename references in the code.  Note that "table" is still used in the schema and internally by prosemirror.  Those use cases are being left as table.  Block is used when referenced by the menus.
