### PR TITLE
fix: support webp images

### DIFF
--- a/blocks/edit/prose/plugins/imageDrop.js
+++ b/blocks/edit/prose/plugins/imageDrop.js
@@ -4,7 +4,7 @@ import getPathDetails from '../../../shared/pathDetails.js';
 import { daFetch } from '../../../shared/utils.js';
 
 const FPO_IMG_URL = '/blocks/edit/img/fpo.svg';
-const SUPPORTED_FILES = ['image/svg+xml', 'image/png', 'image/jpeg', 'image/gif'];
+const SUPPORTED_FILES = ['image/svg+xml', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 
 export default function imageDrop(schema) {
   return new Plugin({

--- a/blocks/shared/constants.js
+++ b/blocks/shared/constants.js
@@ -11,6 +11,7 @@ export const SUPPORTED_FILES = {
   pdf: 'application/pdf',
   svg: 'image/svg+xml',
   ico: 'image/x-icon',
+  webp: 'image/webp',
 };
 
 const DA_ADMIN_ENVS = {


### PR DESCRIPTION
Add drag and drop support for webp files. We recently enabled previewing of `webp` in helix-admin. 

I wasn't able to run da.live locally (kept getting redirected to `/not-found`) so I might have missed something.

As far as I could see there were no existing tests for this. If I missed them let me know.

https://github.com/adobe/helix-admin/pull/3549
