### PR TITLE
fix: shift-tab should not create a new row

### DIFF
--- a/blocks/edit/prose/plugins/keyHandlers.js
+++ b/blocks/edit/prose/plugins/keyHandlers.js
@@ -126,7 +126,7 @@ export function handleTableTab(direction) {
   return (state, dispatch) => {
     if (!isInTable(state)) return false;
     const rect = selectedRect(state);
-    if (isCursorInLastTableCell(rect)) {
+    if (direction === 1 && isCursorInLastTableCell(rect)) {
       addRowAfter(state, dispatch);
       return gtnc(window.view.state, dispatch);
     }


### PR DESCRIPTION
## Description

`Shift+Tab` currently creates a new row AND takes you back a cell if you are in the last cell on a row. Should only take you back a cell. 

## Related Issue

Resolves #791 

## How Has This Been Tested?

Locally and https://i791--da-live--usman-khalid.aem.page/

## Screenshots (if appropriate):
<img width="2008" height="630" alt="2026-04-22 10 33 25" src="https://github.com/user-attachments/assets/83c71a13-b648-4c27-946d-471eb29964c9" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
