### PR TITLE
feat: use new sidekick action to bust cache

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -138,7 +138,13 @@ export default class DaTitle extends LitElement {
         toOpenInAem = `${origin}${path}`;
       }
 
-      window.open(`${toOpenInAem}?nocache=${Date.now()}`, toOpenInAem);
+      // Tell AEM Sidekick to bust cache
+      await window.chrome.runtime.sendMessage(
+        'igkmdomcgoebiipaifhmpfjhbjccggml',
+        { action: 'bustCache', host: new URL(toOpenInAem).hostname },
+      );
+
+      window.open(toOpenInAem, toOpenInAem);
     }
     if (this.details.view === 'edit' && action === 'publish') saveDaVersion(pathname);
     sendBtn.classList.remove('is-sending');


### PR DESCRIPTION
Instead of appending a `nocache` param, use the new sidekick action `bustCache` to circumvent browser cache on the next (re)load. This will also be applied to sub requests like nav, footer, fragments etc and lead to a better author experience.

Depends on https://github.com/adobe/aem-sidekick/pull/809