### PR TITLE
fix: Add padding to not have buttons overlap content

### DIFF
--- a/blocks/edit/prose/diff/diff-utils.css
+++ b/blocks/edit/prose/diff/diff-utils.css
@@ -39,6 +39,7 @@ da-loc-added,
   min-height: 100px;
   background: #fff;
   overflow: clip;
+  padding-bottom: 35px;
 }
 
 .diff-tab-pane {


### PR DESCRIPTION
Before:

<img width="850" height="167" alt="Screenshot 2026-03-13 at 4 41 59 PM" src="https://github.com/user-attachments/assets/aec24791-4042-4da1-972d-080f0d9027f4" />

After:

<img width="862" height="215" alt="Screenshot 2026-03-13 at 4 41 42 PM" src="https://github.com/user-attachments/assets/a65cdddc-6d12-454b-8954-557bef8866b7" />

