### PR TITLE
fix: allow table node selection, fix table select handle z-index

### DIFF
--- a/blocks/edit/da-editor/da-editor.css
+++ b/blocks/edit/da-editor/da-editor.css
@@ -993,7 +993,7 @@ da-diff-deleted, da-diff-added {
   background-position: center;
   border: 1px solid #ccc;
   border-radius: 4px;
-  z-index: 100;
+  z-index: 1;
   cursor: pointer;
   display: none;
   align-items: center;

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -360,7 +360,7 @@ function applyDelayedPlugins(pluginsPromise, schema, canWrite, basePlugins) {
     const buildKeymapPlugin = keymap(buildKeymap(schema));
     const baseKeymapPlugin = keymap(baseKeymap);
     const gapCursorPlugin = gapCursor();
-    const tableEditingPlugin = tableEditing();
+    const tableEditingPlugin = tableEditing({ allowTableNodeSelection: true });
 
     const pluginList = [
       syncPlugin,


### PR DESCRIPTION
#741 broke table node selection, which meant the table select handle stopped working correctly.

Also a small CSS fix to ensure the table select icon does not display over any open menus in the editor.