### PR TITLE
make the preview dialog respect our ref pattern for DA library

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -230,10 +230,10 @@ class DaLibrary extends LitElement {
   }
 
   async handleOpenPreview(item) {
-    const { org, site, pathname } = getItemDetails(item);
+    const { org, site, ref, pathname } = getItemDetails(item);
     this._preview = {
       name: item.name || item.key,
-      url: `https://main--${site}--${org}.aem.page${pathname}`,
+      url: `https://${ref}--${site}--${org}.aem.page${pathname}`,
     };
 
     // Lazily get the preview status

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -6,7 +6,7 @@ import getSheet from '../../shared/sheet.js';
 import inlinesvg from '../../shared/inlinesvg.js';
 import { daFetch } from '../../shared/utils.js';
 import searchFor from './helpers/search.js';
-import { OOTB_PLUGINS, loadLibrary, getItemDetails, getPreviewStatus } from './helpers/helpers.js';
+import { OOTB_PLUGINS, loadLibrary, getItemDetails, getPreviewStatus, ref } from './helpers/helpers.js';
 
 const sheet = await getSheet('/blocks/edit/da-library/da-library.css');
 const buttons = await getSheet(`${getNx()}/styles/buttons.css`);
@@ -230,7 +230,7 @@ class DaLibrary extends LitElement {
   }
 
   async handleOpenPreview(item) {
-    const { org, site, ref, pathname } = getItemDetails(item);
+    const { org, site, pathname } = getItemDetails(item);
     this._preview = {
       name: item.name || item.key,
       url: `https://${ref}--${site}--${org}.aem.page${pathname}`,

--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -205,11 +205,11 @@ export function getPreviewUrl(previewUrl) {
     if (url.origin.includes('--')) return url.href;
     if (url.origin.includes('content.da.live')) {
       const [, org, site, ...split] = url.pathname.split('/');
-      return `https://main--${site}--${org}.aem.page/${split.join('/')}`;
+      return `https://${ref}--${site}--${org}.aem.page/${split.join('/')}`;
     }
     if (url.origin.includes('admin.da.live')) {
       const [, , org, site, ...split] = url.pathname.split('/');
-      return `https://main--${site}--${org}.aem.page/${split.join('/')}`;
+      return `https://${ref}--${site}--${org}.aem.page/${split.join('/')}`;
     }
   } catch {
     return false;
@@ -257,17 +257,17 @@ export function getItemDetails(item) {
 
   // AEM Flavor
   if (hostname.includes('.aem.')) {
-    const [org, site] = hostname.split('.')[0].split('--').reverse();
-    return { org, site, pathname };
+    const [org, site, urlRef] = hostname.split('.')[0].split('--').reverse();
+    return { org, site, ref: urlRef || ref, pathname };
   }
   // DA Content Flavor
   if (hostname.includes('content.da.live')) {
     const [org, site, ...rest] = pathname.slice(1).split('/');
-    return { org, site, pathname: `/${rest.join('/')}` };
+    return { org, site, ref, pathname: `/${rest.join('/')}` };
   }
   // DA Admin Flavor
   const [, org, site, ...rest] = pathname.slice(1).split('/');
-  return { org, site, pathname: `/${rest.join('/')}` };
+  return { org, site, ref, pathname: `/${rest.join('/')}` };
 }
 
 export async function getPreviewStatus({ org, site, pathname }) {

--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -19,7 +19,7 @@ const DA_PLUGINS = {
   icons: {},
 };
 
-const ref = sanitizeName(new URLSearchParams(window.location.search).get('ref'), false) || 'main';
+export const ref = sanitizeName(new URLSearchParams(window.location.search).get('ref'), false) || 'main';
 
 export function parseDom(dom) {
   const { schema } = window.view.state;
@@ -257,17 +257,17 @@ export function getItemDetails(item) {
 
   // AEM Flavor
   if (hostname.includes('.aem.')) {
-    const [org, site, urlRef] = hostname.split('.')[0].split('--').reverse();
-    return { org, site, ref: urlRef || ref, pathname };
+    const [org, site] = hostname.split('.')[0].split('--').reverse();
+    return { org, site, pathname };
   }
   // DA Content Flavor
   if (hostname.includes('content.da.live')) {
     const [org, site, ...rest] = pathname.slice(1).split('/');
-    return { org, site, ref, pathname: `/${rest.join('/')}` };
+    return { org, site, pathname: `/${rest.join('/')}` };
   }
   // DA Admin Flavor
   const [, org, site, ...rest] = pathname.slice(1).split('/');
-  return { org, site, ref, pathname: `/${rest.join('/')}` };
+  return { org, site, pathname: `/${rest.join('/')}` };
 }
 
 export async function getPreviewStatus({ org, site, pathname }) {


### PR DESCRIPTION
Customer team is trying to build out pages for our next release and would like to configure the block library pointing to a branch

Currently DA always use the main branch and doesnt respect the 'ref' for DA library

## Description

With this change, DA should now support 'ref' for DA Block library

## Related Issue

#867

Customer reported issue : [here](https://adobe-dx-support.slack.com/archives/C06PK80B5A5/p1775073424635439?thread_ts=1774277732.195759&cid=C06PK80B5A5)

## Motivation and Context
Customer reported issue and fix gives the users the flexibility to use branch ref and configure their WIP blocks for next release in their test environments

## How Has This Been Tested?

locally using aem-sandbox (http://localhost:3000/edit?ref=test#/aem-sandbox/block-collection/another-id-123)

screenshots attached
<img width="1424" height="838" alt="Screenshot 2026-04-01 at 6 04 37 PM" src="https://github.com/user-attachments/assets/b18a4ff2-9c89-4a98-9a8d-35ad18d84b18" />
<img width="1918" height="738" alt="Screenshot 2026-04-01 at 6 04 15 PM" src="https://github.com/user-attachments/assets/2674431b-6ef4-47a4-90cb-a7eba6b97dad" />
<img width="1932" height="747" alt="Screenshot 2026-04-01 at 6 03 57 PM" src="https://github.com/user-attachments/assets/e6ed8123-e0fa-4d8b-941e-f631e59f8ef2" />



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
