### PR TITLE
fix: wait when getting redirected back from ims

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -257,6 +257,10 @@ function handleAwarenessUpdates(wsProvider, daTitle, win, path) {
 
   wsProvider.on('status', (st) => { daTitle.collabStatus = st.status; });
 
+  // Seed from current provider state in case 'status' fired before subscribe.
+  if (wsProvider.wsconnected) daTitle.collabStatus = 'connected';
+  else daTitle.collabStatus = 'connecting';
+
   wsProvider.on('connection-close', async () => {
     const resp = await checkDoc(path);
     if (resp.status === 404) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -64,7 +64,7 @@ function loadStyles() {
 
 export default async function loadPage() {
   loadStyles();
-  initIms();
+  const imsReady = initIms();
 
   if (!nx2) {
     // pin to light scheme
@@ -73,6 +73,11 @@ export default async function loadPage() {
     decorateArea({});
   }
   await setConfig(CONFIG);
+  // Only block on IMS for OAuth-callback loads
+  const { hash } = window.location;
+  if (hash.includes('access_token=') || hash.includes('old_hash=')) {
+    await imsReady;
+  }
   await loadArea();
 }
 

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -20,6 +20,9 @@ test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo)
 
   const pageURL = getTestPageURL('collab', workerInfo);
   await page.goto(pageURL);
+  await page.waitForTimeout(2000);
+  await page.getByText('Create document', { exact: true }).click();
+
   await expect(page.getByLabel('Open profile menu')).toBeVisible();
   // Wait a little bit so that the collab awareness has caught up and knows that we are logged in as
   // 'DA Testuser'

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -21,6 +21,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   const pageURL = getTestPageURL('copyrename', workerInfo);
   const orgPageName = pageURL.split('/').pop();
   await page.goto(pageURL);
+  await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
   // Allow Y.js WebSocket to stabilize before typing

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -89,6 +89,7 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   const pageName = url.split('/').pop();
 
   await page.goto(url);
+  await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
   // Allow Y.js WebSocket to stabilize before typing

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -18,6 +18,7 @@ test('Update Document', async ({ browser, page }, workerInfo) => {
 
   const url = getTestPageURL('edit1', workerInfo);
   await page.goto(url);
+  await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
   // Allow Y.js WebSocket to stabilize before typing
@@ -84,6 +85,7 @@ test('Change document by switching anchors', async ({ page }, workerInfo) => {
   const urlB = `${url}B`;
 
   await page.goto(urlA);
+  await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
   // Allow Y.js WebSocket to stabilize before typing
@@ -108,6 +110,7 @@ test('Change document by switching anchors', async ({ page }, workerInfo) => {
   await page.waitForTimeout(5000);
 
   await page.goto(urlB);
+  await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
   // Allow Y.js WebSocket to stabilize before typing
@@ -134,6 +137,7 @@ test('Add code mark', async ({ page }, workerInfo) => {
   test.setTimeout(30000);
   const url = getTestPageURL('edit5', workerInfo);
   await page.goto(url);
+  await page.getByText('Create document', { exact: true }).click();
   const proseMirror = page.locator('div.ProseMirror');
   await proseMirror.waitFor();
   await expect(proseMirror).toBeVisible();

--- a/test/e2e/tests/formatting.spec.js
+++ b/test/e2e/tests/formatting.spec.js
@@ -71,7 +71,7 @@ test('Text formatting and links persist after reload', async ({ page }, workerIn
   const url = getTestPageURL('formatting', workerInfo);
   console.log(url);
   await page.goto(url);
-
+  await page.getByText('Create document', { exact: true }).click();
   const proseMirror = page.locator('div.ProseMirror');
   await expect(proseMirror).toBeVisible();
   await expect(proseMirror).toHaveAttribute('contenteditable', 'true');

--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -18,6 +18,7 @@ test('Create Version and Restore from it', async ({ page }, workerInfo) => {
   test.setTimeout(60000);
 
   await page.goto(getTestPageURL('versions', workerInfo));
+  await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
   // Allow Y.js WebSocket to stabilize before typing


### PR DESCRIPTION
Depending on timing, users sometimes were being shown the homepage even though there was a hash path to browse a folder.

Also small fix for collab status race condition

fix #904 

https://ccc-904--da-live--adobe.aem.live/
