### PR TITLE
feat: Support using "features" column to enable focal-point

### DIFF
--- a/blocks/edit/prose/plugins/imageFocalPoint.js
+++ b/blocks/edit/prose/plugins/imageFocalPoint.js
@@ -35,7 +35,8 @@ function shouldShowFocalPoint(tableName, blocks) {
   if (!tableName || !blocks || blocks.length === 0) return false;
 
   const tableNameLower = tableName.toLowerCase().replace(/-/g, ' ');
-  return blocks.some((block) => (block.name.toLowerCase() === tableNameLower && block['focal-point'] === 'yes'));
+  const libBlock = blocks.find((block) => block.name.toLowerCase() === tableNameLower);
+  return libBlock?.features?.includes('focal-point') || libBlock?.['focal-point'] === 'yes';
 }
 
 function updateImageAttributes(img, attrs) {


### PR DESCRIPTION
Focal point for the block can be turned on using a "features" column in the library block sheet.  Backwards compatibility for the "focal-point" column with "yes" value is kept for now.

fix: #709
