### PR TITLE
fix: prevent IMS auth fragments from leaking into API org path

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -260,7 +260,11 @@ function handleAwarenessUpdates(wsProvider, daTitle, win, path) {
   wsProvider.on('connection-close', async () => {
     const resp = await checkDoc(path);
     if (resp.status === 404) {
-      const split = window.location.hash.slice(2).split('/');
+      const { hash } = window.location;
+      // Guard: hash must start with '#/' — during an IMS redirect the hash is '#access_token=...'
+      // and slice(2) would remove '#a', writing 'ccess_token=...' into the URL as an org name.
+      if (!hash.startsWith('#/')) return;
+      const split = hash.slice(2).split('/');
       split.pop();
       // Navigate to the parent folder
       window.location.replace(`/#/${split.join('/')}`);

--- a/blocks/shared/pathDetails.js
+++ b/blocks/shared/pathDetails.js
@@ -123,8 +123,10 @@ export default function getPathDetails(loc) {
   // config, edit, sheet
   const editor = getView(pathname);
 
-  // IMS will redirect and there's a small window where old_hash exists
-  if (!fullpath || fullpath.startsWith('old_hash') || fullpath.startsWith('access_token')) return null;
+  // IMS redirect fragments appear as '/ld_hash=', '/old_hash=', '/access_token=' in the path.
+  // fullpath always starts with '/' here, so strip it before the prefix check.
+  const pathContent = fullpath.slice(1);
+  if (!pathContent || pathContent.startsWith('old_hash') || pathContent.startsWith('access_token') || pathContent.startsWith('ld_hash')) return null;
 
   // Split everything up so it can be later used for both DA & AEM
   const pathParts = sanitizePathParts(fullpath);


### PR DESCRIPTION
## Problem

Two bugs in the client allow IMS OAuth redirect fragments to leak into admin API calls as an org name, producing requests like `GET /config/ccess_token=<jwt>&state=.../` and `GET /config/ld_hash=/`. These caused 500 errors in da-admin (KV 414 key-too-long) and high-volume spurious 404s. See the worker-side fix in adobe/da-admin#270.

---

### Bug 1 — `blocks/edit/prose/index.js:263`: unsafe `hash.slice(2)`

When a collab WebSocket connection closes and the document returns 404, the code navigates to the parent folder:

```js
const split = window.location.hash.slice(2).split('/');
split.pop();
window.location.replace(`/#/${split.join('/')}`);
```

`.slice(2)` is meant to strip the `#/` prefix. But when IMS has set the hash to `#access_token=<jwt>&state=...` (redirect still in progress), there is no `/` after `#`. `.slice(2)` removes `#a` instead, producing `ccess_token=<jwt>&state=...`. The code then navigates to `/#/ccess_token=<jwt>&state=...`, writing the mangled token into the URL as a path segment.

`getPathDetails()` picks up `/ccess_token=...` as the hash path and extracts `ccess_token=<jwt>...` as the org name. The resulting config API call sends a ~1986-byte key to Cloudflare KV (512-byte limit) → **500**.

**Fix:** guard on `hash.startsWith('#/')` before slicing.

---

### Bug 2 — `blocks/shared/pathDetails.js:127`: guard is dead code + `ld_hash` missing

```js
const fullpath = hash.replace('#', '');  // always '/...' — hashPath always starts with '/'

// This can NEVER trigger: fullpath starts with '/', not 'old_hash' or 'access_token'
if (!fullpath || fullpath.startsWith('old_hash') || fullpath.startsWith('access_token')) return null;
```

`fullpath` is derived from `hashPath`, which is found by `parts.find(part => part.startsWith('/'))` — so it always starts with `/`. The prefix checks against `'old_hash'` and `'access_token'` (no leading `/`) can therefore never match. The guard is dead code.

Additionally, `ld_hash` — the IMS PKCE redirect marker — is not covered at all. When IMS sets the hash to `#/ld_hash=`, `hashPath = '/ld_hash='` passes the `startsWith('/')` check, the dead guard ignores it, and `org = 'ld_hash='` flows into the config API call → **high-volume 404s** (`/config/ld_hash=/`, ~500 requests/12h in production).

**Fix:** strip the leading `/` before the prefix checks, and add `ld_hash`.

---

## Changes

| File | Change |
|------|--------|
| `blocks/edit/prose/index.js` | Add `startsWith('#/')` guard before `hash.slice(2)` in `connection-close` handler |
| `blocks/shared/pathDetails.js` | Fix dead guard (strip leading `/` before prefix check), add `ld_hash` |

## Related

Worker-side defensive fix: adobe/da-admin#270 (catches any remaining cases where an oversized key reaches the KV call, returning 403 instead of 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)