### PR TITLE
fix: show scroll bars on da-dialog when needed

### DIFF
--- a/blocks/shared/da-dialog/da-dialog.css
+++ b/blocks/shared/da-dialog/da-dialog.css
@@ -18,6 +18,8 @@ svg.icon {
   padding: 22px 24px 24px;
   width: 350px;
   box-sizing: border-box;
+  max-height: 85vh;
+  overflow: auto;
 
   hr {
     margin: 0 0 20px;
@@ -27,13 +29,12 @@ svg.icon {
     display: flex;
     justify-content: space-between;
     user-select: none;
-  
-  
+
     p {
       line-height: 1;
       padding: 0 0 20px;
     }
-  
+
     .da-dialog-close-btn {
       display: flex;
       justify-content: center;
@@ -47,7 +48,7 @@ svg.icon {
       padding: 0;
       background: transparent;
       border-radius: 4px;
-  
+
       &:hover {
         background-color: var(--s2-gray-200);
       }
@@ -57,18 +58,18 @@ svg.icon {
   .da-dialog-content {
     padding: 0 0 20px;
   }
-  
+
   .da-dialog-footer {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: 12px;
-  
+
     .da-dialog-footer-message {
       font-style: italic;
     }
   }
-  
+
   .da-dialog-footer-left {
     display: flex;
     gap: 8px;
@@ -82,7 +83,7 @@ svg.icon {
   &.da-dialog-small {
     width: 300px;
   }
-  
+
   &.da-dialog-large {
     width: 700px;
     max-width: 90vw;


### PR DESCRIPTION
If the users DA window is too small, sometimes the dialog will not display in full and get cut off.  In those instances we now display scroll bars