### PR TITLE
feat: Ask user if they want to normalize spaces

### DIFF
--- a/blocks/edit/prose/plugins/sectionPasteHandler.js
+++ b/blocks/edit/prose/plugins/sectionPasteHandler.js
@@ -1,5 +1,8 @@
 import { Fragment, Plugin, Slice } from 'da-y-wrapper';
 
+// Non-global regex for detection only
+const NONSTANDARD_SPACE_DETECT = /[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/;
+// Global regex for replacement
 const NONSTANDARD_SPACES_RE = /[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/g;
 
 function normalizeSpaceChars(str) {
@@ -21,7 +24,45 @@ function normalizeSpacesInJSON(obj) {
   return obj;
 }
 
-let normalizeSpacesOnPaste = false;
+function showSpaceNormalizationDialog(view, slice, schema) {
+  import('../../../shared/da-dialog/da-dialog.js').then(() => {
+    const dialog = document.createElement('da-dialog');
+    dialog.title = 'Non-standard spaces detected';
+    dialog.size = 'small';
+
+    const content = document.createElement('p');
+    content.textContent = 'The pasted content contains non-standard space characters (such as non-breaking spaces). Would you like to convert them to regular spaces?';
+    dialog.appendChild(content);
+
+    dialog.action = {
+      label: 'Normalize spaces',
+      style: 'accent',
+      click: () => {
+        const rawJson = slice.toJSON();
+        const normalized = normalizeSpacesInJSON(rawJson);
+        const normalizedSlice = Slice.fromJSON(schema, normalized);
+        view.dispatch(view.state.tr.replaceSelection(normalizedSlice));
+        dialog.close();
+      },
+    };
+
+    const pasteAsIsBtn = document.createElement('sl-button');
+    pasteAsIsBtn.className = 'primary outline';
+    pasteAsIsBtn.textContent = 'Paste as-is';
+    pasteAsIsBtn.slot = 'footer-left';
+    pasteAsIsBtn.addEventListener('click', () => {
+      view.dispatch(view.state.tr.replaceSelection(slice));
+      dialog.close();
+    });
+    dialog.appendChild(pasteAsIsBtn);
+
+    dialog.addEventListener('close', () => {
+      dialog.remove();
+    });
+
+    document.body.appendChild(dialog);
+  });
+}
 
 function closeParagraph(paraContent, newContent) {
   if (paraContent.length > 0) {
@@ -124,17 +165,18 @@ function handleDivLineBreaks(doc) {
 export default function sectionPasteHandler(schema) {
   return new Plugin({
     props: {
-      handleKeyDown: (view, event) => {
-        if (event.code === 'KeyV' && event.shiftKey && (event.metaKey || event.ctrlKey)) {
-          // Shift-Cmd-V is "Paste and Match Style" and will also normalize spaces
-          normalizeSpacesOnPaste = true;
+      handlePaste: (view, event, slice) => {
+        const text = event.clipboardData?.getData('text/plain') || '';
+        const html = event.clipboardData?.getData('text/html') || '';
+        if (NONSTANDARD_SPACE_DETECT.test(text) || NONSTANDARD_SPACE_DETECT.test(html)) {
+          showSpaceNormalizationDialog(view, slice, schema);
+          return true;
         }
         return false;
       },
 
       clipboardTextParser: (text) => {
-        const normalized = normalizeSpacesOnPaste ? normalizeSpaceChars(text) : text;
-        const lines = normalized.split(/\r\n?|\n/);
+        const lines = text.split(/\r\n?|\n/);
         const nodes = lines.map((line) => {
           if (line.length === 0) return schema.nodes.paragraph.create();
           return schema.nodes.paragraph.create(null, [schema.text(line)]);
@@ -146,11 +188,10 @@ export default function sectionPasteHandler(schema) {
        * buried in the HTML that is pasted. This function uses highly specific ways to find
        * these section breaks and adds a <hr/> element for them.
        */
-      transformPastedHTML: (html) => {
-        const inputHtml = normalizeSpacesOnPaste ? normalizeSpaceChars(html) : html;
+      transformPastedHTML: (pastedHtml) => {
         try {
           const parser = new DOMParser();
-          const doc = parser.parseFromString(inputHtml, 'text/html');
+          const doc = parser.parseFromString(pastedHtml, 'text/html');
 
           let modified = handleDesktopWordSectionBreaks(doc);
           if (!modified) {
@@ -161,7 +202,7 @@ export default function sectionPasteHandler(schema) {
           }
 
           if (!modified) {
-            return inputHtml;
+            return pastedHtml;
           }
 
           const serializer = new XMLSerializer();
@@ -169,7 +210,7 @@ export default function sectionPasteHandler(schema) {
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error handling Word section breaks:', error);
-          return inputHtml;
+          return pastedHtml;
         }
       },
 
@@ -177,9 +218,7 @@ export default function sectionPasteHandler(schema) {
        * which is then interpreted as a section break.
        */
       transformPasted: (slice) => {
-        const rawJson = slice.toJSON();
-        const jslice = normalizeSpacesOnPaste ? normalizeSpacesInJSON(rawJson) : rawJson;
-        normalizeSpacesOnPaste = false;
+        const jslice = slice.toJSON();
         if (!jslice) return slice;
         const { content } = jslice;
         if (!content) return slice;

--- a/test/unit/blocks/edit/prose/plugins/sectionPasteHandler.test.js
+++ b/test/unit/blocks/edit/prose/plugins/sectionPasteHandler.test.js
@@ -377,125 +377,63 @@ describe('Section paste handler', () => {
   });
 });
 
-describe('Shift-Cmd/Ctrl-V space normalization', () => {
-  // normalizeSpacesOnPaste is module-level, so consume it after tests that set
-  // it without going through the full clipboardTextParser → transformPasted pipeline.
-  function resetNormalizeFlag() {
-    const p = sectionPasteHandler(baseSchema);
-    p.props.transformPasted(Slice.fromJSON(baseSchema, {
-      content: [{ type: 'paragraph' }], openStart: 1, openEnd: 1,
-    }));
+describe('Non-standard space detection on paste', () => {
+  function mockEvent(text = '', html = '') {
+    return {
+      clipboardData: {
+        getData: (type) => {
+          if (type === 'text/plain') return text;
+          if (type === 'text/html') return html;
+          return '';
+        },
+      },
+    };
   }
 
-  it('handleKeyDown returns false for Shift-Cmd-V to allow native paste', () => {
+  const dummySlice = Slice.fromJSON(baseSchema, {
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'test' }] }],
+    openStart: 1,
+    openEnd: 1,
+  });
+
+  it('handlePaste returns false when no non-standard spaces in text', () => {
     const plugin = sectionPasteHandler(baseSchema);
-    const result = plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, metaKey: true });
+    const result = plugin.props.handlePaste({}, mockEvent('hello world'), dummySlice);
     expect(result).to.be.false;
-    resetNormalizeFlag();
   });
 
-  it('handleKeyDown returns false for Shift-Ctrl-V to allow native paste', () => {
+  it('handlePaste returns true when NBSP found in plain text', () => {
     const plugin = sectionPasteHandler(baseSchema);
-    const result = plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, ctrlKey: true });
+    const result = plugin.props.handlePaste({}, mockEvent('hello\u00A0world'), dummySlice);
+    expect(result).to.be.true;
+  });
+
+  it('handlePaste returns true when non-standard space found in HTML', () => {
+    const plugin = sectionPasteHandler(baseSchema);
+    const result = plugin.props.handlePaste(
+      {},
+      mockEvent('hello world', '<p>hello\u2003world</p>'),
+      dummySlice,
+    );
+    expect(result).to.be.true;
+  });
+
+  it('handlePaste detects all non-standard Unicode space types', () => {
+    const plugin = sectionPasteHandler(baseSchema);
+    const spaces = [
+      '\u00A0', '\u1680', '\u2000', '\u2001', '\u2002', '\u2003',
+      '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009',
+      '\u200A', '\u202F', '\u205F', '\u3000',
+    ];
+    spaces.forEach((sp) => {
+      const result = plugin.props.handlePaste({}, mockEvent(`a${sp}b`), dummySlice);
+      expect(result).to.be.true;
+    });
+  });
+
+  it('handlePaste returns false when event has no clipboardData', () => {
+    const plugin = sectionPasteHandler(baseSchema);
+    const result = plugin.props.handlePaste({}, {}, dummySlice);
     expect(result).to.be.false;
-    resetNormalizeFlag();
-  });
-
-  it('handleKeyDown does not set flag for plain Cmd-V', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: false, metaKey: true });
-    const slice = plugin.props.clipboardTextParser('hello\u00A0world');
-    expect(slice.content.toJSON()[0].content[0].text).to.equal('hello\u00A0world');
-  });
-
-  it('clipboardTextParser normalizes NBSP and narrow no-break space after Shift-Cmd-V', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, metaKey: true });
-    const slice = plugin.props.clipboardTextParser('a\u00A0b\u202Fc');
-    expect(slice.content.toJSON()[0].content[0].text).to.equal('a b c');
-    resetNormalizeFlag();
-  });
-
-  it('clipboardTextParser normalizes all non-standard Unicode space types after Shift-Cmd-V', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, metaKey: true });
-    // One of each: Ogham, en quad, em quad, en, em, 3/em, 4/em, 6/em, figure, punctuation, thin, hair, medium math, ideographic
-    const input = 'a\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u205F\u3000b';
-    const slice = plugin.props.clipboardTextParser(input);
-    expect(slice.content.toJSON()[0].content[0].text).to.equal('a              b');
-    resetNormalizeFlag();
-  });
-
-  it('clipboardTextParser preserves non-standard spaces on regular Cmd-V', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    const slice = plugin.props.clipboardTextParser('hello\u00A0world');
-    expect(slice.content.toJSON()[0].content[0].text).to.equal('hello\u00A0world');
-  });
-
-  it('clipboardTextParser normalizes spaces via Shift-Ctrl-V (Windows)', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, ctrlKey: true });
-    const slice = plugin.props.clipboardTextParser('hello\u00A0world');
-    expect(slice.content.toJSON()[0].content[0].text).to.equal('hello world');
-    resetNormalizeFlag();
-  });
-
-  it('transformPastedHTML normalizes non-standard spaces in text content after Shift-Cmd-V', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, metaKey: true });
-    const result = plugin.props.transformPastedHTML('<p>hello\u00A0world\u202Ftest</p>');
-    expect(result).to.contain('hello world test');
-    expect(result).not.to.contain('\u00A0');
-    expect(result).not.to.contain('\u202F');
-    resetNormalizeFlag();
-  });
-
-  it('transformPastedHTML preserves non-standard spaces on regular paste', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    const result = plugin.props.transformPastedHTML('<p>hello\u00A0world</p>');
-    expect(result).to.contain('hello\u00A0world');
-  });
-
-  it('transformPasted normalizes non-standard spaces in text nodes after Shift-Cmd-V', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, metaKey: true });
-    const slice = Slice.fromJSON(baseSchema, {
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello\u00A0world\u202Ftest' }] }],
-      openStart: 1,
-      openEnd: 1,
-    });
-    const result = plugin.props.transformPasted(slice);
-    expect(result.content.toJSON()[0].content[0].text).to.equal('hello world test');
-  });
-
-  it('transformPasted preserves non-standard spaces on regular paste', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    const slice = Slice.fromJSON(baseSchema, {
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello\u00A0world' }] }],
-      openStart: 1,
-      openEnd: 1,
-    });
-    const result = plugin.props.transformPasted(slice);
-    expect(result.content.toJSON()[0].content[0].text).to.equal('hello\u00A0world');
-  });
-
-  it('transformPasted resets flag so subsequent paste is not normalized', () => {
-    const plugin = sectionPasteHandler(baseSchema);
-    plugin.props.handleKeyDown({}, { code: 'KeyV', shiftKey: true, metaKey: true });
-
-    // First paste consumes the flag
-    plugin.props.transformPasted(Slice.fromJSON(baseSchema, {
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'x' }] }],
-      openStart: 1,
-      openEnd: 1,
-    }));
-
-    // Second paste — flag must be reset, spaces must be preserved
-    const result = plugin.props.transformPasted(Slice.fromJSON(baseSchema, {
-      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello\u00A0world' }] }],
-      openStart: 1,
-      openEnd: 1,
-    }));
-    expect(result.content.toJSON()[0].content[0].text).to.equal('hello\u00A0world');
   });
 });


### PR DESCRIPTION
When content is pasted into da that contains non-standard Unicode space characters (U+00A0, U+202F, U+2000–U+200A,
U+1680, U+205F, U+3000), a dialog will ask the user if they would like to convert those to regular spaces or keep as is.

<img width="343" height="301" alt="Screenshot 2026-03-31 at 3 38 56 PM" src="https://github.com/user-attachments/assets/eae57795-fc1e-4757-8424-6a7c29dfdcac" />

https://sp-paste--da-live--adobe.aem.live/edit#/aem-sandbox/block-collection/drafts/ccc/test