### PR TITLE
fix: do not pre-create HTML doc when an external editor (form/UE) is configured

### DIFF
--- a/blocks/browse/da-new/da-new.js
+++ b/blocks/browse/da-new/da-new.js
@@ -103,7 +103,7 @@ export default class DaNew extends LitElement {
     let path = `${this.fullpath}/${this._createName}`;
     if (ext) path += `.${ext}`;
     const editPath = getEditPath({ path, ext, editor: this.editor });
-    if (ext === 'html') {
+    if (ext === 'html' && !this.editor) {
       await saveToDa({ path, formData });
       window.location = editPath;
     } else if (ext && ext !== 'link') {

--- a/test/unit/blocks/browse/da-new/da-new.test.js
+++ b/test/unit/blocks/browse/da-new/da-new.test.js
@@ -150,14 +150,14 @@ describe('DaNew', () => {
       expect(sendEvents[0].name).to.equal('foo');
     });
 
-    it('creates an empty HTML document via saveToDa before navigating (document type)', async () => {
+    it('creates an empty HTML document via saveToDa before navigating (document type, no external editor)', async () => {
       const el = new DaNew();
       const input = makeNameInput();
       stubShadowRoot(el, { '.da-actions-input[placeholder="name"]': input });
       el._createName = 'my-doc';
       el._createType = 'document';
       el.fullpath = '/org/repo';
-      el.editor = '/edit#';
+      el.editor = '';
 
       const fetchCalls = [];
       const savedFetch = window.fetch;
@@ -192,6 +192,34 @@ describe('DaNew', () => {
       expect(fetchCalls[0].bodyText).to.equal(
         '<body><header></header><main><div></div></main><footer></footer></body>',
       );
+    });
+
+    it('does NOT pre-create document when an external editor is configured (form/UE)', async () => {
+      const el = new DaNew();
+      const input = makeNameInput();
+      stubShadowRoot(el, { '.da-actions-input[placeholder="name"]': input });
+      el._createName = 'my-form-doc';
+      el._createType = 'document';
+      el.fullpath = '/org/repo';
+      el.editor = 'https://da.live/form#';
+
+      const fetchCalls = [];
+      const savedFetch = window.fetch;
+      window.fetch = async (url, opts) => {
+        fetchCalls.push({ url, method: opts?.method });
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      };
+
+      el.sendNewItem = () => {};
+      el.resetCreate = () => {};
+
+      try {
+        await el.handleSave();
+      } finally {
+        window.fetch = savedFetch;
+      }
+
+      expect(fetchCalls).to.have.length(0);
     });
   });
 


### PR DESCRIPTION
The da-not-found commit pre-created all new HTML documents with EMPTY_DOC before navigating. This broke the da-nx form block, which depends on a 404 to show the schema picker for new documents. When the file already exists as EMPTY_DOC, the form block renders a blank form with no fields.

Only pre-create when no external editor is set (standard DA edit path).

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
