### PR TITLE
feat: Ask Sidekick to bust cache

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -13,6 +13,7 @@ import getSheet from '../../shared/sheet.js';
 
 const sheet = await getSheet('/blocks/edit/da-title/da-title.css');
 
+const SK_EXT_ID = 'igkmdomcgoebiipaifhmpfjhbjccggml';
 const LAZY_DELAY = 1500;
 const ICONS = [
   '/blocks/edit/img/Smock_Cloud_18_N.svg',
@@ -180,6 +181,24 @@ export default class DaTitle extends LitElement {
     });
   }
 
+  /**
+   * Attempt to have Sidekick bust the author's cache
+   * @param {String} toOpen the href to open
+   * @returns {Promise<void>}
+   */
+  async sidekickCacheBust(toOpen) {
+    if (!window.chrome) return;
+    try {
+      const opts = { action: 'bustCache', host: new URL(toOpen).hostname };
+      const extId = window.localStorage.getItem('aem-sidekick-id') || SK_EXT_ID;
+
+      // Tell AEM Sidekick to bust cache
+      await window.chrome.runtime.sendMessage(extId, opts);
+    } catch {
+      // Gracefully die
+    }
+  }
+
   async handleAction(action) {
     this._status = null;
     this._sendButton.classList.add('is-sending');
@@ -247,8 +266,10 @@ export default class DaTitle extends LitElement {
         const origin = action === 'publish' ? this.livePrefix : this.previewPrefix;
         toOpen = `${origin}${byoPath}`;
       }
+      // Attempt a Sidekick cache bust
+      await this.sidekickCacheBust(toOpen);
 
-      window.open(`${toOpen}?nocache=${Date.now()}`, toOpen);
+      window.open(toOpen, toOpen);
     }
 
     if (view === 'edit') {


### PR DESCRIPTION
* Early returns if `window.chrome` object does not exist
* Tries to fire Chrome runtime message for the extension ID
* Supports Extension ID override for local development
* Removes all traces of `?nocache=` for all use cases (no ext, FF, safari)

Resolves: #844

## Motivation and Context

SK will now force requests to not use the browser's cache.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
