### PR TITLE
feat: Do not auto-create docs on edit nav

### DIFF
--- a/blocks/browse/da-new/da-new.js
+++ b/blocks/browse/da-new/da-new.js
@@ -7,6 +7,7 @@ import getEditPath from '../shared.js';
 const { default: getStyle } = await import(`${getNx()}/utils/styles.js`);
 const STYLE = await getStyle(import.meta.url);
 
+const EMPTY_DOC = '<body><header></header><main><div></div></main><footer></footer></body>';
 const INPUT_ERROR = 'da-input-error';
 
 export default class DaNew extends LitElement {
@@ -79,6 +80,11 @@ export default class DaNew extends LitElement {
     switch (this._createType) {
       case 'document':
         ext = 'html';
+        formData = new FormData();
+        formData.append(
+          'data',
+          new Blob([EMPTY_DOC], { type: 'text/html' }),
+        );
         break;
       case 'sheet':
         ext = 'json';
@@ -97,7 +103,10 @@ export default class DaNew extends LitElement {
     let path = `${this.fullpath}/${this._createName}`;
     if (ext) path += `.${ext}`;
     const editPath = getEditPath({ path, ext, editor: this.editor });
-    if (ext && ext !== 'link') {
+    if (ext === 'html') {
+      await saveToDa({ path, formData });
+      window.location = editPath;
+    } else if (ext && ext !== 'link') {
       window.location = editPath;
     } else {
       await saveToDa({ path, formData });

--- a/blocks/edit/da-not-found/da-not-found.css
+++ b/blocks/edit/da-not-found/da-not-found.css
@@ -1,0 +1,16 @@
+da-dialog.da-not-found-dialog::part(inner) {
+  width: 460px;
+}
+
+da-dialog.da-not-found-dialog p {
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+da-dialog.da-not-found-dialog p:last-of-type {
+  margin-bottom: 0;
+}
+
+da-dialog.da-not-found-dialog sl-button[slot="footer-left"] {
+  white-space: nowrap;
+}

--- a/blocks/edit/da-not-found/da-not-found.js
+++ b/blocks/edit/da-not-found/da-not-found.js
@@ -1,0 +1,78 @@
+import '../../shared/da-dialog/da-dialog.js';
+import { daFetch } from '../../shared/utils.js';
+import { DA_ORIGIN } from '../../shared/constants.js';
+import { getNx, nxJS } from '../../../scripts/utils.js';
+
+const { loadStyle } = await import(`${getNx()}${nxJS}`);
+await loadStyle('/blocks/edit/da-not-found/da-not-found.css');
+
+async function folderHasContents(folderPath) {
+  try {
+    const resp = await daFetch(`${DA_ORIGIN}/list${folderPath}`);
+    if (!resp.ok) return false;
+    const json = await resp.json();
+    return Array.isArray(json) && json.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export default async function showNotFoundDialog(details) {
+  const folderPath = details.fullpath.replace(/\.html$/, '');
+  const listPath = folderPath.startsWith('/') ? folderPath : `/${folderPath}`;
+  const folderExists = await folderHasContents(listPath);
+
+  return new Promise((resolve) => {
+    const dialog = document.createElement('da-dialog');
+    dialog.title = 'Document not found';
+    dialog.classList.add('da-not-found-dialog');
+
+    const docName = details.name.replace(/\.html$/, '');
+    const intro = document.createElement('p');
+    intro.innerHTML = folderExists
+      ? `There is no document named <b><em>${docName}</em></b> at this path, but there is a folder with that name.`
+      : `There is no document named <b><em>${docName}</em></b> at this path.`;
+    dialog.appendChild(intro);
+
+    const prompt = document.createElement('p');
+    prompt.textContent = 'What would you like to do?';
+    dialog.appendChild(prompt);
+
+    let resolved = false;
+    const finish = (result) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(result);
+      dialog.close();
+    };
+
+    dialog.action = {
+      label: 'Create document',
+      style: 'accent',
+      click: () => finish('create'),
+    };
+
+    const cancelBtn = document.createElement('sl-button');
+    cancelBtn.className = 'primary outline';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.slot = 'footer-left';
+    cancelBtn.addEventListener('click', () => finish('cancel'));
+    dialog.appendChild(cancelBtn);
+
+    if (folderExists) {
+      const folderBtn = document.createElement('sl-button');
+      folderBtn.className = 'primary outline';
+      folderBtn.textContent = 'Open folder';
+      folderBtn.slot = 'footer-left';
+      folderBtn.addEventListener('click', () => finish('folder'));
+      dialog.appendChild(folderBtn);
+    }
+
+    dialog.addEventListener('close', () => {
+      finish('cancel');
+      dialog.remove();
+    });
+
+    document.body.appendChild(dialog);
+  });
+}

--- a/blocks/edit/da-not-found/da-not-found.js
+++ b/blocks/edit/da-not-found/da-not-found.js
@@ -20,59 +20,72 @@ async function folderHasContents(folderPath) {
 export default async function showNotFoundDialog(details) {
   const folderPath = details.fullpath.replace(/\.html$/, '');
   const listPath = folderPath.startsWith('/') ? folderPath : `/${folderPath}`;
+
+  let dialog = null;
+  let resolved = false;
+  let resolveFn;
+  const promise = new Promise((r) => { resolveFn = r; });
+
+  // eslint-disable-next-line no-use-before-define
+  const onHashChange = () => finish('hashchange');
+  function finish(result) {
+    if (resolved) return;
+    resolved = true;
+    window.removeEventListener('hashchange', onHashChange);
+    resolveFn(result);
+    if (dialog) dialog.close();
+  }
+
+  // Attach listener BEFORE the async folder check so a hashchange during the
+  // fetch also cancels this dialog flow — otherwise the old edit URL's dialog
+  // would flash over the editor that the new hash loaded.
+  window.addEventListener('hashchange', onHashChange);
+
   const folderExists = await folderHasContents(listPath);
+  if (resolved) return promise;
 
-  return new Promise((resolve) => {
-    const dialog = document.createElement('da-dialog');
-    dialog.title = 'Document not found';
-    dialog.classList.add('da-not-found-dialog');
+  dialog = document.createElement('da-dialog');
+  dialog.title = 'Document not found';
+  dialog.classList.add('da-not-found-dialog');
 
-    const docName = details.name.replace(/\.html$/, '');
-    const intro = document.createElement('p');
-    intro.innerHTML = folderExists
-      ? `There is no document named <b><em>${docName}</em></b> at this path, but there is a folder with that name.`
-      : `There is no document named <b><em>${docName}</em></b> at this path.`;
-    dialog.appendChild(intro);
+  const docName = details.name.replace(/\.html$/, '');
+  const intro = document.createElement('p');
+  intro.innerHTML = folderExists
+    ? `There is no document named <b><em>${docName}</em></b> at this path, but there is a folder with that name.`
+    : `There is no document named <b><em>${docName}</em></b> at this path.`;
+  dialog.appendChild(intro);
 
-    const prompt = document.createElement('p');
-    prompt.textContent = 'What would you like to do?';
-    dialog.appendChild(prompt);
+  const prompt = document.createElement('p');
+  prompt.textContent = 'What would you like to do?';
+  dialog.appendChild(prompt);
 
-    let resolved = false;
-    const finish = (result) => {
-      if (resolved) return;
-      resolved = true;
-      resolve(result);
-      dialog.close();
-    };
+  dialog.action = {
+    label: 'Create document',
+    style: 'accent',
+    click: () => finish('create'),
+  };
 
-    dialog.action = {
-      label: 'Create document',
-      style: 'accent',
-      click: () => finish('create'),
-    };
+  const cancelBtn = document.createElement('sl-button');
+  cancelBtn.className = 'primary outline';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.slot = 'footer-left';
+  cancelBtn.addEventListener('click', () => finish('cancel'));
+  dialog.appendChild(cancelBtn);
 
-    const cancelBtn = document.createElement('sl-button');
-    cancelBtn.className = 'primary outline';
-    cancelBtn.textContent = 'Cancel';
-    cancelBtn.slot = 'footer-left';
-    cancelBtn.addEventListener('click', () => finish('cancel'));
-    dialog.appendChild(cancelBtn);
+  if (folderExists) {
+    const folderBtn = document.createElement('sl-button');
+    folderBtn.className = 'primary outline';
+    folderBtn.textContent = 'Open folder';
+    folderBtn.slot = 'footer-left';
+    folderBtn.addEventListener('click', () => finish('folder'));
+    dialog.appendChild(folderBtn);
+  }
 
-    if (folderExists) {
-      const folderBtn = document.createElement('sl-button');
-      folderBtn.className = 'primary outline';
-      folderBtn.textContent = 'Open folder';
-      folderBtn.slot = 'footer-left';
-      folderBtn.addEventListener('click', () => finish('folder'));
-      dialog.appendChild(folderBtn);
-    }
-
-    dialog.addEventListener('close', () => {
-      finish('cancel');
-      dialog.remove();
-    });
-
-    document.body.appendChild(dialog);
+  dialog.addEventListener('close', () => {
+    finish('cancel');
+    dialog.remove();
   });
+
+  document.body.appendChild(dialog);
+  return promise;
 }

--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -69,6 +69,18 @@ async function setUI(el) {
   let permissions;
   let doc;
   if (resp.status === 404) {
+    const { default: showNotFoundDialog } = await import('./da-not-found/da-not-found.js');
+    const choice = await showNotFoundDialog(details);
+    if (choice === 'folder') {
+      const folderPath = details.fullpath.replace(/\.html$/, '');
+      const hashPath = folderPath.startsWith('/') ? folderPath : `/${folderPath}`;
+      window.location = `/#${hashPath}`;
+      return;
+    }
+    if (choice !== 'create') {
+      window.location = `/#${details.parent}`;
+      return;
+    }
     const createResp = await createDoc(details.sourceUrl);
     permissions = createResp.permissions;
     doc = DOMPARSER.parseFromString(EMPTY_DOC, 'text/html');

--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -71,6 +71,9 @@ async function setUI(el) {
   if (resp.status === 404) {
     const { default: showNotFoundDialog } = await import('./da-not-found/da-not-found.js');
     const choice = await showNotFoundDialog(details);
+    // A hashchange spawns a parallel setUI for the new path — bail out of
+    // this one so the two don't race over window.location / editor state.
+    if (choice === 'hashchange') return;
     if (choice === 'folder') {
       const folderPath = details.fullpath.replace(/\.html$/, '');
       const hashPath = folderPath.startsWith('/') ? folderPath : `/${folderPath}`;

--- a/test/unit/blocks/browse/da-new/da-new.test.js
+++ b/test/unit/blocks/browse/da-new/da-new.test.js
@@ -149,6 +149,50 @@ describe('DaNew', () => {
       expect(sendEvents[0].path).to.equal('/org/repo/foo.link');
       expect(sendEvents[0].name).to.equal('foo');
     });
+
+    it('creates an empty HTML document via saveToDa before navigating (document type)', async () => {
+      const el = new DaNew();
+      const input = makeNameInput();
+      stubShadowRoot(el, { '.da-actions-input[placeholder="name"]': input });
+      el._createName = 'my-doc';
+      el._createType = 'document';
+      el.fullpath = '/org/repo';
+      el.editor = '/edit#';
+
+      const fetchCalls = [];
+      const savedFetch = window.fetch;
+      // Intercept the saveToDa PUT so we can verify it ran *before* the
+      // window.location navigation. Throw so handleSave rejects before it
+      // reaches the navigation line — letting the assertion run reliably.
+      const NAV_SENTINEL = new Error('stop-before-nav');
+      window.fetch = async (url, opts) => {
+        const body = opts?.body instanceof FormData ? opts.body.get('data') : null;
+        const bodyText = body && typeof body.text === 'function' ? await body.text() : null;
+        fetchCalls.push({ url, method: opts?.method, bodyText });
+        throw NAV_SENTINEL;
+      };
+
+      el.sendNewItem = () => {};
+      el.resetCreate = () => {};
+
+      let caught;
+      try {
+        await el.handleSave();
+      } catch (e) {
+        caught = e;
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      // saveToDa's daFetch does not catch the raw throw, so it surfaces here.
+      expect(caught).to.equal(NAV_SENTINEL);
+      expect(fetchCalls).to.have.length(1);
+      expect(fetchCalls[0].url).to.equal('https://admin.da.live/source/org/repo/my-doc.html');
+      expect(fetchCalls[0].method).to.equal('PUT');
+      expect(fetchCalls[0].bodyText).to.equal(
+        '<body><header></header><main><div></div></main><footer></footer></body>',
+      );
+    });
   });
 
   describe('handleUpload', () => {

--- a/test/unit/blocks/edit/da-not-found/da-not-found.test.js
+++ b/test/unit/blocks/edit/da-not-found/da-not-found.test.js
@@ -1,0 +1,167 @@
+/* eslint-disable no-underscore-dangle */
+import { expect } from '@esm-bundle/chai';
+
+const { setNx } = await import('../../../../../scripts/utils.js');
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { default: showNotFoundDialog } = await import('../../../../../blocks/edit/da-not-found/da-not-found.js');
+
+// da-dialog calls showModal() via a 20ms setTimeout in connectedCallback.
+const waitForDialog = () => new Promise((r) => { setTimeout(r, 50); });
+
+describe('showNotFoundDialog', () => {
+  let savedFetch;
+  let fetchCalls;
+
+  const details = {
+    fullpath: '/org/repo/some/missing-doc.html',
+    name: 'missing-doc',
+    parent: '/org/repo/some',
+  };
+
+  function mockFetch(listResponse) {
+    window.fetch = async (url) => {
+      fetchCalls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => listResponse,
+        headers: { get: () => null },
+      };
+    };
+  }
+
+  beforeEach(() => {
+    fetchCalls = [];
+    savedFetch = window.fetch;
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+    document.querySelectorAll('da-dialog').forEach((d) => d.remove());
+  });
+
+  it('resolves "create" when the action button is clicked', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    // Action (rightmost) button is rendered in da-dialog's shadow DOM.
+    const actionBtn = dialog.shadowRoot.querySelector('.da-dialog-footer sl-button');
+    actionBtn.click();
+
+    expect(await promise).to.equal('create');
+  });
+
+  it('resolves "cancel" when the cancel button is clicked', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    const cancelBtn = dialog.querySelector('sl-button[slot="footer-left"]');
+    expect(cancelBtn.textContent).to.equal('Cancel');
+    cancelBtn.click();
+
+    expect(await promise).to.equal('cancel');
+  });
+
+  it('omits the "Open folder" button when no folder exists', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    const leftBtns = dialog.querySelectorAll('sl-button[slot="footer-left"]');
+    expect(leftBtns.length).to.equal(1);
+    expect(leftBtns[0].textContent).to.equal('Cancel');
+
+    leftBtns[0].click();
+    await promise;
+  });
+
+  it('shows "Open folder" and resolves "folder" when folder has contents', async () => {
+    mockFetch([{ path: '/org/repo/some/missing-doc/child', name: 'child' }]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    const leftBtns = dialog.querySelectorAll('sl-button[slot="footer-left"]');
+    expect(leftBtns.length).to.equal(2);
+    const folderBtn = [...leftBtns].find((b) => b.textContent === 'Open folder');
+    expect(folderBtn).to.exist;
+    folderBtn.click();
+
+    expect(await promise).to.equal('folder');
+  });
+
+  it('calls the /list endpoint with the path stripped of .html', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    expect(fetchCalls[0]).to.equal('https://admin.da.live/list/org/repo/some/missing-doc');
+
+    // Clean up by cancelling.
+    document.querySelector('da-dialog').querySelector('sl-button[slot="footer-left"]').click();
+    await promise;
+  });
+
+  it('resolves "cancel" when the dialog is closed without a button action', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    document.querySelector('da-dialog').close();
+
+    expect(await promise).to.equal('cancel');
+  });
+
+  it('mentions the existing folder in the message when one exists', async () => {
+    mockFetch([{ path: '/org/repo/some/missing-doc/child', name: 'child' }]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    const intro = dialog.querySelector('p');
+    expect(intro.textContent).to.equal(
+      'There is no document named "missing-doc" at this path, but there is a folder with that name.',
+    );
+
+    dialog.querySelector('sl-button[slot="footer-left"]').click();
+    await promise;
+  });
+
+  it('uses the plain message when no folder exists', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    const intro = dialog.querySelector('p');
+    expect(intro.textContent).to.equal(
+      'There is no document named "missing-doc" at this path.',
+    );
+
+    dialog.querySelector('sl-button[slot="footer-left"]').click();
+    await promise;
+  });
+
+  it('resolves "cancel" when the folder existence check fails', async () => {
+    // Non-ok response → folderHasContents returns false, no "Open folder" button.
+    window.fetch = async (url) => {
+      fetchCalls.push(url);
+      return { ok: false, status: 500, json: async () => ({}), headers: { get: () => null } };
+    };
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+
+    const dialog = document.querySelector('da-dialog');
+    const leftBtns = dialog.querySelectorAll('sl-button[slot="footer-left"]');
+    expect(leftBtns.length).to.equal(1);
+
+    leftBtns[0].click();
+    expect(await promise).to.equal('cancel');
+  });
+});

--- a/test/unit/blocks/edit/da-not-found/da-not-found.test.js
+++ b/test/unit/blocks/edit/da-not-found/da-not-found.test.js
@@ -126,7 +126,7 @@ describe('showNotFoundDialog', () => {
     const dialog = document.querySelector('da-dialog');
     const intro = dialog.querySelector('p');
     expect(intro.textContent).to.equal(
-      'There is no document named "missing-doc" at this path, but there is a folder with that name.',
+      'There is no document named missing-doc at this path, but there is a folder with that name.',
     );
 
     dialog.querySelector('sl-button[slot="footer-left"]').click();
@@ -141,11 +141,49 @@ describe('showNotFoundDialog', () => {
     const dialog = document.querySelector('da-dialog');
     const intro = dialog.querySelector('p');
     expect(intro.textContent).to.equal(
-      'There is no document named "missing-doc" at this path.',
+      'There is no document named missing-doc at this path.',
     );
 
     dialog.querySelector('sl-button[slot="footer-left"]').click();
     await promise;
+  });
+
+  it('closes the dialog and resolves "hashchange" on hashchange', async () => {
+    mockFetch([]);
+    const promise = showNotFoundDialog(details);
+    await waitForDialog();
+    expect(document.querySelector('da-dialog')).to.exist;
+
+    window.dispatchEvent(new Event('hashchange'));
+
+    expect(await promise).to.equal('hashchange');
+  });
+
+  it('resolves "hashchange" without showing the dialog if hash changes during the folder check', async () => {
+    let resolveFetch;
+    window.fetch = (url) => {
+      fetchCalls.push(url);
+      return new Promise((r) => { resolveFetch = r; });
+    };
+
+    const promise = showNotFoundDialog(details);
+    // daFetch has its own async prelude (token lookup) before it reaches
+    // window.fetch, so yield the event loop until our mock is actually invoked.
+    await new Promise((r) => { setTimeout(r, 10); });
+    expect(resolveFetch, 'fetch mock should have been called').to.be.a('function');
+
+    // Fire hashchange while the folder-check fetch is still pending.
+    window.dispatchEvent(new Event('hashchange'));
+    // Let the fetch complete afterwards — dialog code must short-circuit.
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => [],
+      headers: { get: () => null },
+    });
+
+    expect(await promise).to.equal('hashchange');
+    expect(document.querySelector('da-dialog')).to.be.null;
   });
 
   it('resolves "cancel" when the folder existence check fails', async () => {


### PR DESCRIPTION
Instead of automatically creating a doc when going to a new edit path, we now will present the user with a dialog asking what they would like to do.  If they choose to not create a doc, they are navigated to the containing directory for that file.

<img width="487" height="250" alt="Screenshot 2026-04-23 at 3 38 26 PM" src="https://github.com/user-attachments/assets/3d60a27b-d41f-4157-a785-4a4cf206916b" />

If a folder exists with the same name, they are also given the option of opening that folder.

<img width="519" height="280" alt="Screenshot 2026-04-23 at 3 37 42 PM" src="https://github.com/user-attachments/assets/d26a9fac-d85a-4980-be24-63bc789401be" />

fix #702
