### PR TITLE
feat: use new sidekick action to bust cache

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -148,11 +148,10 @@ export default class DaTitle extends LitElement {
       } catch (e) {
         // Non-chromium browser or AEM Sidekick not found
       }
-      if (!cacheBustedBySidekick) {
-        // Fall back to cache-busting query parameter
-        toOpenInAem = `${toOpenInAem}?nocache=${Date.now()}`;
-      }
-      window.open(toOpenInAem, toOpenInAem);
+      window.open(
+        cacheBustedBySidekick ? toOpenInAem : `${toOpenInAem}?nocache=${Date.now()}`,
+        toOpenInAem,
+      );
     }
     if (this.details.view === 'edit' && action === 'publish') saveDaVersion(pathname);
     sendBtn.classList.remove('is-sending');


### PR DESCRIPTION
Instead of appending a `nocache` param, use the new sidekick action `bustCache` to circumvent browser cache on the next (re)load. This will also be applied to sub requests like nav, footer, fragments etc and lead to a better author experience.

See https://github.com/adobe/aem-sidekick/pull/809

Fixes #844