### PR TITLE
fix: await content cookie later in loading

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -49,10 +49,7 @@ async function setUI(el) {
   document.title = `Edit ${details.name} - DA`;
 
   const { owner, repo } = details;
-  await Promise.all([
-    contentLogin(owner, repo),
-    livePreviewLogin(owner, repo),
-  ]);
+  const contentCookiePromise = contentLogin(owner, repo);
 
   const daTitle = initArea('da-title', details, el);
 
@@ -95,6 +92,9 @@ async function setUI(el) {
   daTitle.permissions = permissions;
   daContent.permissions = permissions;
 
+  // If content cookie hasn't loaded yet, wait for it
+  await contentCookiePromise;
+
   const metadataEl = doc.querySelector('main > .metadata');
   // Check if the metadata div has no additional classes (or doesn't exist)
   const isDefaultMetadata = !(metadataEl?.classList.length > 1);
@@ -112,7 +112,11 @@ async function setUI(el) {
       daContent,
       wsPromise,
     });
+
+    // set the live preview cookie async
+    livePreviewLogin(owner, repo);
   }
+
   // FUTURE: else load BYO Editor
 }
 


### PR DESCRIPTION
We can start the cookie call in the same place, then await it after the doc has been downloaded.   In my testing even with throttling the cookie is set and the await doesn't slow anything down.  The preview cookie can be started afterwards as no one opens preview right at page load.

200-400ms gain in page load
