### PR TITLE
feat: detect stale sheet/config and prevent concurrent overwrites

### DIFF
--- a/blocks/edit/da-title/da-title.css
+++ b/blocks/edit/da-title/da-title.css
@@ -44,6 +44,11 @@ da-dialog {
   background: var(--s2-blue-900);
   border-color: var(--s2-blue-900);
   color: #FFF;
+
+  &:disabled {
+    background: var(--s2-gray-500);
+    border-color: var(--s2-gray-500);
+  }
 }
 
 .da-title-inner {
@@ -121,13 +126,16 @@ da-dialog {
   z-index: 2;
 }
 
-.collab-icon.collab-popup::after {
+.collab-icon.collab-popup::after,
+.da-title-action::after {
   display: block;
   content: attr(data-popup-content);
   position: absolute;
   bottom: -32px;
   left: 50%;
   transform: translateX(-50%);
+  font-size: 12px;
+  line-height: 1.6;
   text-align: center;
   text-transform: capitalize;
   background: #676767;
@@ -135,6 +143,21 @@ da-dialog {
   white-space: nowrap;
   padding: 0 8px;
   border-radius: 4px;
+}
+
+.da-title-action {
+  position: relative;
+  display: none;
+
+  &::after {
+    display: none;
+    bottom: -22px;
+    text-transform: unset;
+  }
+
+  &:hover::after {
+    display: unset;
+  }
 }
 
 .collab-icon-user {
@@ -172,9 +195,15 @@ da-dialog {
   height: 27px;
 }
 
-.da-title-action {
+.da-title-action-send {
   position: relative;
-  display: none;
+  padding: 5px 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
 }
 
 .da-title-actions {
@@ -184,7 +213,8 @@ da-dialog {
   gap: 12px;
   height: 44px;
 
-  &.is-open {
+  &.is-open,
+  &.has-one-action {
     margin-left: 12px;
 
     .da-title-action {
@@ -200,23 +230,24 @@ da-dialog {
     }
   }
 
+  &.has-one-action {
+    margin-left: 0;
+
+    .da-title-action-send {
+      display: none;
+    }
+
+    &::before {
+      background: transparent;
+    }
+  }
+
   &.is-fixed {
     position: fixed;
     right: 18px;
     bottom: 12px;
     z-index: 10000;
   }
-}
-
-.da-title-action-send {
-  position: relative;
-  padding: 5px 0;
-  width: 44px;
-  height: 44px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
 }
 
 .da-title-action-send-icon {

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -92,9 +92,7 @@ export default class DaTitle extends LitElement {
 
   setup() {
     this.reset();
-    this._actions = {
-      available: this.getAvailableActions()
-    }
+    this._actions = { available: this.getAvailableActions() };
     // Lazily filter the actions down
     this.filterActions();
   }
@@ -147,7 +145,7 @@ export default class DaTitle extends LitElement {
     ]);
 
     const { org, site, path, fullpath } = this.details;
-    
+
     // Only a valid path gets AEM-bound features
     if (path) {
       this._aemHrefs = await getAemHrefs({ path: fullpath });

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -367,7 +367,7 @@ export default class DaTitle extends LitElement {
         @click=${() => this.handleAction(action)}
         class="con-button blue da-title-action"
         aria-label="Send"
-        data-popup-content="${this.disabledText ? this.disabledText : nothing}"
+        data-popup-content=${this.disabledText ?? nothing}
         ?disabled=${this.disabledText}>
         ${action.charAt(0).toUpperCase() + action.slice(1)}
       </button>

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -38,10 +38,12 @@ export default class DaTitle extends LitElement {
     collabUsers: { attribute: false },
     previewPrefix: { attribute: false },
     livePrefix: { attribute: false },
+    disabledText: { attribute: false },
     _lazyMods: { state: true },
     _configs: { state: true },
     _actions: { state: true },
     _status: { state: true },
+    _isSending: { state: true },
     _dialog: { state: true },
   };
 
@@ -68,7 +70,7 @@ export default class DaTitle extends LitElement {
   update(changed) {
     super.update(changed);
     if (changed.has('details') && this.details) {
-      this.reset();
+      this.setup();
       this.delayedSetup();
     }
   }
@@ -86,7 +88,51 @@ export default class DaTitle extends LitElement {
   reset() {
     this._scheduled = undefined;
     this._configs = undefined;
-    this._actions = {};
+  }
+
+  setup() {
+    this.reset();
+    this._actions = {
+      available: this.getAvailableActions()
+    }
+    // Lazily filter the actions down
+    this.filterActions();
+  }
+
+  getAvailableActions() {
+    const { view, path, fullpath } = this.details;
+
+    // Config only gets save
+    if (view === 'config') return ['save'];
+
+    // DA app configs only get save
+    if (fullpath.includes('/.da/') && view === 'sheet') return ['save'];
+
+    const availableActions = [];
+
+    if (view === 'sheet') {
+      availableActions.push('save');
+    }
+
+    if (path) {
+      availableActions.push('preview', 'publish');
+    }
+
+    return availableActions;
+  }
+
+  async filterActions() {
+    const { org, site, fullpath } = this.details;
+    const configs = await Promise.all(fetchDaConfigs({ org, site }));
+    const configTab = configs.flatMap((config) => getFirstSheet(config) || []);
+
+    // Check which actions should be allowed for the document based on config
+    const publishConfigs = configTab.filter((c) => c.key === 'editor.hidePublish');
+    const hidePublish = publishConfigs.some((c) => fullpath.startsWith(c.value));
+    if (!hidePublish) return;
+
+    this._actions.available = this._actions.available.filter((action) => action !== 'publish');
+    this.requestUpdate();
   }
 
   // Run setup after a short delay.
@@ -101,12 +147,7 @@ export default class DaTitle extends LitElement {
     ]);
 
     const { org, site, path, fullpath } = this.details;
-    const configs = await Promise.all(fetchDaConfigs({ org, site }));
-    this._configs = configs.flatMap((config) => getFirstSheet(config) || []);
-
-    this._actions.available = await this.getAvailableActions();
-    this.requestUpdate();
-
+    
     // Only a valid path gets AEM-bound features
     if (path) {
       this._aemHrefs = await getAemHrefs({ path: fullpath });
@@ -119,40 +160,20 @@ export default class DaTitle extends LitElement {
     return getExistingSchedule(org, site, path);
   }
 
-  async getAvailableActions() {
-    const { view, path, fullpath } = this.details;
-
-    // Config only gets save
-    if (view === 'config') return ['save'];
-
-    const availableActions = [];
-
-    if (view === 'sheet') {
-      availableActions.push('save');
-    }
-
-    if (path) {
-      availableActions.push('preview');
-
-      // Check which actions should be allowed for the document based on config
-      const publishConfigs = this._configs.filter((c) => c.key === 'editor.hidePublish');
-      const hidePublish = publishConfigs.some((c) => fullpath.startsWith(c.value));
-
-      if (!hidePublish) availableActions.push('publish');
-    }
-
-    return availableActions;
-  }
-
   toggleActions() {
     this._actions.open = !this._actions.open;
     this.requestUpdate();
   }
 
-  handleError(json, action, icon) {
+  handleSuccess(action) {
+    const opts = { detail: { action }, composed: true, bubbles: true };
+    const event = new CustomEvent('success', opts);
+    this.dispatchEvent(event);
+  }
+
+  handleError(json, action) {
     this._status = { ...json.error, action };
-    icon.classList.remove('is-sending');
-    icon.parentElement.classList.add('is-error');
+    this._isSending = false;
   }
 
   async setScheduledDialog(schedule) {
@@ -207,13 +228,22 @@ export default class DaTitle extends LitElement {
 
   async handleAction(action) {
     this._status = null;
-    this._sendButton.classList.add('is-sending');
+    this._isSending = true;
     this._actions.open = false;
-    this.requestUpdate();
 
     const { org, site, view, fullpath, path } = this.details;
 
     const aemPath = `/${org}/${site}${path}`;
+
+    // Bail before writing if the remote drifted under us — protects against
+    // last-write-wins. Drift triggers the stale-content dialog via onStale.
+    if (view === 'sheet' || view === 'config') {
+      const { staleCheck } = await import('../../sheet/utils/utils.js');
+      if (await staleCheck.checkForDrift()) {
+        this._isSending = false;
+        return;
+      }
+    }
 
     // Only save to DA if it is a sheet or config
     if (view === 'sheet') {
@@ -229,11 +259,16 @@ export default class DaTitle extends LitElement {
         return;
       }
     }
+    if (view === 'sheet' || view === 'config') {
+      // Tell anything listening save was successful
+      this.handleSuccess('save');
+    }
+
     // AEM Actions
     if (action === 'preview' || action === 'publish') {
       let json = await saveToAem(aemPath, 'preview');
       if (json.error) {
-        this.handleError(json, 'preview', this._sendButton);
+        this.handleError(json, 'preview');
         return;
       }
 
@@ -244,7 +279,7 @@ export default class DaTitle extends LitElement {
         if (this._scheduled?.scheduled) {
           const shouldContinue = await this.setScheduledDialog(this._scheduled);
           if (!shouldContinue) {
-            this._sendButton.classList.remove('is-sending');
+            this._isSending = false;
             return;
           }
         }
@@ -254,7 +289,7 @@ export default class DaTitle extends LitElement {
 
       // Handle all AEM errors
       if (json.error) {
-        this.handleError(json, 'publish', this._sendButton);
+        this.handleError(json, 'publish');
         return;
       }
 
@@ -286,7 +321,7 @@ export default class DaTitle extends LitElement {
       if (action === 'publish') saveDaVersion(fullpath, 'Published');
       else if (action === 'preview') saveDaVersion(fullpath, 'Previewed');
     }
-    this._sendButton.classList.remove('is-sending');
+    this._isSending = false;
   }
 
   async handleRoleRequest() {
@@ -317,10 +352,6 @@ export default class DaTitle extends LitElement {
     this._dialog = { title, content, action: closeAction };
   }
 
-  get _sendButton() {
-    return this.shadowRoot.querySelector('.da-title-action-send-icon');
-  }
-
   get _canPrepare() {
     return !!this.details.path;
   }
@@ -337,7 +368,9 @@ export default class DaTitle extends LitElement {
       <button
         @click=${() => this.handleAction(action)}
         class="con-button blue da-title-action"
-        aria-label="Send">
+        aria-label="Send"
+        data-popup-content="${this.disabledText ? this.disabledText : nothing}"
+        ?disabled=${this.disabledText}>
         ${action.charAt(0).toUpperCase() + action.slice(1)}
       </button>
     `)}`;
@@ -406,10 +439,10 @@ export default class DaTitle extends LitElement {
           ${this.collabStatus ? this.renderCollab() : nothing}
           ${this._canPrepare ? html`<da-prepare .details=${this.details}></da-prepare>` : nothing}
           ${this._status ? this.renderError() : nothing}
-          <div class="da-title-actions ${this._actions.open ? 'is-open' : ''} ${this._actions.fixed ? 'is-fixed' : ''}">
+          <div class="da-title-actions ${this._actions.available?.length === 1 && !this._isSending ? 'has-one-action' : ''} ${this._actions.open ? 'is-open' : ''} ${this._actions.fixed ? 'is-fixed' : ''}">
             ${this.renderActions()}
-            <button @click=${this.toggleActions} class="con-button blue da-title-action-send" aria-label="Send">
-              <svg class="da-title-action-send-icon" viewBox="0 0 20 20">
+            <button @click=${this.toggleActions} class="con-button blue da-title-action-send ${this._status ? 'is-error' : ''}" aria-label="Send">
+              <svg class="da-title-action-send-icon ${this._isSending ? 'is-sending' : ''}" viewBox="0 0 20 20">
                 <use href="/blocks/edit/img/S2_Icon_Publish_20_N.svg#S2_Icon_Publish"/>
               </svg>
             </button>

--- a/blocks/sheet/sheet.js
+++ b/blocks/sheet/sheet.js
@@ -3,6 +3,8 @@ import getPathDetails from '../shared/pathDetails.js';
 import { getNx } from '../../scripts/utils.js';
 import '../edit/da-title/da-title.js';
 import { getData } from './utils/index.js';
+import { staleCheck, showDaDialog } from './utils/utils.js';
+import { convertSheets } from '../edit/utils/helpers.js';
 
 const { default: getStyle } = await import(`${getNx()}/utils/styles.js`);
 
@@ -53,6 +55,7 @@ class DaSheetPanes extends LitElement {
 
       const initSheet = (await import('./utils/index.js')).default;
       daTitle.sheet = await initSheet(daSheet, verReview.data);
+      staleCheck.markSynced(verReview.data);
       verReview.remove();
     });
 
@@ -113,12 +116,44 @@ customElements.define('da-sheet-panes', DaSheetPanes);
 
 let initSheet;
 
+async function reloadSheet(daTitle, daSheet) {
+  if (!initSheet) initSheet = (await import('./utils/index.js')).default;
+  daTitle.sheet = await initSheet(daSheet);
+  daTitle.disabledText = undefined;
+}
+
 async function setSheet(details, daTitle, daSheet) {
+  // Drop any open stale-content dialog so its Cancel can't act on the new path's staleCheck.
+  document.body.querySelectorAll(':scope > da-dialog').forEach((d) => d.remove());
+  // Full reset before the load — getData calls markSynced which sets _lastJsonString.
+  // start() below only wires up the interval without resetting state.
+  staleCheck.stop();
+
   daTitle.details = details;
   daSheet.details = details;
 
-  if (!initSheet) initSheet = (await import('./utils/index.js')).default;
-  daTitle.sheet = await initSheet(daSheet);
+  await reloadSheet(daTitle, daSheet);
+
+  const onStale = async ({ dirty }) => {
+    if (!dirty) {
+      await reloadSheet(daTitle, daSheet);
+      return;
+    }
+    // Block saves immediately so edits made while the dialog is open don't
+    // re-trigger drift detection. Reload (via markSynced) clears the block.
+    staleCheck.blockSaves();
+    daTitle.disabledText = 'Stale content';
+    const result = await showDaDialog({
+      title: 'Content changed',
+      body: 'The content has changed since you opened it. Refresh to get latest or close this dialog to keep your edits without saving.',
+      confirmLabel: 'Refresh',
+    });
+    if (result === 'confirm') {
+      await reloadSheet(daTitle, daSheet);
+    }
+  };
+
+  staleCheck.start({ url: details.sourceUrl, onStale });
 }
 
 export default async function init(el) {
@@ -153,6 +188,11 @@ export default async function init(el) {
   setSheet(details, daTitle, daSheet);
 
   el.append(daTitle, versionWrapper);
+
+  daTitle.addEventListener('success', (e) => {
+    if (e.detail.action !== 'save') return;
+    staleCheck.markSynced(convertSheets(daSheet.jexcel));
+  });
 
   window.addEventListener('hashchange', async () => {
     details = getPathDetails();

--- a/blocks/sheet/utils/index.js
+++ b/blocks/sheet/utils/index.js
@@ -1,6 +1,6 @@
 import { daFetch } from '../../shared/utils.js';
 import { getNx, nxJS } from '../../../scripts/utils.js';
-import { handleSave } from './utils.js';
+import { handleSave, staleCheck } from './utils.js';
 import '../da-sheet-tabs.js';
 
 const { loadStyle } = await import(`${getNx()}${nxJS}`);
@@ -101,10 +101,10 @@ export async function getData(url) {
   // Get base data
   const json = await resp.json();
 
-  const sheetPanes = document.querySelector('da-sheet-panes');
-  if (sheetPanes && !url.includes('/versionsource')) {
-    // Set AEM-formatted JSON for real-time preview
-    sheetPanes.data = json;
+  if (!url.includes('/versionsource')) {
+    staleCheck.markSynced(json);
+    const sheetPanes = document.querySelector('da-sheet-panes');
+    if (sheetPanes) sheetPanes.data = json;
   }
 
   // Single sheet

--- a/blocks/sheet/utils/utils.js
+++ b/blocks/sheet/utils/utils.js
@@ -1,9 +1,83 @@
 import { convertSheets, debounce, saveToDa } from '../../edit/utils/helpers.js';
+import { daFetch } from '../../shared/utils.js';
 
 const DEBOUNCE_TIME = 1000;
+const POLL_INTERVAL = 30000;
+
+class StaleCheck {
+  constructor() {
+    this._intervalId = null;
+    this._sourceUrl = null;
+    this._lastJsonString = null;
+    this._hasLocalEdits = false;
+    this._saveBlocked = false;
+    this._onStale = null;
+  }
+
+  start({ url, onStale }) {
+    if (this._intervalId) clearInterval(this._intervalId);
+    this._sourceUrl = url;
+    this._onStale = onStale;
+    this._intervalId = setInterval(() => this.checkForDrift(), POLL_INTERVAL);
+  }
+
+  stop() {
+    if (this._intervalId) clearInterval(this._intervalId);
+    this._intervalId = null;
+    this._sourceUrl = null;
+    this._lastJsonString = null;
+    this._hasLocalEdits = false;
+    this._saveBlocked = false;
+    this._onStale = null;
+  }
+
+  markSynced(json) {
+    this._lastJsonString = JSON.stringify(json);
+    this._hasLocalEdits = false;
+    // Clear the post-Cancel block: a fresh sync (load or save) is the recovery path.
+    this._saveBlocked = false;
+  }
+
+  markEdited() {
+    this._hasLocalEdits = true;
+  }
+
+  blockSaves() {
+    this._saveBlocked = true;
+  }
+
+  get isBlocked() {
+    return this._saveBlocked;
+  }
+
+  // Returns true if drift was detected (caller should not write).
+  // Skips while blocked so a stale dialog doesn't keep re-firing on subsequent edits/polls.
+  async checkForDrift() {
+    if (this._saveBlocked) return true;
+    try {
+      const resp = await daFetch(this._sourceUrl);
+      if (!resp.ok) return false;
+      const json = await resp.json();
+      const text = JSON.stringify(json);
+      if (text === this._lastJsonString) return false;
+      this._onStale({ json, dirty: this._hasLocalEdits });
+      return true;
+    } catch {
+      // swallow transient errors; retry next tick
+      return false;
+    }
+  }
+}
+
+export const staleCheck = new StaleCheck();
 
 export const saveSheets = async (sheets) => {
-  document.querySelector('da-sheet-panes').data = convertSheets(sheets);
+  const convertedJson = convertSheets(sheets);
+  document.querySelector('da-sheet-panes').data = convertedJson;
+
+  // Bail before writing if the remote moved out from under us — protects against
+  // last-write-wins between concurrent editors. Drift triggers the onStale flow.
+  if (await staleCheck.checkForDrift()) return false;
 
   const { hash } = window.location;
   const pathname = hash.replace('#', '');
@@ -13,13 +87,45 @@ export const saveSheets = async (sheets) => {
     console.error('Error saving sheet', dasSave);
     return false;
   }
+  staleCheck.markSynced(convertedJson);
   return true;
 };
 
 const debouncedSaveSheets = debounce(saveSheets, DEBOUNCE_TIME);
 
 export function handleSave(jexcel, view) {
-  if (view !== 'config') {
-    debouncedSaveSheets(jexcel);
-  }
+  // markEdited must precede the config bail so config edits still mark dirty for stale-detection.
+  staleCheck.markEdited();
+  if (view === 'config') return;
+  if (staleCheck.isBlocked) return;
+  debouncedSaveSheets(jexcel);
+}
+
+export async function showDaDialog({ title, body, confirmLabel }) {
+  await import('../../shared/da-dialog/da-dialog.js');
+  return new Promise((resolve) => {
+    const daDialog = document.createElement('da-dialog');
+    daDialog.title = title;
+
+    let done = false;
+    const finish = (result) => {
+      if (done) return;
+      done = true;
+      daDialog.remove();
+      resolve(result);
+    };
+
+    daDialog.action = {
+      label: confirmLabel,
+      click: () => finish('confirm'),
+    };
+
+    const bodyNode = typeof body === 'string'
+      ? Object.assign(document.createElement('p'), { textContent: body })
+      : body;
+    daDialog.append(bodyNode);
+
+    daDialog.addEventListener('close', () => finish('cancel'));
+    document.body.append(daDialog);
+  });
 }

--- a/test/unit/blocks/edit/da-title/da-title.test.js
+++ b/test/unit/blocks/edit/da-title/da-title.test.js
@@ -147,13 +147,11 @@ describe('DaTitle', () => {
       el = await fixture();
       el._scheduled = 'something';
       el._configs = ['config'];
-      el._actions = { open: true };
 
       el.reset();
 
       expect(el._scheduled).to.be.undefined;
       expect(el._configs).to.be.undefined;
-      expect(el._actions).to.deep.equal({});
     });
   });
 
@@ -171,22 +169,17 @@ describe('DaTitle', () => {
   });
 
   describe('handleError', () => {
-    it('sets status and updates icon classes', async () => {
+    it('sets status and clears sending state', async () => {
       el = await fixture();
-
-      const icon = document.createElement('div');
-      icon.classList.add('is-sending');
-      const parent = document.createElement('div');
-      parent.appendChild(icon);
+      el._isSending = true;
 
       const json = { error: { message: 'Not authorized', status: 403 } };
-      el.handleError(json, 'preview', icon);
+      el.handleError(json, 'preview');
 
       expect(el._status.message).to.equal('Not authorized');
       expect(el._status.status).to.equal(403);
       expect(el._status.action).to.equal('preview');
-      expect(icon.classList.contains('is-sending')).to.be.false;
-      expect(parent.classList.contains('is-error')).to.be.true;
+      expect(el._isSending).to.be.false;
     });
   });
 
@@ -219,26 +212,66 @@ describe('DaTitle', () => {
       expect(actions).to.include('publish');
     });
 
-    it('excludes publish when hidePublish config matches path', async () => {
-      el = await fixture({
-        details: createDetails({
-          view: 'edit',
-          path: '/test/page',
-          fullpath: '/testorg/testsite/test/page',
-        }),
-      });
-      el._configs = [{ key: 'editor.hidePublish', value: '/testorg/testsite/test' }];
-      const actions = await el.getAvailableActions();
-      expect(actions).to.not.include('publish');
-      expect(actions).to.include('preview');
-    });
-
     it('returns no preview/publish when no path', async () => {
       el = await fixture({ details: createDetails({ view: 'edit', path: '' }) });
       el._configs = [];
       const actions = await el.getAvailableActions();
       expect(actions).to.not.include('preview');
       expect(actions).to.not.include('publish');
+    });
+  });
+
+  describe('filterActions', () => {
+    it('removes publish when hidePublish config matches path', async () => {
+      const configResp = { data: [{ key: 'editor.hidePublish', value: '/filterorg/filtersite/test' }] };
+      const origFetch = window.fetch;
+      window.fetch = async (url, opts) => {
+        if (url.includes('/config/filterorg')) {
+          return new Response(JSON.stringify(configResp), { status: 200 });
+        }
+        return origFetch(url, opts);
+      };
+
+      el = await fixture({
+        details: createDetails({
+          org: 'filterorg',
+          site: 'filtersite',
+          path: '/test/page',
+          fullpath: '/filterorg/filtersite/test/page',
+        }),
+      });
+      el._actions = { available: ['preview', 'publish'] };
+      await el.filterActions();
+
+      expect(el._actions.available).to.include('preview');
+      expect(el._actions.available).to.not.include('publish');
+      window.fetch = origFetch;
+    });
+
+    it('keeps publish when hidePublish config does not match path', async () => {
+      const configResp = { data: [{ key: 'editor.hidePublish', value: '/filterorg2/filtersite2/other' }] };
+      const origFetch = window.fetch;
+      window.fetch = async (url, opts) => {
+        if (url.includes('/config/filterorg2')) {
+          return new Response(JSON.stringify(configResp), { status: 200 });
+        }
+        return origFetch(url, opts);
+      };
+
+      el = await fixture({
+        details: createDetails({
+          org: 'filterorg2',
+          site: 'filtersite2',
+          path: '/test/page',
+          fullpath: '/filterorg2/filtersite2/test/page',
+        }),
+      });
+      el._actions = { available: ['preview', 'publish'] };
+      await el.filterActions();
+
+      expect(el._actions.available).to.include('preview');
+      expect(el._actions.available).to.include('publish');
+      window.fetch = origFetch;
     });
   });
 


### PR DESCRIPTION
* Add StaleCheck class to check for stale configs and sheets
  * Checks every 30 seconds for changes.
  * If changes, but nothing new locally, automatically updates local sheet.
  * If local and remote changes, present a dialog allowing to refresh or keep local edits. Keeping local edits will prevent auto saves and manual blue button saves.
* da-title updates to support the following:
  * disabledText property which doubles for disabling actions
  * Remove paper plane if only one action available
  * Any sheet inside `/.da/` can no longer be previewed or published.
  * Lazily check for disablePublish to ensure actions show ASAP.
  * Move `isSending` to class property to allow showing send event for save only actions.
  * Created a class-level event for save action

Resolves: #704

## How Has This Been Tested?

### Sheet
https://stale--da-live--adobe.aem.live/sheet#/aem-sandbox/block-collection/.da/temp-translate

### Config
https://stale--da-live--adobe.aem.live/config#/aem-sandbox/block-collection/

## Screenshots (if appropriate):
<img width="1840" src="https://github.com/user-attachments/assets/ecbbb11e-e0d1-4f9c-82b2-146882d0f39c" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
