### PR TITLE
Remove '/original/' from image paths to support smart crop. Keep it f…

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -125,7 +125,7 @@ export async function openAssets() {
     if (!dmDeliveryEnabled) {
       return `https://${prodOrigin}${asset.path}`;
     }
-    return `${getBaseDmUrl(asset)}/original/as/${name}`;
+    return `${getBaseDmUrl(asset)}${asset.mimetype?.startsWith('video/') ? '/original' : ''}/as/${name}`;
   };
 
   // Determine if images should be links


### PR DESCRIPTION
## Description

With https://github.com/adobe/da-live/commit/c0d346c0b5d9e47e632aa34e77a2c702ee9e62a1 we added `/original/` to paths to make videos work. Unfortunately the paths are not consistent with smartcrop and therefore we need to distinguish between image assets and videos. 

## How Has This Been Tested?

Overwrite via Dev Tools.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
