### PR TITLE
fix: prevent dialog/fullsize-dialog plugins from closing immediately after page load

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -3,7 +3,6 @@ import { DOMParser as proseDOMParser, DOMSerializer, TextSelection } from 'da-y-
 import {
   LitElement,
   html,
-  render,
   until,
   createRef,
   ref,
@@ -60,8 +59,9 @@ class DaLibrary extends LitElement {
     _libraryDetails: { state: true },
     _searchStr: { state: true },
     _blockPreviewPath: { state: true },
-    _previewItemName: { Type: String },
-    _previewStatus: { Type: Object },
+    _previewItemName: { state: true },
+    _previewStatus: { state: true },
+    _activeDialogPlugin: { state: true },
   };
 
   constructor() {
@@ -93,17 +93,28 @@ class DaLibrary extends LitElement {
     import('../../shared/da-dialog/da-dialog.js');
   }
 
+  updated(changedProperties) {
+    if (changedProperties.has('_activeDialogPlugin') && this._activeDialogPlugin) {
+      const selector = this._activeDialogPlugin.experience === 'fullsize-dialog'
+        ? '.da-fs-dialog-plugin'
+        : '.da-dialog-plugin';
+      this.shadowRoot.querySelector(selector)?.showModal();
+    }
+  }
+
   handleKeydown(e) {
     if (e.key === 'Escape') closeLibrary();
   }
 
   handleModalClose() {
-    this.shadowRoot.querySelector('.da-dialog-plugin').close();
+    this.shadowRoot.querySelector('.da-dialog-plugin')?.close();
+    this._activeDialogPlugin = null;
     closeLibrary();
   }
 
   handleFullsizeModalClose() {
-    this.shadowRoot.querySelector('.da-fs-dialog-plugin').close();
+    this.shadowRoot.querySelector('.da-fs-dialog-plugin')?.close();
+    this._activeDialogPlugin = null;
     closeLibrary();
   }
 
@@ -114,51 +125,8 @@ class DaLibrary extends LitElement {
       return;
     }
 
-    if (library.experience === 'dialog') {
-      let dialog = this.shadowRoot.querySelector('.da-dialog-plugin');
-      if (dialog) dialog.remove();
-
-      dialog = html`
-        <dialog class="da-dialog-plugin">
-          <div class="da-dialog-header">
-            <div class="da-dialog-header-title">
-              <img src="${library.icon}" />
-              <p>${library.title || library.name}</p>
-            </div>
-            <button class="primary" @click=${this.handleModalClose}>Close</button>
-          </div>
-          ${this.renderPlugin(library, true)}
-        </dialog>
-      `;
-
-      render(dialog, this.shadowRoot);
-
-      this.shadowRoot.querySelector('.da-dialog-plugin').showModal();
-
-      return;
-    }
-
-    if (library.experience === 'fullsize-dialog') {
-      let dialog = this.shadowRoot.querySelector('.da-dialog-plugin');
-      if (dialog) dialog.remove();
-
-      dialog = html`
-        <dialog class="da-fs-dialog-plugin">
-          <div class="da-dialog-header">
-            <div class="da-dialog-header-title">
-              <img src="${library.icon}" />
-              <p>${library.title || library.name}</p>
-            </div>
-            <button class="primary" @click=${this.handleFullsizeModalClose}>Close</button>
-          </div>
-          ${this.renderPlugin(library, true)}
-        </dialog>
-      `;
-
-      render(dialog, this.shadowRoot);
-
-      this.shadowRoot.querySelector('.da-fs-dialog-plugin').showModal();
-
+    if (library.experience === 'dialog' || library.experience === 'fullsize-dialog') {
+      this._activeDialogPlugin = library;
       return;
     }
 
@@ -620,6 +588,28 @@ class DaLibrary extends LitElement {
     return html`${name}`;
   }
 
+  renderActiveDialog() {
+    const library = this._activeDialogPlugin;
+    const isFullsize = library.experience === 'fullsize-dialog';
+    const className = isFullsize ? 'da-fs-dialog-plugin' : 'da-dialog-plugin';
+    const closeHandler = isFullsize
+      ? this.handleFullsizeModalClose
+      : this.handleModalClose;
+
+    return html`
+      <dialog class="${className}">
+        <div class="da-dialog-header">
+          <div class="da-dialog-header-title">
+            <img src="${library.icon}" />
+            <p>${library.title || library.name}</p>
+          </div>
+          <button class="primary" @click=${closeHandler}>Close</button>
+        </div>
+        ${this.renderPlugin(library, true)}
+      </dialog>
+    `;
+  }
+
   renderMainMenu() {
     return html`
       <ul class="da-library-item-list da-library-item-list-main">
@@ -675,6 +665,7 @@ class DaLibrary extends LitElement {
       <div class="da-library-preview">
         ${this._blockPreviewPath ? this.renderPreview() : nothing}
       </div>
+      ${this._activeDialogPlugin ? this.renderActiveDialog() : nothing}
     `;
   }
 


### PR DESCRIPTION
## Description
Opening a dialog or fullsize-dialog plugin within the first ~2-3 seconds of page load causes it to appear briefly then close on its own.

`handleLibSwitch` used standalone `render()` into the shadow root, which conflicted with LitElement's own rendering. Async re-renders (e.g. from `checkPreviewStatus`) overwrote the dialog, closing it. Fixed by rendering the dialog through LitElement's reactive cycle instead.

## How Has This Been Tested?

Tested on localhost, https://library--da-live--usman-khalid.aem.page/ and with browser override on da.live

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
