### PR TITLE
fix: Strip da-diff-added attrs when accepting diff content

### DIFF
--- a/blocks/edit/prose/diff/diff-actions.js
+++ b/blocks/edit/prose/diff/diff-actions.js
@@ -28,6 +28,23 @@ const objHash = async (obj) => {
 
 const isTableNode = (node) => (node.content?.content?.length === 3 && node.content.content[1].type.name === 'table');
 
+// When content is parsed from <da-diff-added>, each direct child gets a
+// `daDiffAdded: ''` attribute (added by the diff_added parseDOM contentElement
+// in the schema). When accepting the addition, strip that attribute so the
+// accepted content no longer serializes with `da-diff-added=""` on every child.
+export function stripDaDiffAddedAttrs(nodes) {
+  return nodes.map((node) => {
+    if (node.attrs && node.attrs.daDiffAdded != null) {
+      return node.type.create(
+        { ...node.attrs, daDiffAdded: null },
+        node.content,
+        node.marks,
+      );
+    }
+    return node;
+  });
+}
+
 function escapeHTML(str) {
   return str.replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
@@ -220,8 +237,8 @@ export function handleKeepSingleNode(view, getPos, isValidPosition, isLocNode, f
 
     addToHashMetadata(currentNode, ACCEPTED_KEY);
 
-    // Use the improved content filtering like the tabbed interface
-    const filteredContent = filterNodeContent(currentNode);
+    // Use the improved content filtering like the tabbed interface.
+    const filteredContent = stripDaDiffAddedAttrs(filterNodeContent(currentNode));
     dispatchContentTransaction(
       currentPos,
       currentPos + currentNode.nodeSize,
@@ -337,7 +354,7 @@ export function handleKeepAdded(context) {
   handleOperation(context, {
     acceptAdded: true,
     acceptDeleted: false,
-    getContent: ({ addedNode }) => filterNodeContent(addedNode),
+    getContent: ({ addedNode }) => stripDaDiffAddedAttrs(filterNodeContent(addedNode)),
   });
 }
 
@@ -348,7 +365,7 @@ export function handleKeepBoth(context) {
     acceptDeleted: true,
     getContent: ({ deletedNode, addedNode }) => {
       const deletedContent = filterNodeContent(deletedNode);
-      const addedContent = filterNodeContent(addedNode);
+      const addedContent = stripDaDiffAddedAttrs(filterNodeContent(addedNode));
       return [...deletedContent, ...addedContent];
     },
   });

--- a/blocks/edit/prose/diff/diff-global-dialog.js
+++ b/blocks/edit/prose/diff/diff-global-dialog.js
@@ -1,7 +1,12 @@
 // Global dialog management - only needed when multiple LOC nodes exist
-import { Slice } from 'da-y-wrapper';
+import { Fragment, Slice } from 'da-y-wrapper';
 import { createElement, createButton, createTooltip, getDiffLabels } from '../../utils/helpers.js';
-import { addToHashMetadata, ACCEPTED_KEY, REJECTED_KEY } from './diff-actions.js';
+import {
+  addToHashMetadata,
+  stripDaDiffAddedAttrs,
+  ACCEPTED_KEY,
+  REJECTED_KEY,
+} from './diff-actions.js';
 
 const KEEP = 'keep';
 const DELETE = 'delete';
@@ -68,9 +73,15 @@ function processLocNode(tr, node, pos, action) {
 
     if (node.content.size === 0) return tr.delete(pos, pos + node.nodeSize);
 
+    // Strip `daDiffAdded` from direct children so accepted content doesn't
+    // serialize with `da-diff-added=""` (no-op for diff_deleted children).
+    const children = [];
+    node.content.forEach((child) => children.push(child));
+    const strippedContent = Fragment.fromArray(stripDaDiffAddedAttrs(children));
+
     const isInListItem = $pos.parent.type.name === 'list_item';
     const openDepth = isInListItem ? 1 : 0;
-    const slice = new Slice(node.content, openDepth, openDepth);
+    const slice = new Slice(strippedContent, openDepth, openDepth);
     return tr.replace(pos, pos + node.nodeSize, slice);
   }
 


### PR DESCRIPTION
The da-diff-added attribute was mistakenly left on content that was accepted.
