### PR TITLE
fix: disallow double hyphen in names

### DIFF
--- a/blocks/browse/da-list-item/da-list-item.js
+++ b/blocks/browse/da-list-item/da-list-item.js
@@ -1,6 +1,6 @@
 import { LitElement, html, nothing, until } from 'da-lit';
 import { DA_ORIGIN } from '../../shared/constants.js';
-import { daFetch, aemAdmin, delay } from '../../shared/utils.js';
+import { daFetch, aemAdmin, delay, sanitizeName } from '../../shared/utils.js';
 import { getNx } from '../../../scripts/utils.js';
 import getEditPath from '../shared.js';
 import { formatDate } from '../../edit/da-versions/helpers.js';
@@ -124,10 +124,14 @@ export default class DaListItem extends LitElement {
   async handleRenameSubmit(e) {
     e.preventDefault();
 
-    const newName = e.target.elements['new-name'].value;
+    const newName = sanitizeName(e.target.elements['new-name'].value, { trimTrailing: true });
 
     if (e.submitter.value === 'cancel' || this.name === newName) {
       this.handleChecked();
+    } else if (!newName) {
+      this.setStatus('A name is required.', 'Please enter a valid name.');
+      await delay(2000);
+      this.setStatus();
     } else {
       const idx = this.path.lastIndexOf(this.name);
       const oldPath = this.path;
@@ -172,7 +176,7 @@ export default class DaListItem extends LitElement {
   }
 
   handleRename({ target }) {
-    target.value = target.value.replaceAll(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+    target.value = sanitizeName(target.value);
   }
 
   toggleExpand() {

--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -400,7 +400,7 @@ export default class DaList extends LitElement {
         rest.pop();
 
         const date = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-');
-        const datename = `${item.name}--${date}${item.ext ? `.${item.ext}` : ''}`;
+        const datename = `${item.name}-${date}${item.ext ? `.${item.ext}` : ''}`;
         item.destination = `/${org}/${site}/.trash/${rest.length > 0 ? `${rest.join('/')}/` : ''}${datename}`;
       }
 

--- a/blocks/browse/da-new/da-new.js
+++ b/blocks/browse/da-new/da-new.js
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'da-lit';
-import { saveToDa } from '../../shared/utils.js';
+import { saveToDa, sanitizeName } from '../../shared/utils.js';
 import { getNx } from '../../../scripts/utils.js';
 import getEditPath from '../shared.js';
 
@@ -48,7 +48,13 @@ export default class DaNew extends LitElement {
   }
 
   handleNameChange(e) {
-    this._createName = e.target.value.replaceAll(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+    const normalized = sanitizeName(e.target.value);
+    // Explicitly sync the DOM value: when two invalid chars are typed in a
+    // row, the sanitized result can be identical to the previous value, so
+    // Lit's property binding would not re-render and the raw typed value
+    // would remain in the input.
+    e.target.value = normalized;
+    this._createName = normalized;
     if (e.target.placeholder === 'name') {
       e.target.classList.remove(INPUT_ERROR);
     }
@@ -60,10 +66,12 @@ export default class DaNew extends LitElement {
 
   async handleSave() {
     const nameInput = this.shadowRoot.querySelector('.da-actions-input[placeholder="name"]');
-    if (!this._createName) {
+    const finalName = sanitizeName(this._createName || '', { trimTrailing: true });
+    if (!finalName) {
       if (nameInput) nameInput.classList.add(INPUT_ERROR);
       return;
     }
+    this._createName = finalName;
     if (nameInput) nameInput.classList.remove(INPUT_ERROR);
 
     let ext;
@@ -111,7 +119,7 @@ export default class DaNew extends LitElement {
     const formData = new FormData(e.target);
     const split = this._fileLabel.split('.');
     const ext = split.pop();
-    const name = split.join('.').replaceAll(/[^a-zA-Z0-9.]/g, '-').toLowerCase();
+    const name = sanitizeName(split.join('.'), { allowDot: true, trimTrailing: true });
     const filename = `${name}.${ext}`;
     const path = `${this.fullpath}/${filename}`;
 

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -253,3 +253,20 @@ export const getAemSiteToken = (() => {
 export function delay(ms) {
   return new Promise((res) => { setTimeout(res, ms); });
 }
+
+// Replaces every character not in `allowed` with '-', then collapses any run
+// of hyphens into a single '-'. Ensures a typed (or substituted) invalid
+// character next to an existing hyphen does not produce a double hyphen.
+// When `trimTrailing` is true, also strips any trailing non-alphanumeric
+// characters so the name ends with an alphanumeric char. Use at finalization
+// time (save/upload/rename submit), not on every keystroke, or the user will
+// be unable to type a hyphen mid-name.
+export function sanitizeName(value, { allowDot = false, trimTrailing = false } = {}) {
+  const pattern = allowDot ? /[^a-zA-Z0-9.]/g : /[^a-zA-Z0-9]/g;
+  let result = value
+    .replaceAll(pattern, '-')
+    .replaceAll(/-+/g, '-')
+    .toLowerCase();
+  if (trimTrailing) result = result.replace(/[^a-zA-Z0-9]+$/, '');
+  return result;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default defineConfig([
     '**/deps',
     'test/e2e',
     'coverage',
+    '.claude',
   ]),
   {
     languageOptions: {

--- a/test/unit/blocks/browse/da-list-item/da-list-item.test.js
+++ b/test/unit/blocks/browse/da-list-item/da-list-item.test.js
@@ -1,0 +1,170 @@
+/* eslint-disable no-underscore-dangle, max-statements-per-line, max-len */
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+describe('DaListItem', () => {
+  let DaListItem;
+
+  before(async () => {
+    setNx('/test/fixtures/nx', { hostname: 'example.com' });
+    const mod = await import('../../../../../blocks/browse/da-list-item/da-list-item.js');
+    DaListItem = mod.default;
+  });
+
+  describe('handleRename', () => {
+    it('lowercases and replaces invalid chars with hyphens', () => {
+      const el = new DaListItem();
+      const target = { value: 'Foo Bar' };
+      el.handleRename({ target });
+      expect(target.value).to.equal('foo-bar');
+    });
+
+    it('collapses consecutive invalid chars into a single hyphen', () => {
+      const el = new DaListItem();
+      const target = { value: 'foo!!bar' };
+      el.handleRename({ target });
+      expect(target.value).to.equal('foo-bar');
+    });
+
+    it('collapses an invalid char typed right after an existing hyphen', () => {
+      const el = new DaListItem();
+      const target = { value: 'foo-!' };
+      el.handleRename({ target });
+      expect(target.value).to.equal('foo-');
+    });
+
+    it('preserves a single trailing hyphen during typing', () => {
+      const el = new DaListItem();
+      const target = { value: 'foo!' };
+      el.handleRename({ target });
+      expect(target.value).to.equal('foo-');
+    });
+
+    it('preserves a valid hyphen between alphanumeric chars', () => {
+      const el = new DaListItem();
+      const target = { value: 'foo-bar' };
+      el.handleRename({ target });
+      expect(target.value).to.equal('foo-bar');
+    });
+  });
+
+  describe('handleRenameSubmit', () => {
+    function makeSubmitEvent({ value, submitterValue = 'confirm' }) {
+      return {
+        preventDefault: () => {},
+        submitter: { value: submitterValue },
+        target: { elements: { 'new-name': { value } } },
+      };
+    }
+
+    it('strips trailing hyphen from the submitted name before renaming', async () => {
+      const el = new DaListItem();
+      el.name = 'original';
+      el.path = '/org/repo/folder/original';
+      el.ext = '';
+
+      const fetched = [];
+      const savedFetch = window.fetch;
+      window.fetch = (url, opts) => {
+        fetched.push({ url, opts });
+        // 204 signals a successful move.
+        return Promise.resolve(new Response(null, { status: 204 }));
+      };
+      el.setStatus = () => {};
+      el.updateAEMStatus = () => {};
+      el.notifyRenamed = () => {};
+      el.handleChecked = () => {};
+
+      try {
+        await el.handleRenameSubmit(makeSubmitEvent({ value: 'renamed-' }));
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(el.name).to.equal('renamed');
+      expect(el.path).to.equal('/org/repo/folder/renamed');
+
+      const moveCall = fetched.find(({ url }) => url.includes('/move'));
+      expect(moveCall, 'expected a call to the move endpoint').to.exist;
+      expect(moveCall.opts.body.get('destination')).to.equal('/org/repo/folder/renamed');
+    });
+
+    it('treats a submission that sanitizes to the original name as a no-op', async () => {
+      const el = new DaListItem();
+      el.name = 'foo';
+      el.path = '/org/repo/foo';
+      el.ext = '';
+
+      let fetchCalled = false;
+      const savedFetch = window.fetch;
+      window.fetch = () => { fetchCalled = true; return Promise.resolve(new Response(null, { status: 204 })); };
+
+      let checkedCalled = false;
+      el.handleChecked = () => { checkedCalled = true; };
+      el.setStatus = () => {};
+
+      try {
+        // "foo-" trims to "foo", which matches this.name — should not move.
+        await el.handleRenameSubmit(makeSubmitEvent({ value: 'foo-' }));
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(fetchCalled).to.be.false;
+      expect(checkedCalled).to.be.true;
+    });
+
+    it('shows a status message and skips renaming when the name becomes empty', async function test() {
+      // handleRenameSubmit waits 2s via delay() before clearing the status,
+      // so we need more than mocha's 2s default test timeout.
+      this.timeout(5000);
+      const el = new DaListItem();
+      el.name = 'original';
+      el.path = '/org/repo/original';
+      el.ext = '';
+
+      let fetchCalled = false;
+      const savedFetch = window.fetch;
+      window.fetch = () => { fetchCalled = true; return Promise.resolve(new Response(null, { status: 204 })); };
+
+      const statusCalls = [];
+      el.setStatus = (...args) => statusCalls.push(args);
+      el.handleChecked = () => {};
+
+      try {
+        // All hyphens -> trims to empty string.
+        await el.handleRenameSubmit(makeSubmitEvent({ value: '---' }));
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(fetchCalled).to.be.false;
+      // The first setStatus call surfaces the error to the user.
+      expect(statusCalls.length).to.be.at.least(1);
+      expect(statusCalls[0][0]).to.match(/name is required/i);
+    });
+
+    it('cancels without renaming when submitter value is cancel', async () => {
+      const el = new DaListItem();
+      el.name = 'foo';
+      el.path = '/org/repo/foo';
+
+      let fetchCalled = false;
+      const savedFetch = window.fetch;
+      window.fetch = () => { fetchCalled = true; return Promise.resolve(new Response(null, { status: 204 })); };
+
+      let checkedCalled = false;
+      el.handleChecked = () => { checkedCalled = true; };
+      el.setStatus = () => {};
+
+      try {
+        await el.handleRenameSubmit(makeSubmitEvent({ value: 'anything', submitterValue: 'cancel' }));
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(fetchCalled).to.be.false;
+      expect(checkedCalled).to.be.true;
+    });
+  });
+});

--- a/test/unit/blocks/browse/da-new/da-new.test.js
+++ b/test/unit/blocks/browse/da-new/da-new.test.js
@@ -1,0 +1,247 @@
+/* eslint-disable no-underscore-dangle, max-len */
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+describe('DaNew', () => {
+  let DaNew;
+
+  before(async () => {
+    setNx('/test/fixtures/nx', { hostname: 'example.com' });
+    const mod = await import('../../../../../blocks/browse/da-new/da-new.js');
+    DaNew = mod.default;
+  });
+
+  describe('handleNameChange', () => {
+    it('lowercases and replaces invalid chars with hyphens', () => {
+      const el = new DaNew();
+      const target = { value: 'Foo Bar', placeholder: 'name', classList: { remove: () => {} } };
+      el.handleNameChange({ target });
+      expect(el._createName).to.equal('foo-bar');
+      expect(target.value).to.equal('foo-bar');
+    });
+
+    it('collapses consecutive invalid chars into a single hyphen', () => {
+      const el = new DaNew();
+      const target = { value: 'foo!!bar', placeholder: 'name', classList: { remove: () => {} } };
+      el.handleNameChange({ target });
+      expect(el._createName).to.equal('foo-bar');
+      expect(target.value).to.equal('foo-bar');
+    });
+
+    it('collapses an invalid char typed right after an existing hyphen', () => {
+      // Simulates the DOM state after a prior keystroke: input value is "foo-",
+      // user types another invalid character making it "foo-!".
+      const el = new DaNew();
+      const target = { value: 'foo-!', placeholder: 'name', classList: { remove: () => {} } };
+      el.handleNameChange({ target });
+      expect(el._createName).to.equal('foo-');
+      // Explicit DOM sync is required here: without it, Lit's property binding
+      // would skip the re-render when the sanitized value is unchanged.
+      expect(target.value).to.equal('foo-');
+    });
+
+    it('preserves a single trailing hyphen during typing', () => {
+      const el = new DaNew();
+      const target = { value: 'foo!', placeholder: 'name', classList: { remove: () => {} } };
+      el.handleNameChange({ target });
+      expect(el._createName).to.equal('foo-');
+      expect(target.value).to.equal('foo-');
+    });
+
+    it('removes the input-error class on the name input', () => {
+      const el = new DaNew();
+      let removed = false;
+      const target = {
+        value: 'abc',
+        placeholder: 'name',
+        classList: { remove: (cls) => { if (cls === 'da-input-error') removed = true; } },
+      };
+      el.handleNameChange({ target });
+      expect(removed).to.be.true;
+    });
+
+    it('does not touch the class list when the input is the url field', () => {
+      const el = new DaNew();
+      let removed = false;
+      const target = {
+        value: 'abc',
+        placeholder: 'url',
+        classList: { remove: () => { removed = true; } },
+      };
+      el.handleNameChange({ target });
+      expect(removed).to.be.false;
+    });
+  });
+
+  describe('handleSave', () => {
+    function stubShadowRoot(el, selectorMap) {
+      // shadowRoot is a read-only DOM property, so we have to shadow it on the
+      // instance via defineProperty rather than simple assignment.
+      Object.defineProperty(el, 'shadowRoot', {
+        configurable: true,
+        value: { querySelector: (selector) => (selector in selectorMap ? selectorMap[selector] : null) },
+      });
+    }
+
+    function makeNameInput() {
+      return { classList: { added: [], add(c) { this.added.push(c); }, remove() {} } };
+    }
+
+    it('does not save and flags the input when _createName is empty', async () => {
+      const el = new DaNew();
+      const input = makeNameInput();
+      stubShadowRoot(el, { '.da-actions-input[placeholder="name"]': input });
+      el._createName = '';
+      let reset = false;
+      el.resetCreate = () => { reset = true; };
+
+      await el.handleSave();
+      expect(input.classList.added).to.include('da-input-error');
+      expect(reset).to.be.false;
+    });
+
+    it('flags the input when the finalized name becomes empty after trimming', async () => {
+      const el = new DaNew();
+      const input = makeNameInput();
+      stubShadowRoot(el, { '.da-actions-input[placeholder="name"]': input });
+      // Only hyphens -> trims to empty string.
+      el._createName = '---';
+      let reset = false;
+      el.resetCreate = () => { reset = true; };
+
+      await el.handleSave();
+      expect(input.classList.added).to.include('da-input-error');
+      expect(reset).to.be.false;
+    });
+
+    it('strips a trailing hyphen from _createName before saving (link type)', async () => {
+      const el = new DaNew();
+      const input = makeNameInput();
+      stubShadowRoot(el, { '.da-actions-input[placeholder="name"]': input });
+      el._createName = 'foo-';
+      el._createType = 'link';
+      el._externalUrl = 'https://example.com';
+      el.fullpath = '/org/repo';
+      el.editor = '';
+
+      const savedPaths = [];
+      // Intercept internal helpers rather than the global fetch because saveToDa
+      // is imported into da-new.js and called directly.
+      const sendEvents = [];
+      el.sendNewItem = (item) => sendEvents.push(item);
+      el.resetCreate = () => {};
+
+      // Save uses window.fetch via saveToDa for the 'link' type.
+      const savedFetch = window.fetch;
+      window.fetch = (url, opts) => {
+        savedPaths.push({ url, method: opts?.method });
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      };
+
+      try {
+        await el.handleSave();
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(el._createName).to.equal('foo');
+      expect(sendEvents).to.have.length(1);
+      expect(sendEvents[0].path).to.equal('/org/repo/foo.link');
+      expect(sendEvents[0].name).to.equal('foo');
+    });
+  });
+
+  describe('handleUpload', () => {
+    it('returns false when no file has been selected', async () => {
+      const el = new DaNew();
+      el._fileLabel = 'Select file';
+      const label = { classList: { added: [], add(c) { this.added.push(c); } } };
+      Object.defineProperty(el, 'shadowRoot', {
+        configurable: true,
+        value: { querySelector: () => label },
+      });
+
+      const result = await el.handleUpload({ preventDefault: () => {}, target: document.createElement('form') });
+      expect(result).to.equal(false);
+      expect(label.classList.added).to.include('da-input-error');
+    });
+
+    it('strips trailing hyphen from the filename base', async () => {
+      const el = new DaNew();
+      el._fileLabel = 'hello world!.png';
+      el.fullpath = '/org/repo';
+
+      let capturedUrl;
+      const savedFetch = window.fetch;
+      window.fetch = (url) => {
+        capturedUrl = url;
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      };
+
+      const sendEvents = [];
+      el.sendNewItem = (item) => sendEvents.push(item);
+      el.resetCreate = () => {};
+      el.requestUpdate = () => {};
+
+      const form = document.createElement('form');
+      try {
+        await el.handleUpload({ preventDefault: () => {}, target: form });
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(sendEvents).to.have.length(1);
+      expect(sendEvents[0].name).to.equal('hello-world');
+      expect(sendEvents[0].path).to.equal('/org/repo/hello-world.png');
+      expect(sendEvents[0].ext).to.equal('png');
+      expect(capturedUrl).to.include('/org/repo/hello-world.png');
+    });
+
+    it('collapses consecutive invalid chars in the filename base', async () => {
+      const el = new DaNew();
+      el._fileLabel = 'foo!!bar.jpg';
+      el.fullpath = '/org/repo';
+
+      const savedFetch = window.fetch;
+      window.fetch = () => Promise.resolve(new Response('ok', { status: 200 }));
+
+      const sendEvents = [];
+      el.sendNewItem = (item) => sendEvents.push(item);
+      el.resetCreate = () => {};
+      el.requestUpdate = () => {};
+
+      try {
+        await el.handleUpload({ preventDefault: () => {}, target: document.createElement('form') });
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(sendEvents[0].name).to.equal('foo-bar');
+      expect(sendEvents[0].path).to.equal('/org/repo/foo-bar.jpg');
+    });
+
+    it('preserves internal dots while stripping trailing hyphens', async () => {
+      const el = new DaNew();
+      el._fileLabel = 'my.file name!.html';
+      el.fullpath = '/org/repo';
+
+      const savedFetch = window.fetch;
+      window.fetch = () => Promise.resolve(new Response('ok', { status: 200 }));
+
+      const sendEvents = [];
+      el.sendNewItem = (item) => sendEvents.push(item);
+      el.resetCreate = () => {};
+      el.requestUpdate = () => {};
+
+      try {
+        await el.handleUpload({ preventDefault: () => {}, target: document.createElement('form') });
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      // Base before ext is "my.file name!" -> "my.file-name-" -> "my.file-name".
+      expect(sendEvents[0].name).to.equal('my.file-name');
+      expect(sendEvents[0].path).to.equal('/org/repo/my.file-name.html');
+    });
+  });
+});

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -9,6 +9,7 @@ import {
   checkLockdownImages,
   delay,
   getSidekickConfig,
+  sanitizeName,
 } from '../../../../blocks/shared/utils.js';
 
 describe('getSheetByIndex', () => {
@@ -58,6 +59,89 @@ describe('delay', () => {
     const result = delay(0);
     expect(result).to.be.instanceOf(Promise);
     await result;
+  });
+});
+
+describe('sanitizeName', () => {
+  it('Lowercases alphanumeric input unchanged', () => {
+    expect(sanitizeName('AbC123')).to.equal('abc123');
+  });
+
+  it('Replaces a single invalid character with a hyphen', () => {
+    expect(sanitizeName('foo bar')).to.equal('foo-bar');
+  });
+
+  it('Collapses consecutive invalid characters into a single hyphen', () => {
+    expect(sanitizeName('foo!!bar')).to.equal('foo-bar');
+    expect(sanitizeName('foo   bar')).to.equal('foo-bar');
+    expect(sanitizeName('a!@#$%b')).to.equal('a-b');
+  });
+
+  it('Preserves an existing single hyphen between alphanumeric chars', () => {
+    expect(sanitizeName('foo-bar')).to.equal('foo-bar');
+  });
+
+  it('Collapses hyphens adjacent to hyphens produced by substitution', () => {
+    // Simulates: user already has "foo-" and then types an invalid char.
+    expect(sanitizeName('foo-!')).to.equal('foo-');
+    expect(sanitizeName('foo-!bar')).to.equal('foo-bar');
+  });
+
+  it('Preserves a single trailing hyphen by default (typing-time behavior)', () => {
+    expect(sanitizeName('foo!')).to.equal('foo-');
+    expect(sanitizeName('foo-')).to.equal('foo-');
+  });
+
+  it('Removes dots by default', () => {
+    expect(sanitizeName('foo.bar')).to.equal('foo-bar');
+  });
+
+  it('Preserves dots when allowDot is true', () => {
+    expect(sanitizeName('foo.bar', { allowDot: true })).to.equal('foo.bar');
+    expect(sanitizeName('my.file.name', { allowDot: true })).to.equal('my.file.name');
+  });
+
+  it('Does not collapse dots into hyphens in allowDot mode', () => {
+    expect(sanitizeName('foo..bar', { allowDot: true })).to.equal('foo..bar');
+  });
+
+  it('Still collapses invalid chars around dots in allowDot mode', () => {
+    expect(sanitizeName('foo!.bar', { allowDot: true })).to.equal('foo-.bar');
+    expect(sanitizeName('foo.!bar', { allowDot: true })).to.equal('foo.-bar');
+  });
+
+  it('Trims a trailing hyphen when trimTrailing is true', () => {
+    expect(sanitizeName('foo!', { trimTrailing: true })).to.equal('foo');
+    expect(sanitizeName('foo-', { trimTrailing: true })).to.equal('foo');
+  });
+
+  it('Trims multiple trailing non-alphanumeric chars when trimTrailing is true', () => {
+    expect(sanitizeName('foo!!!', { trimTrailing: true })).to.equal('foo');
+  });
+
+  it('Trims trailing hyphens and dots in allowDot + trimTrailing mode', () => {
+    expect(sanitizeName('foo.', { allowDot: true, trimTrailing: true })).to.equal('foo');
+    expect(sanitizeName('foo-', { allowDot: true, trimTrailing: true })).to.equal('foo');
+    expect(sanitizeName('foo.-', { allowDot: true, trimTrailing: true })).to.equal('foo');
+  });
+
+  it('Returns empty string when input is only invalid chars and trimTrailing is true', () => {
+    expect(sanitizeName('!!!', { trimTrailing: true })).to.equal('');
+    expect(sanitizeName('---', { trimTrailing: true })).to.equal('');
+  });
+
+  it('Returns empty string for empty input', () => {
+    expect(sanitizeName('')).to.equal('');
+    expect(sanitizeName('', { trimTrailing: true })).to.equal('');
+  });
+
+  it('Does not trim leading hyphens (only trailing)', () => {
+    expect(sanitizeName('!foo', { trimTrailing: true })).to.equal('-foo');
+  });
+
+  it('Does not affect internal hyphens when trimming trailing', () => {
+    expect(sanitizeName('foo-bar-', { trimTrailing: true })).to.equal('foo-bar');
+    expect(sanitizeName('foo-bar-baz', { trimTrailing: true })).to.equal('foo-bar-baz');
   });
 });
 


### PR DESCRIPTION
Fix: #873 

Also removes double-hyphen from .trash file names
