### PR TITLE
Show error when it is not approved and activation target is set to something other than delivery

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -105,7 +105,7 @@ export function buildHandleSelection(
     // Author+DM mode: check asset is approved for delivery before inserting
     if (repoConfig.tierType === 'author' && repoConfig.isDmEnabled) {
       const { status, activationTarget } = getDmApprovalStatus(asset);
-      if (activationTarget !== 'delivery' || status !== 'approved') {
+      if (status !== 'approved' || (activationTarget && activationTarget !== 'delivery')) {
         showSecondaryPanel(assetPanel, secondaryPanel);
         showErrorPanel(secondaryPanel, resetToAssetPanel, closeAndReset);
         return;

--- a/test/unit/blocks/edit/da-assets/da-assets.test.js
+++ b/test/unit/blocks/edit/da-assets/da-assets.test.js
@@ -374,6 +374,18 @@ describe('buildHandleSelection', () => {
     expect(secondaryPanel.querySelector('.da-dialog-asset-error')).to.exist;
   });
 
+  it('allows approved asset with undefined activationTarget in author+DM mode', async () => {
+    window.fetch = async () => ({ ok: true, json: async () => ({ items: [] }) });
+    const { dialog, secondaryPanel, handler } = setup({ ...AUTHOR_DM_CONFIG, isSmartCrop: false });
+    const noTarget = {
+      ...IMAGE_ASSET,
+      _embedded: { 'http://ns.adobe.com/adobecloud/rel/metadata/asset': { 'dam:assetStatus': 'approved' } },
+    };
+    await handler([noTarget]);
+    expect(dialog.isOpen).to.be.false;
+    expect(secondaryPanel.querySelector('.da-dialog-asset-error')).to.not.exist;
+  });
+
   it('does NOT show error panel for approved+delivery asset in author+DM mode', async () => {
     window.fetch = async () => ({ ok: true, json: async () => ({ items: [] }) });
     const { secondaryPanel, handler } = setup({ ...AUTHOR_DM_CONFIG, isSmartCrop: false });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Show an error when it is not approved, and the activation target is set to something other than delivery, since the asset is available on delivery when the status is approved, and activationTarget is not available in the metadata

## Related Issue

#842 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
