### PR TITLE
video url fixed when author repo is configured

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -125,7 +125,7 @@ export async function openAssets() {
     if (!dmDeliveryEnabled) {
       return `https://${prodOrigin}${asset.path}`;
     }
-    return `${getBaseDmUrl(asset)}/as/${name}`;
+    return `${getBaseDmUrl(asset)}/original/as/${name}`;
   };
 
   // Determine if images should be links


### PR DESCRIPTION


## Description

The videos that are selected from the asset selector are broken when the author repo is configured where DM OpenAPI is enabled. The generated video link should have '/original/as' instead of '/as' for it to work.

## Related Issue

#802 

## Motivation and Context

The e-Luscious team couldn't author the videos due to this bug.

## How Has This Been Tested?

Overrode the `da-assets.js` file from the Chrome Dev Tools and tested if the video links are generated correctly.

## Screenshots (if appropriate):

<img width="1156" height="627" alt="Screenshot 2026-02-20 at 1 10 41 PM" src="https://github.com/user-attachments/assets/911c9644-ab57-464d-b635-be1a1ec6ca80" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
