### PR TITLE
fix: restore editor.hidePublish in da-title

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -7,7 +7,7 @@ import {
   saveDaVersion,
   getAemHrefs,
 } from '../utils/helpers.js';
-import { delay, fetchDaConfigs } from '../../shared/utils.js';
+import { delay, fetchDaConfigs, getFirstSheet } from '../../shared/utils.js';
 import inlinesvg from '../../shared/inlinesvg.js';
 import getSheet from '../../shared/sheet.js';
 
@@ -100,7 +100,8 @@ export default class DaTitle extends LitElement {
     ]);
 
     const { org, site, path, fullpath } = this.details;
-    this._configs = await fetchDaConfigs({ org, site });
+    const configs = await Promise.all(fetchDaConfigs({ org, site }));
+    this._configs = configs.flatMap((config) => getFirstSheet(config) || []);
 
     this._actions.available = await this.getAvailableActions();
     this.requestUpdate();


### PR DESCRIPTION
## Description

With #847, `da-title` started reading config data via `fetchDaConfigs()`, but it was no longer resolving the returned config promises into sheet rows which stopped respecting the `editor.hidePublish` property.

## How Has This Been Tested?

- Tested on localhost and https://hideonpub--da-live--usman-khalid.aem.page/edit#/usman-khalid/stage-site/collaboration

## Screenshots (if appropriate):
<img width="1006" height="159" alt="image" src="https://github.com/user-attachments/assets/2b846317-e30c-4de6-95cb-8160440cd771" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
