### PR TITLE
fix: sort editor.path matches by path prefix length, not total string length

### DIFF
--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -104,7 +104,7 @@ export default class DaBrowse extends LitElement {
     if (matchedConfs.length === 0) return DEF_EDIT;
 
     // Sort by length in descending order (longest first)
-    const matchedConf = matchedConfs.sort((a, b) => b.length - a.length)[0];
+    const matchedConf = matchedConfs.sort((a, b) => b.split('=')[0].length - a.split('=')[0].length)[0];
 
     return matchedConf.split('=')[1];
   }

--- a/test/unit/blocks/browse/da-browse/da-browse.test.js
+++ b/test/unit/blocks/browse/da-browse/da-browse.test.js
@@ -349,6 +349,62 @@ describe('DaBrowse Component', () => {
     daBrowseComp.details = { fullpath: '/myorg/mysite/folder', owner: 'myorg', depth: 3 };
   });
 
+  describe('getEditor', () => {
+    const UE_CONF = '/myorg/mysite=https://experience.adobe.com/#/@dxorg/aem/editor/canvas/main--mysite--myorg.ue.da.live';
+    const FORM_CONF = '/myorg/mysite/dealers=https://da.live/form#';
+
+    function mockConfig(rows) {
+      window.fetch = async () => ({
+        ok: true,
+        json: async () => ({ data: rows }),
+      });
+    }
+
+    afterEach(() => { window.fetch = undefined; });
+
+    it('returns default edit path when no editor.path rows exist', async () => {
+      mockConfig([]);
+      const url = await daBrowseComp.getEditor(true);
+      expect(url).to.equal('/edit#');
+    });
+
+    it('matches a single editor.path row by prefix', async () => {
+      daBrowseComp.details = { fullpath: '/myorg/mysite/some-doc', owner: 'myorg', depth: 3 };
+      mockConfig([{ key: 'editor.path', value: UE_CONF }]);
+      const url = await daBrowseComp.getEditor(true);
+      expect(url).to.equal('https://experience.adobe.com/#/@dxorg/aem/editor/canvas/main--mysite--myorg.ue.da.live');
+    });
+
+    it('prefers the more specific (longer prefix) match over a shorter one', async () => {
+      daBrowseComp.details = { fullpath: '/myorg/mysite/dealers/acme', owner: 'myorg', depth: 4 };
+      mockConfig([
+        { key: 'editor.path', value: UE_CONF },
+        { key: 'editor.path', value: FORM_CONF },
+      ]);
+      const url = await daBrowseComp.getEditor(true);
+      // /myorg/mysite/dealers is more specific than /myorg/mysite even though
+      // UE_CONF has a longer total string length
+      expect(url).to.equal('https://da.live/form#');
+    });
+
+    it('falls back to the broader match when path is outside the specific folder', async () => {
+      daBrowseComp.details = { fullpath: '/myorg/mysite/other/page', owner: 'myorg', depth: 4 };
+      mockConfig([
+        { key: 'editor.path', value: UE_CONF },
+        { key: 'editor.path', value: FORM_CONF },
+      ]);
+      const url = await daBrowseComp.getEditor(true);
+      expect(url).to.equal('https://experience.adobe.com/#/@dxorg/aem/editor/canvas/main--mysite--myorg.ue.da.live');
+    });
+
+    it('returns default edit path when no prefix matches the current path', async () => {
+      daBrowseComp.details = { fullpath: '/otherorg/othersite/page', owner: 'otherorg', depth: 3 };
+      mockConfig([{ key: 'editor.path', value: UE_CONF }]);
+      const url = await daBrowseComp.getEditor(true);
+      expect(url).to.equal('/edit#');
+    });
+  });
+
   describe('isRootFolder', () => {
     it('returns true for root path (org only)', () => {
       expect(daBrowseComp.isRootFolder('/myorg')).to.be.true;


### PR DESCRIPTION
* Without this fix, a short formsref URL would lose to a long UE URL even when the formsref path is more specific, causing the wrong editor to open for subfolder overrides.
*  Adds cases for single match, most-specific-prefix wins, broader fallback, and no-match — directly covering the sort bug fixed in the prior commit.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
