### PR TITLE
feat: Improved html diffing & version compare

### DIFF
--- a/blocks/edit/da-content/da-content.js
+++ b/blocks/edit/da-content/da-content.js
@@ -15,6 +15,7 @@ export default class DaContent extends LitElement {
     _editorLoaded: { state: true },
     _showPane: { state: true },
     _versionUrl: { state: true },
+    _versionLabel: { state: true },
     _externalUrl: { state: true },
   };
 
@@ -64,10 +65,12 @@ export default class DaContent extends LitElement {
 
   handleVersionReset() {
     this._versionUrl = null;
+    this._versionLabel = null;
   }
 
   handleVersionPreview({ detail }) {
     this._versionUrl = detail.url;
+    this._versionLabel = detail.label || detail.date || '';
   }
 
   render() {
@@ -79,6 +82,7 @@ export default class DaContent extends LitElement {
         <da-editor
           path="${this.details.sourceUrl}"
           version="${this._versionUrl}"
+          .versionLabel=${this._versionLabel}
           .permissions=${this.permissions}
           .proseEl=${this.proseEl}
           .wsProvider=${this.wsProvider}

--- a/blocks/edit/da-editor/da-compare.css
+++ b/blocks/edit/da-editor/da-compare.css
@@ -1,0 +1,173 @@
+/* stylelint-disable selector-class-pattern */
+.da-compare-backdrop {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.da-compare-modal {
+  background: #FFF;
+  border-radius: 10px;
+  box-shadow: rgb(0 0 0 / 25%) 0 4px 24px;
+  width: min(960px, 100%);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.da-compare-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  border-bottom: 1px solid #DDD;
+  flex: 0 0 auto;
+}
+
+.da-compare-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.da-compare-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  font-family: var(--body-font-family);
+}
+
+.da-compare-close {
+  background: none;
+  border: none;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 8px;
+  color: #000;
+}
+
+.da-compare-close:hover {
+  color: var(--s2-blue-800);
+}
+
+.da-compare-key {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-family: var(--body-font-family);
+  font-size: 14px;
+}
+
+.da-compare-key del.diffdel,
+.da-compare-key ins.diffins {
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+
+.da-compare-key del.diffdel {
+  background-color: #ffebee;
+  color: #c62828;
+  text-decoration: line-through;
+  border-color: #ef9a9a;
+}
+
+.da-compare-key ins.diffins {
+  background-color: #e8f5e8;
+  color: #2e7d32;
+  text-decoration: none;
+  border-color: #a5d6a7;
+}
+
+.da-compare-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 24px;
+}
+
+.da-compare-modal .da-compare-body .ProseMirror {
+  min-height: auto;
+  box-shadow: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.da-compare-body ins.diffins,
+.da-compare-body ins.diffmod {
+  background-color: #e8f5e8;
+  color: #2e7d32;
+  text-decoration: none;
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid #a5d6a7;
+}
+
+.da-compare-body del.diffdel,
+.da-compare-body del.diffmod {
+  background-color: #ffebee;
+  color: #c62828;
+  text-decoration: line-through;
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid #ef9a9a;
+}
+
+.da-compare-body del.diffmod {
+  background-color: #fff3e0;
+  color: #ef6c00;
+  border-color: #ffcc02;
+}
+
+/* When ins/del wraps block content (tables, table wrappers, paragraphs),
+   render as a block with a colored side bar instead of an inline pill. */
+.da-compare-body ins.diffins:has(table),
+.da-compare-body ins.diffmod:has(table),
+.da-compare-body del.diffdel:has(table),
+.da-compare-body del.diffmod:has(table) {
+  display: block;
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0 0 0 12px;
+  margin: 4px 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.da-compare-body ins.diffins:has(table) {
+  border-left: 4px solid #2e7d32;
+}
+
+.da-compare-body del.diffdel:has(table) {
+  border-left: 4px solid #c62828;
+}
+
+.da-compare-body del.diffmod:has(table) {
+  border-left: 4px solid #ef6c00;
+}
+
+.da-compare-body ins.diffins:has(table) .tableWrapper {
+  border-color: #2e7d32;
+  box-shadow: 0 0 0 1px #a5d6a7;
+}
+
+.da-compare-body del.diffdel:has(table) .tableWrapper {
+  border-color: #c62828;
+  box-shadow: 0 0 0 1px #ef9a9a;
+}
+
+.da-compare-body del.diffdel:has(table) table,
+.da-compare-body del.diffdel:has(table) td,
+.da-compare-body del.diffdel:has(table) th {
+  text-decoration: line-through;
+  color: #8a3a3a;
+}

--- a/blocks/edit/da-editor/da-compare.js
+++ b/blocks/edit/da-editor/da-compare.js
@@ -1,0 +1,97 @@
+import { DOMSerializer } from 'da-y-wrapper';
+import { html } from 'da-lit';
+import getSheet from '../../shared/sheet.js';
+
+let compareSheetPromise;
+function loadCompareSheet() {
+  if (!compareSheetPromise) {
+    compareSheetPromise = getSheet('/blocks/edit/da-editor/da-compare.css');
+  }
+  return compareSheetPromise;
+}
+
+function wrapTablesInWrappers(root) {
+  root.querySelectorAll('table').forEach((table) => {
+    if (table.parentElement?.classList.contains('tableWrapper')) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'tableWrapper';
+    table.replaceWith(wrapper);
+    wrapper.appendChild(table);
+  });
+}
+
+function stripEmptyTopLevelBlocks(root) {
+  const isWhitespace = (s) => !s || /^\s*$/.test(s);
+  Array.from(root.children).forEach((child) => {
+    const hasMedia = child.querySelector('img, video, table, hr, iframe, svg');
+    if (!hasMedia && isWhitespace(child.textContent)) child.remove();
+  });
+}
+
+/**
+ * @param {object} opts
+ * @param {ShadowRoot} opts.shadowRoot
+ * @param {Element|null} opts.versionDom
+ * @param {Function} opts.onClose
+ * @param {Function} opts.onResult - called with (compareDom, cleanup)
+ */
+export async function compare({ shadowRoot, versionDom, onClose, onResult }) {
+  const { schema, doc } = window.view.state;
+  const fragment = DOMSerializer.fromSchema(schema).serializeFragment(doc.content);
+  const liveContainer = document.createElement('div');
+  liveContainer.append(fragment);
+  wrapTablesInWrappers(liveContainer);
+  stripEmptyTopLevelBlocks(liveContainer);
+  const liveHtml = liveContainer.innerHTML;
+
+  let versionHtml = '';
+  if (versionDom) {
+    const versionContainer = versionDom.cloneNode(true);
+    stripEmptyTopLevelBlocks(versionContainer);
+    versionHtml = versionContainer.innerHTML;
+  }
+
+  const [{ htmlDiff }, compareSheet] = await Promise.all([
+    import('../prose/diff/htmldiff.js'),
+    loadCompareSheet(),
+  ]);
+
+  if (!shadowRoot.adoptedStyleSheets.includes(compareSheet)) {
+    shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, compareSheet];
+  }
+
+  const dom = document.createElement('div');
+  dom.className = 'ProseMirror';
+  dom.innerHTML = htmlDiff(liveHtml, versionHtml);
+  wrapTablesInWrappers(dom);
+
+  const onDocClick = (ev) => {
+    const insideModal = ev.composedPath().some((n) => n?.classList?.contains?.('da-compare-modal'));
+    if (!insideModal) onClose();
+  };
+
+  const cleanup = () => document.removeEventListener('click', onDocClick, true);
+
+  setTimeout(() => document.addEventListener('click', onDocClick, true), 0);
+
+  onResult(dom, cleanup);
+}
+
+export function renderModal(versionLabel, compareDom, onClose) {
+  return html`
+    <div class="da-compare-backdrop">
+      <div class="da-compare-modal" role="dialog" aria-label="Compare with current document">
+        <div class="da-compare-header">
+          <div class="da-compare-header-text">
+            <h2 class="da-compare-title">Compare with current document</h2>
+            <div class="da-compare-key">
+              <del class="diffdel">Current Document</del>
+              <ins class="diffins">Version: ${versionLabel || ''}</ins>
+            </div>
+          </div>
+          <button class="da-compare-close" aria-label="Close" @click=${onClose}>&times;</button>
+        </div>
+        <div class="da-compare-body">${compareDom}</div>
+      </div>
+    </div>`;
+}

--- a/blocks/edit/da-editor/da-editor.css
+++ b/blocks/edit/da-editor/da-editor.css
@@ -20,7 +20,8 @@
 
 .da-version-action-area {
   display: flex;
-  justify-content: end;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
   position: absolute;
   top: 0;
@@ -30,6 +31,24 @@
   background: #EFEFEF;
   box-sizing: border-box;
   border-radius: 10px 10px 0 0;
+}
+
+.da-version-title {
+  margin: 0;
+  font-family: var(--body-font-family);
+  font-size: 18px;
+  font-weight: 700;
+  color: #000;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.da-version-action-buttons {
+  display: flex;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 
 .da-version-action-area button {

--- a/blocks/edit/da-editor/da-editor.js
+++ b/blocks/edit/da-editor/da-editor.js
@@ -6,16 +6,34 @@ import { setDaMetadata, htmlToProse } from '../utils/helpers.js';
 
 const sheet = await getSheet('/blocks/edit/da-editor/da-editor.css');
 
+function wrapTablesInWrappers(root) {
+  root.querySelectorAll('table').forEach((table) => {
+    if (table.parentElement?.classList.contains('tableWrapper')) return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'tableWrapper';
+    table.replaceWith(wrapper);
+    wrapper.appendChild(table);
+  });
+}
+
+let daCompare;
+async function loadDaCompare() {
+  if (!daCompare) daCompare = await import('./da-compare.js');
+  return daCompare;
+}
+
 export default class DaEditor extends LitElement {
   static properties = {
     path: { type: String },
     version: { type: String },
+    versionLabel: { attribute: false },
     proseEl: { attribute: false },
     wsProvider: { attribute: false },
     permissions: { state: true },
     _imsLoaded: { state: false },
     _versionDom: { state: true },
     _daMetadata: { state: true },
+    _compareDom: { state: true },
   };
 
   connectedCallback() {
@@ -35,6 +53,7 @@ export default class DaEditor extends LitElement {
 
     const metadataMap = ydoc.getMap('daMetadata');
     this._daMetadata = Object.fromEntries(metadataMap.entries());
+    wrapTablesInWrappers(dom);
     this._versionDom = dom;
   }
 
@@ -43,6 +62,25 @@ export default class DaEditor extends LitElement {
     const event = new CustomEvent('versionreset', opts);
     this.dispatchEvent(event);
     this._versionDom = null;
+    this.handleCloseCompare();
+  }
+
+  async handleCompare() {
+    const m = await loadDaCompare();
+    m.compare({
+      shadowRoot: this.shadowRoot,
+      versionDom: this._versionDom,
+      onClose: this.handleCloseCompare.bind(this),
+      onResult: (dom, cleanup) => {
+        this._compareDom = dom;
+        this._compareCleanup = cleanup;
+      },
+    });
+  }
+
+  handleCloseCompare() {
+    this._compareDom = null;
+    this._compareCleanup?.();
   }
 
   handleRestore() {
@@ -53,7 +91,6 @@ export default class DaEditor extends LitElement {
     const newState = window.view.state.apply(tr);
     window.view.updateState(newState);
 
-    // Restore document metadata to yMap
     Object.entries(this._daMetadata).forEach(([key, value]) => {
       setDaMetadata(key, value);
     });
@@ -74,10 +111,15 @@ export default class DaEditor extends LitElement {
     return html`
       <div class="da-prose-mirror da-version-preview">
         <div class="da-version-action-area">
-          <button @click=${this.handleCancel}>Cancel</button>
-          <button class="accent" @click=${this.handleRestore} ?disabled=${!this._canWrite}>Restore</button>
+          <h2 class="da-version-title">Version: ${this.versionLabel || ''}</h2>
+          <div class="da-version-action-buttons">
+            <button @click=${this.handleCancel}>Cancel</button>
+            <button @click=${this.handleCompare}>Compare</button>
+            <button class="accent" @click=${this.handleRestore} ?disabled=${!this._canWrite}>Restore</button>
+          </div>
         </div>
         <div class="ProseMirror">${this._versionDom}</div>
+        ${this._compareDom ? daCompare.renderModal(this.versionLabel, this._compareDom, this.handleCloseCompare.bind(this)) : nothing}
       </div>`;
   }
 
@@ -92,7 +134,6 @@ export default class DaEditor extends LitElement {
       this.fetchVersion();
     }
 
-    // Do not setup prosemirror until we know the permissions
     if (props.has('proseEl') && this.path && this.permissions) {
       if (this._proseEl) this._proseEl.remove();
       this.shadowRoot.append(this.proseEl);

--- a/blocks/edit/da-versions/da-versions.js
+++ b/blocks/edit/da-versions/da-versions.js
@@ -49,7 +49,7 @@ export default class DaVersions extends LitElement {
     if (!entryEl.classList.contains('is-open')) {
       entryEl.classList.toggle('is-open');
     }
-    const detail = { url: `${DA_ORIGIN}${entry.url}` };
+    const detail = { url: `${DA_ORIGIN}${entry.url}`, label: entry.label, date: entry.date };
     const opts = { detail, bubbles: true, composed: true };
     const event = new CustomEvent('preview', opts);
     this.dispatchEvent(event);

--- a/blocks/edit/prose/diff/htmldiff.js
+++ b/blocks/edit/prose/diff/htmldiff.js
@@ -1,183 +1,638 @@
-/* eslint-disable no-case-declarations */
+/* eslint-disable no-cond-assign, no-case-declarations */
 /**
- * HTML-aware diff functionality that preserves formatting
- * Provides word-level diffing while maintaining HTML structure
+ * HTML-aware diff that produces low-noise, structure-preserving change markup.
+ *
+ * Pipeline:
+ *   1. Block-level pre-segmentation. Top-level block elements are paired so a change in
+ *      one paragraph cannot misalign neighbouring paragraphs. Unpaired blocks are wrapped
+ *      whole; paired-but-modified blocks fall through to inline diff.
+ *   2. Word/tag tokenization with normalised tag signatures (attribute-set equality, not
+ *      string equality) and whitespace-tolerant equality (any run of whitespace == any
+ *      other), so trivial reformatting does not produce diffs.
+ *   3. Ratcliff–Obershelp matching-blocks LCS (the algorithm behind Python's
+ *      difflib.SequenceMatcher), then a semantic-cleanup pass that coalesces edit
+ *      clusters separated only by short or whitespace-only equal runs.
+ *   4. Tag-balanced rendering: <ins>/<del> wrappers never enclose an unbalanced open or
+ *      close tag, and a tag-pair added/removed around equal content is rendered as a
+ *      single wrapper around the whole element rather than two separate markers.
  */
 
-/**
- * Parse HTML into an array of tokens (tags and text segments)
- * @param {string} html - HTML string to parse
- * @returns {Array} Array of token objects with type and content
- */
-function parseHtmlTokens(html) {
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+  'link', 'meta', 'param', 'source', 'track', 'wbr',
+]);
+
+// ---------------------------------------------------------------------------
+// Tokenization
+// ---------------------------------------------------------------------------
+
+const TAG_RE = /<\/?[a-zA-Z][a-zA-Z0-9-]*[^>]*>/g;
+const ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_.:]*)\s*=\s*("[^"]*"|'[^']*'|[^\s"'>=`]+)/g;
+
+function normalizeAttrs(attrString) {
+  if (!attrString) return '';
+  const attrs = [];
+  let m;
+  ATTR_RE.lastIndex = 0;
+  while ((m = ATTR_RE.exec(attrString)) !== null) {
+    let val = m[2];
+    if ((val.startsWith('"') && val.endsWith('"'))
+        || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    attrs.push(`${m[1].toLowerCase()}=${val.replace(/\s+/g, ' ').trim()}`);
+  }
+  attrs.sort();
+  return attrs.join('|');
+}
+
+function describeTag(raw) {
+  const m = raw.match(/^<\s*(\/)?\s*([a-zA-Z][a-zA-Z0-9-]*)([^>]*?)\s*\/?\s*>$/);
+  if (!m) return { kind: 'void', name: '', signature: `raw:${raw}`, content: raw };
+  const isClose = !!m[1];
+  const name = m[2].toLowerCase();
+  const attrString = m[3] || '';
+  const selfClosing = /\/\s*>$/.test(raw);
+  let kind;
+  if (isClose) kind = 'close';
+  else if (selfClosing || VOID_ELEMENTS.has(name)) kind = 'void';
+  else kind = 'open';
+  const signature = `${kind}:${name}:${normalizeAttrs(attrString)}`;
+  return { kind, name, signature, content: raw };
+}
+
+function pushTextTokens(tokens, text) {
+  if (!text) return;
+  const parts = text.split(/(\s+)/);
+  for (const part of parts) {
+    if (!part) {
+      // empty splits at the boundaries
+    } else if (/^\s+$/.test(part)) {
+      tokens.push({ kind: 'space', content: part, signature: 'space' });
+    } else {
+      tokens.push({ kind: 'word', content: part, signature: `w:${part}` });
+    }
+  }
+}
+
+function tokenize(html) {
   const tokens = [];
-  const tagRegex = /<[^>]*>/g;
-  let lastIndex = 0;
-  let match;
-
-  // eslint-disable-next-line no-cond-assign
-  while ((match = tagRegex.exec(html)) !== null) {
-    if (match.index > lastIndex) {
-      const textContent = html.substring(lastIndex, match.index);
-      if (textContent) {
-        // Split text into words and whitespace
-        const textTokens = textContent.split(/(\s+)/).filter((token) => token.length > 0);
-        tokens.push(...textTokens.map((token) => ({ type: 'text', content: token })));
-      }
-    }
-
-    tokens.push({ type: 'tag', content: match[0] });
-    lastIndex = match.index + match[0].length;
+  let last = 0;
+  let m;
+  TAG_RE.lastIndex = 0;
+  while ((m = TAG_RE.exec(html)) !== null) {
+    if (m.index > last) pushTextTokens(tokens, html.substring(last, m.index));
+    const tag = describeTag(m[0]);
+    tokens.push({ ...tag });
+    last = m.index + m[0].length;
   }
-
-  if (lastIndex < html.length) {
-    const textContent = html.substring(lastIndex);
-    if (textContent) {
-      const textTokens = textContent.split(/(\s+)/).filter((token) => token.length > 0);
-      tokens.push(...textTokens.map((token) => ({ type: 'text', content: token })));
-    }
-  }
-
+  if (last < html.length) pushTextTokens(tokens, html.substring(last));
   return tokens;
 }
 
-/**
- * Check if two tokens are equal
- * @param {Object} token1 - First token
- * @param {Object} token2 - Second token
- * @returns {boolean} True if tokens are equal
- */
-function tokensEqual(token1, token2) {
-  return token1.type === token2.type && token1.content === token2.content;
+// ---------------------------------------------------------------------------
+// Ratcliff–Obershelp matching-blocks LCS
+// ---------------------------------------------------------------------------
+
+function buildIndex(tokens) {
+  const map = new Map();
+  for (let i = 0; i < tokens.length; i += 1) {
+    const sig = tokens[i].signature;
+    let bucket = map.get(sig);
+    if (!bucket) {
+      bucket = [];
+      map.set(sig, bucket);
+    }
+    bucket.push(i);
+  }
+  return map;
 }
 
-/**
- * Find diff operations using a simplified LCS approach
- * @param {Array} oldTokens - Tokens from original HTML
- * @param {Array} newTokens - Tokens from modified HTML
- * @returns {Array} Array of diff operations
- */
-function findDiffOperations(oldTokens, newTokens) {
-  const operations = [];
-  let oldIndex = 0;
-  let newIndex = 0;
-
-  while (oldIndex < oldTokens.length || newIndex < newTokens.length) {
-    if (oldIndex >= oldTokens.length) {
-      operations.push({ type: 'insert', oldIndex, newIndex, length: newTokens.length - newIndex });
-      break;
-    } else if (newIndex >= newTokens.length) {
-      operations.push({ type: 'delete', oldIndex, newIndex, length: oldTokens.length - oldIndex });
-      break;
-    } else if (tokensEqual(oldTokens[oldIndex], newTokens[newIndex])) {
-      let matchLength = 0;
-      while (
-        oldIndex + matchLength < oldTokens.length
-        && newIndex + matchLength < newTokens.length
-        && tokensEqual(oldTokens[oldIndex + matchLength], newTokens[newIndex + matchLength])
-      ) {
-        matchLength += 1;
-      }
-      operations.push({ type: 'equal', oldIndex, newIndex, length: matchLength });
-      oldIndex += matchLength;
-      newIndex += matchLength;
-    } else {
-      let foundMatch = false;
-      const lookAhead = 10;
-
-      // Look ahead in new tokens for current old token
-      for (let i = 1; i <= lookAhead && newIndex + i < newTokens.length; i += 1) {
-        if (tokensEqual(oldTokens[oldIndex], newTokens[newIndex + i])) {
-          operations.push({ type: 'insert', oldIndex, newIndex, length: i });
-          newIndex += i;
-          foundMatch = true;
-          break;
-        }
-      }
-
-      if (!foundMatch) {
-        // Look ahead in old tokens for current new token
-        for (let i = 1; i <= lookAhead && oldIndex + i < oldTokens.length; i += 1) {
-          if (tokensEqual(oldTokens[oldIndex + i], newTokens[newIndex])) {
-            operations.push({ type: 'delete', oldIndex, newIndex, length: i });
-            oldIndex += i;
-            foundMatch = true;
-            break;
+function findLongestMatch(a, b, alo, ahi, blo, bhi, b2j) {
+  let besti = alo;
+  let bestj = blo;
+  let bestsize = 0;
+  let j2len = new Map();
+  for (let i = alo; i < ahi; i += 1) {
+    const newJ2len = new Map();
+    const indices = b2j.get(a[i].signature);
+    if (indices) {
+      for (const j of indices) {
+        if (j >= bhi) break;
+        if (j >= blo) {
+          const k = (j2len.get(j - 1) || 0) + 1;
+          newJ2len.set(j, k);
+          if (k > bestsize) {
+            besti = i - k + 1;
+            bestj = j - k + 1;
+            bestsize = k;
           }
         }
       }
+    }
+    j2len = newJ2len;
+  }
+  return { besti, bestj, bestsize };
+}
 
-      if (!foundMatch) {
-        operations.push({ type: 'delete', oldIndex, newIndex, length: 1 });
-        operations.push({ type: 'insert', oldIndex: oldIndex + 1, newIndex, length: 1 });
-        oldIndex += 1;
-        newIndex += 1;
+function getMatchingBlocks(a, b) {
+  const b2j = buildIndex(b);
+  const blocks = [];
+  const stack = [[0, a.length, 0, b.length]];
+  while (stack.length) {
+    const [alo, ahi, blo, bhi] = stack.pop();
+    const { besti, bestj, bestsize } = findLongestMatch(a, b, alo, ahi, blo, bhi, b2j);
+    if (bestsize > 0) {
+      blocks.push({ ai: besti, bi: bestj, size: bestsize });
+      if (alo < besti && blo < bestj) stack.push([alo, besti, blo, bestj]);
+      if (besti + bestsize < ahi && bestj + bestsize < bhi) {
+        stack.push([besti + bestsize, ahi, bestj + bestsize, bhi]);
       }
     }
   }
-
-  return operations;
-}
-
-/**
- * Build the final diff HTML from operations
- * @param {Array} operations - Array of diff operations
- * @param {Array} oldTokens - Original tokens
- * @param {Array} newTokens - Modified tokens
- * @returns {string} HTML string with diff markup
- */
-function buildDiffHtml(operations, oldTokens, newTokens) {
-  const result = [];
-
-  for (const op of operations) {
-    switch (op.type) {
-      case 'equal':
-        for (let i = 0; i < op.length; i += 1) {
-          result.push(oldTokens[op.oldIndex + i].content);
-        }
-        break;
-
-      case 'delete':
-        // Wrap deleted tokens in <del> tags
-        const deletedContent = [];
-        for (let i = 0; i < op.length; i += 1) {
-          deletedContent.push(oldTokens[op.oldIndex + i].content);
-        }
-        if (deletedContent.length > 0) {
-          result.push(`<del class="diffdel">${deletedContent.join('')}</del>`);
-        }
-        break;
-
-      case 'insert':
-        // Wrap inserted tokens in <ins> tags
-        const insertedContent = [];
-        for (let i = 0; i < op.length; i += 1) {
-          insertedContent.push(newTokens[op.newIndex + i].content);
-        }
-        if (insertedContent.length > 0) {
-          result.push(`<ins class="diffins">${insertedContent.join('')}</ins>`);
-        }
-        break;
-      default:
-        break;
+  blocks.sort((x, y) => x.ai - y.ai || x.bi - y.bi);
+  const merged = [];
+  for (const blk of blocks) {
+    const last = merged.length ? merged[merged.length - 1] : null;
+    if (last && last.ai + last.size === blk.ai && last.bi + last.size === blk.bi) {
+      last.size += blk.size;
+    } else {
+      merged.push({ ...blk });
     }
   }
+  merged.push({ ai: a.length, bi: b.length, size: 0 });
+  return merged;
+}
 
-  return result.join('');
+function computeOps(a, b) {
+  const blocks = getMatchingBlocks(a, b);
+  const ops = [];
+  let ai = 0;
+  let bi = 0;
+  for (const blk of blocks) {
+    const oldLen = blk.ai - ai;
+    const newLen = blk.bi - bi;
+    if (oldLen > 0 && newLen > 0) {
+      ops.push({ type: 'delete', oldStart: ai, oldEnd: blk.ai });
+      ops.push({ type: 'insert', newStart: bi, newEnd: blk.bi });
+    } else if (oldLen > 0) {
+      ops.push({ type: 'delete', oldStart: ai, oldEnd: blk.ai });
+    } else if (newLen > 0) {
+      ops.push({ type: 'insert', newStart: bi, newEnd: blk.bi });
+    }
+    if (blk.size > 0) {
+      ops.push({
+        type: 'equal',
+        oldStart: blk.ai,
+        oldEnd: blk.ai + blk.size,
+        newStart: blk.bi,
+        newEnd: blk.bi + blk.size,
+      });
+    }
+    ai = blk.ai + blk.size;
+    bi = blk.bi + blk.size;
+  }
+  return ops;
+}
+
+// ---------------------------------------------------------------------------
+// Semantic cleanup: coalesce edit clusters separated by trivial equal runs
+// ---------------------------------------------------------------------------
+
+function isSubstantialEqual(op, oldTokens) {
+  if (op.type !== 'equal') return false;
+  // Any non-whitespace token anchors. Whitespace-only equal runs get merged into
+  // surrounding edits, so trivial spacing between phrases doesn't fragment the output.
+  for (let i = op.oldStart; i < op.oldEnd; i += 1) {
+    if (oldTokens[i].kind !== 'space') return true;
+  }
+  return false;
+}
+
+function cleanupSemantic(ops, oldTokens) {
+  const out = [];
+  let cluster = [];
+
+  const flushCluster = () => {
+    if (cluster.length === 0) return;
+    // Pull whitespace-only equals at the cluster boundaries back out as their own ops,
+    // so a space adjacent to an edit doesn't get swallowed into the <ins>/<del> wrapper.
+    while (cluster.length > 0 && cluster[0].type === 'equal') {
+      out.push(cluster.shift());
+    }
+    const trailing = [];
+    while (cluster.length > 0 && cluster[cluster.length - 1].type === 'equal') {
+      trailing.unshift(cluster.pop());
+    }
+    if (cluster.length > 0) {
+      let oldStart = Infinity;
+      let oldEnd = -Infinity;
+      let newStart = Infinity;
+      let newEnd = -Infinity;
+      for (const op of cluster) {
+        if (op.type === 'equal' || op.type === 'delete') {
+          oldStart = Math.min(oldStart, op.oldStart);
+          oldEnd = Math.max(oldEnd, op.oldEnd);
+        }
+        if (op.type === 'equal' || op.type === 'insert') {
+          newStart = Math.min(newStart, op.newStart);
+          newEnd = Math.max(newEnd, op.newEnd);
+        }
+      }
+      const hasOld = Number.isFinite(oldStart) && oldEnd > oldStart;
+      const hasNew = Number.isFinite(newStart) && newEnd > newStart;
+      if (hasOld) out.push({ type: 'delete', oldStart, oldEnd });
+      if (hasNew) out.push({ type: 'insert', newStart, newEnd });
+    }
+    for (const t of trailing) out.push(t);
+    cluster = [];
+  };
+
+  for (const op of ops) {
+    if (op.type === 'equal' && isSubstantialEqual(op, oldTokens)) {
+      flushCluster();
+      out.push(op);
+    } else {
+      cluster.push(op);
+    }
+  }
+  flushCluster();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tag-balanced rendering with wrap-around detection
+// ---------------------------------------------------------------------------
+
+function findUnbalanced(tokens) {
+  const unbalanced = new Set();
+  const stack = [];
+  for (let i = 0; i < tokens.length; i += 1) {
+    const t = tokens[i];
+    if (t.kind === 'open') {
+      stack.push(i);
+    } else if (t.kind === 'close') {
+      let matched = -1;
+      for (let s = stack.length - 1; s >= 0; s -= 1) {
+        if (tokens[stack[s]].name === t.name) {
+          matched = s;
+          break;
+        }
+      }
+      if (matched === -1) {
+        unbalanced.add(i);
+      } else {
+        stack.length = matched;
+      }
+    }
+  }
+  for (const idx of stack) unbalanced.add(idx);
+  return unbalanced;
+}
+
+function wrap(html, klass) {
+  if (!html) return '';
+  const tag = klass === 'diffins' ? 'ins' : 'del';
+  return `<${tag} class="${klass}">${html}</${tag}>`;
+}
+
+function renderEditTokens(tokens, klass) {
+  if (tokens.length === 0) return '';
+  const unbalanced = findUnbalanced(tokens);
+  let out = '';
+  let buffer = '';
+  for (let i = 0; i < tokens.length; i += 1) {
+    if (unbalanced.has(i)) {
+      out += wrap(buffer, klass);
+      out += wrap(tokens[i].content, klass);
+      buffer = '';
+    } else {
+      buffer += tokens[i].content;
+    }
+  }
+  out += wrap(buffer, klass);
+  return out;
+}
+
+function tokensToString(tokens) {
+  let s = '';
+  for (const t of tokens) s += t.content;
+  return s;
 }
 
 /**
- * Main HTML diff function - compares two HTML strings and returns diff markup
- * @param {string} oldHtml - Original HTML string
- * @param {string} newHtml - Modified HTML string
- * @returns {string} HTML string with diff markup (ins/del tags)
+ * Detect a "wrap-around" change: an edit run starts with one or more unbalanced opens
+ * and the next edit run of the same type (after one equal run) starts with the matching
+ * unbalanced closes. Render those unbalanced tags with their equal-content sandwiched,
+ * marked with diffmod styling, instead of emitting the open and close as two separate
+ * <ins>/<del> blocks. This is what makes "<strong> wrapped around 'world'" read as one
+ * change rather than two stranded tag insertions.
+ */
+function tryWrapAround(opIndex, ops, oldTokens, newTokens) {
+  const op = ops[opIndex];
+  if (op.type !== 'insert' && op.type !== 'delete') return null;
+  const next = ops[opIndex + 1];
+  const after = ops[opIndex + 2];
+  if (!next || next.type !== 'equal') return null;
+  if (!after || after.type !== op.type) return null;
+
+  const editTokens = op.type === 'insert'
+    ? newTokens.slice(op.newStart, op.newEnd)
+    : oldTokens.slice(op.oldStart, op.oldEnd);
+  const closeTokens = op.type === 'insert'
+    ? newTokens.slice(after.newStart, after.newEnd)
+    : oldTokens.slice(after.oldStart, after.oldEnd);
+
+  // Collect leading opens on the first edit and matching trailing closes on the second.
+  const leadingOpens = [];
+  for (const t of editTokens) {
+    if (t.kind === 'open') leadingOpens.push(t);
+    else break;
+  }
+  if (leadingOpens.length === 0) return null;
+
+  let matched = 0;
+  const trailingCloses = [];
+  for (let i = 0; i < closeTokens.length; i += 1) {
+    const t = closeTokens[i];
+    if (t.kind === 'close' && matched < leadingOpens.length
+        && t.name === leadingOpens[leadingOpens.length - 1 - matched].name) {
+      trailingCloses.push(t);
+      matched += 1;
+    } else {
+      break;
+    }
+  }
+  if (matched === 0) return null;
+
+  const usedOpens = leadingOpens.slice(0, matched);
+  const usedCloses = trailingCloses.slice(0, matched);
+
+  // The remaining tokens on either side fall back through normal rendering.
+  const editRest = editTokens.slice(usedOpens.length);
+  const closeRest = closeTokens.slice(usedCloses.length);
+
+  const klass = op.type === 'insert' ? 'diffins' : 'diffdel';
+  let html = '';
+  if (editRest.length) html += renderEditTokens(editRest, klass);
+
+  // Wrap the equal content with the inserted/deleted tags, inside a single <ins>/<del>.
+  let inner = '';
+  for (const t of usedOpens) inner += t.content;
+  inner += tokensToString(
+    oldTokens.slice(next.oldStart, next.oldEnd),
+  );
+  for (const t of usedCloses) inner += t.content;
+  html += wrap(inner, klass);
+
+  if (closeRest.length) html += renderEditTokens(closeRest, klass);
+
+  return { html, consumed: 3 };
+}
+
+function renderOps(ops, oldTokens, newTokens) {
+  let out = '';
+  let i = 0;
+  while (i < ops.length) {
+    const op = ops[i];
+    if (op.type === 'equal') {
+      // Use new-side tokens so whitespace/attribute normalization reflects the new state.
+      out += tokensToString(newTokens.slice(op.newStart, op.newEnd));
+      i += 1;
+    } else {
+      const wrapped = tryWrapAround(i, ops, oldTokens, newTokens);
+      if (wrapped) {
+        out += wrapped.html;
+        i += wrapped.consumed;
+      } else {
+        if (op.type === 'insert') {
+          out += renderEditTokens(newTokens.slice(op.newStart, op.newEnd), 'diffins');
+        } else {
+          out += renderEditTokens(oldTokens.slice(op.oldStart, op.oldEnd), 'diffdel');
+        }
+        i += 1;
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Inline diff (Phases 1+2 combined): tokenize → LCS → cleanup → render
+// ---------------------------------------------------------------------------
+
+function inlineDiff(oldHtml, newHtml) {
+  if (oldHtml === newHtml) return oldHtml;
+  const oldTokens = tokenize(oldHtml);
+  const newTokens = tokenize(newHtml);
+  const rawOps = computeOps(oldTokens, newTokens);
+  const ops = cleanupSemantic(rawOps, oldTokens);
+  return renderOps(ops, oldTokens, newTokens);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: block-level segmentation
+// ---------------------------------------------------------------------------
+
+/**
+ * Split HTML into top-level "block units" using a depth-tracking tokenizer pass.
+ * Each unit is either a closed block element, a void element, or a run of inline content.
+ * Returns null if the depth never returns to zero (malformed HTML), so the caller can
+ * fall back to plain inline diff.
+ */
+function segmentTopLevelBlocks(html) {
+  const units = [];
+  const tagRe = /<\/?([a-zA-Z][a-zA-Z0-9-]*)([^>]*?)\/?>/g;
+  let depth = 0;
+  let blockStart = -1;
+  let inlineStart = 0;
+  let m;
+  while ((m = tagRe.exec(html)) !== null) {
+    const name = m[1].toLowerCase();
+    const isClose = m[0].startsWith('</');
+    const isSelfClose = /\/\s*>$/.test(m[0]);
+    const isVoid = VOID_ELEMENTS.has(name) || isSelfClose;
+
+    if (depth === 0) {
+      if (isClose) {
+        // Stray close at top level — treat as malformed.
+        return null;
+      }
+      // Flush any inline content that preceded this top-level open/void.
+      if (m.index > inlineStart) {
+        const inline = html.substring(inlineStart, m.index);
+        if (inline.trim()) units.push({ kind: 'inline', html: inline, text: inline, name: 'inline' });
+      }
+      if (isVoid) {
+        units.push({ kind: 'void', html: m[0], text: '', name });
+        inlineStart = m.index + m[0].length;
+      } else {
+        depth = 1;
+        blockStart = m.index;
+      }
+    } else if (isClose) {
+      depth -= 1;
+      if (depth === 0) {
+        const blockHtml = html.substring(blockStart, m.index + m[0].length);
+        const text = blockHtml.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+        const topName = (blockHtml.match(/^<\s*([a-zA-Z][a-zA-Z0-9-]*)/) || [])[1] || '';
+        units.push({ kind: 'block', html: blockHtml, text, name: topName.toLowerCase() });
+        inlineStart = m.index + m[0].length;
+      }
+    } else if (!isVoid) {
+      depth += 1;
+    }
+  }
+  if (depth !== 0) return null;
+  if (inlineStart < html.length) {
+    const inline = html.substring(inlineStart);
+    if (inline.trim()) units.push({ kind: 'inline', html: inline, text: inline, name: 'inline' });
+  }
+  return units;
+}
+
+function similarityScore(a, b) {
+  const sameKind = a.kind === b.kind;
+  const sameName = a.name === b.name;
+  const wordsA = new Set(a.text.toLowerCase().split(/\s+/).filter(Boolean));
+  const wordsB = new Set(b.text.toLowerCase().split(/\s+/).filter(Boolean));
+  if (wordsA.size === 0 && wordsB.size === 0) return sameKind && sameName ? 1 : 0;
+  let inter = 0;
+  for (const w of wordsA) if (wordsB.has(w)) inter += 1;
+  const union = wordsA.size + wordsB.size - inter;
+  const jaccard = union === 0 ? 0 : inter / union;
+  // Same kind + same tag name is a strong pairing signal even without word overlap —
+  // e.g. "<strong>world</strong>" and "<strong>universe</strong>" should still pair so
+  // we can inline-diff them rather than emit two whole-block del/ins markers.
+  let score = jaccard;
+  if (sameKind && sameName) score += 0.5;
+  else if (sameKind) score += 0.1;
+  return Math.min(1, score);
+}
+
+function pairAndDiffUnits(oldUnits, newUnits) {
+  if (oldUnits.length === 0 && newUnits.length === 0) return '';
+  if (oldUnits.length === 0) {
+    return newUnits.map((u) => wrap(u.html, 'diffins')).join('');
+  }
+  if (newUnits.length === 0) {
+    return oldUnits.map((u) => wrap(u.html, 'diffdel')).join('');
+  }
+
+  // Greedy similarity pairing, but only forward-monotonic pairs (preserves order).
+  const pairs = [];
+  const candidates = [];
+  for (let i = 0; i < oldUnits.length; i += 1) {
+    for (let j = 0; j < newUnits.length; j += 1) {
+      const score = similarityScore(oldUnits[i], newUnits[j]);
+      if (score >= 0.34) candidates.push({ i, j, score });
+    }
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  const usedOld = new Set();
+  const usedNew = new Set();
+  for (const c of candidates) {
+    if (!usedOld.has(c.i) && !usedNew.has(c.j)) {
+      // Reject if it would cross an existing pair (preserve relative order).
+      let crosses = false;
+      for (const p of pairs) {
+        if ((p.i < c.i && p.j > c.j) || (p.i > c.i && p.j < c.j)) {
+          crosses = true;
+          break;
+        }
+      }
+      if (!crosses) {
+        pairs.push({ i: c.i, j: c.j });
+        usedOld.add(c.i);
+        usedNew.add(c.j);
+      }
+    }
+  }
+  pairs.sort((a, b) => a.i - b.i);
+
+  let oi = 0;
+  let ni = 0;
+  let out = '';
+  for (const p of pairs) {
+    while (oi < p.i) {
+      out += wrap(oldUnits[oi].html, 'diffdel');
+      oi += 1;
+    }
+    while (ni < p.j) {
+      out += wrap(newUnits[ni].html, 'diffins');
+      ni += 1;
+    }
+    out += inlineDiff(oldUnits[p.i].html, newUnits[p.j].html);
+    oi += 1;
+    ni += 1;
+  }
+  while (oi < oldUnits.length) {
+    out += wrap(oldUnits[oi].html, 'diffdel');
+    oi += 1;
+  }
+  while (ni < newUnits.length) {
+    out += wrap(newUnits[ni].html, 'diffins');
+    ni += 1;
+  }
+  return out;
+}
+
+function diffByBlocks(oldHtml, newHtml) {
+  const oldUnits = segmentTopLevelBlocks(oldHtml);
+  const newUnits = segmentTopLevelBlocks(newHtml);
+  if (!oldUnits || !newUnits) return null;
+
+  // Don't bother with block-level work if neither side actually has multiple blocks
+  // and there is no full-block insert or delete to detect.
+  const oldBlockCount = oldUnits.filter((u) => u.kind === 'block').length;
+  const newBlockCount = newUnits.filter((u) => u.kind === 'block').length;
+  if (oldBlockCount <= 1 && newBlockCount <= 1
+      && oldUnits.length === 1 && newUnits.length === 1) {
+    return null;
+  }
+
+  // Match blocks by exact text+tag signature first; whatever's left between anchors
+  // gets paired by similarity.
+  const sig = (u) => `${u.kind}:${u.name}:${u.text}`;
+  const oldSigs = oldUnits.map((u) => ({ signature: sig(u) }));
+  const newSigs = newUnits.map((u) => ({ signature: sig(u) }));
+  const blocks = getMatchingBlocks(oldSigs, newSigs);
+
+  let out = '';
+  let oi = 0;
+  let ni = 0;
+  for (const blk of blocks) {
+    if (blk.ai > oi || blk.bi > ni) {
+      out += pairAndDiffUnits(
+        oldUnits.slice(oi, blk.ai),
+        newUnits.slice(ni, blk.bi),
+      );
+    }
+    for (let k = 0; k < blk.size; k += 1) {
+      out += oldUnits[blk.ai + k].html;
+    }
+    oi = blk.ai + blk.size;
+    ni = blk.bi + blk.size;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two HTML strings and return diff markup using <ins class="diffins">
+ * and <del class="diffdel">.
  */
 // eslint-disable-next-line import/prefer-default-export
 export function htmlDiff(oldHtml, newHtml) {
-  const oldTokens = parseHtmlTokens(oldHtml);
-  const newTokens = parseHtmlTokens(newHtml);
+  if (oldHtml === newHtml) return oldHtml;
+  if (!oldHtml) return newHtml ? wrap(newHtml, 'diffins') : '';
+  if (!newHtml) return wrap(oldHtml, 'diffdel');
 
-  const operations = findDiffOperations(oldTokens, newTokens);
+  const blockResult = diffByBlocks(oldHtml, newHtml);
+  if (blockResult !== null) return blockResult;
 
-  return buildDiffHtml(operations, oldTokens, newTokens);
+  return inlineDiff(oldHtml, newHtml);
 }

--- a/test/unit/blocks/edit/prose/diff/htmldiff.test.js
+++ b/test/unit/blocks/edit/prose/diff/htmldiff.test.js
@@ -34,14 +34,16 @@ describe('HTML Diff', () => {
       const oldHtml = '<p>Hello world</p>';
       const newHtml = '<p>Hello <strong>world</strong></p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p>Hello <ins class="diffins"><strong></ins>world<ins class="diffins"></strong></ins></p>');
+      // Wrap-around insertion: <strong> opened around equal content "world" and closed
+      // again all in one logical change, so it renders as one wrapper instead of two.
+      expect(result).to.equal('<p>Hello <ins class="diffins"><strong>world</strong></ins></p>');
     });
 
     it('should handle HTML tag removals', () => {
       const oldHtml = '<p>Hello <strong>world</strong></p>';
       const newHtml = '<p>Hello world</p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p>Hello <del class="diffdel"><strong></del>world<del class="diffdel"></strong></del></p>');
+      expect(result).to.equal('<p>Hello <del class="diffdel"><strong>world</strong></del></p>');
     });
 
     it('should handle complex HTML structures', () => {
@@ -68,18 +70,21 @@ describe('HTML Diff', () => {
       expect(result).to.equal('<del class="diffdel"><p>Hello</p></del>');
     });
 
-    it('should handle whitespace changes', () => {
+    it('should treat whitespace-only changes as no-op', () => {
+      // Whitespace runs are equality-tolerant (any run of whitespace == any other), so
+      // pretty-printing differences round-trip silently instead of polluting the diff.
       const oldHtml = '<p>Hello world</p>';
       const newHtml = '<p>Hello  world</p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p>Hello<del class="diffdel"> </del><ins class="diffins">  </ins>world</p>');
+      expect(result).to.equal('<p>Hello  world</p>');
     });
 
     it('should handle multiple word changes', () => {
       const oldHtml = '<p>The quick brown fox</p>';
       const newHtml = '<p>The slow red fox</p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p>The <del class="diffdel">quick</del><ins class="diffins">slow</ins> <del class="diffdel">brown</del><ins class="diffins">red</ins> fox</p>');
+      // Adjacent edits separated only by whitespace are coalesced into a single change.
+      expect(result).to.equal('<p>The <del class="diffdel">quick brown</del><ins class="diffins">slow red</ins> fox</p>');
     });
 
     it('should handle nested HTML tags', () => {
@@ -114,7 +119,7 @@ describe('HTML Diff', () => {
       const oldHtml = '<p>one two three</p>';
       const newHtml = '<p>alpha beta gamma</p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p><del class="diffdel">one</del><ins class="diffins">alpha</ins> <del class="diffdel">two</del><ins class="diffins">beta</ins> <del class="diffdel">three</del><ins class="diffins">gamma</ins></p>');
+      expect(result).to.equal('<p><del class="diffdel">one two three</del><ins class="diffins">alpha beta gamma</ins></p>');
     });
 
     it('should handle word reordering', () => {
@@ -169,7 +174,7 @@ describe('HTML Diff', () => {
       const oldHtml = '<p>Hello     world</p>';
       const newHtml = '<p>Hello world</p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p>Hello<del class="diffdel">     </del><ins class="diffins"> </ins>world</p>');
+      expect(result).to.equal('<p>Hello world</p>');
     });
 
     it('should handle tag attribute changes (tags treated as different)', () => {
@@ -183,7 +188,9 @@ describe('HTML Diff', () => {
       const oldHtml = '<div><p>Hello</p></div>';
       const newHtml = '<section><h1>Hello</h1></section>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<del class="diffdel"><div></del><ins class="diffins"><section></ins><del class="diffdel"><p></del><ins class="diffins"><h1></ins>Hello<del class="diffdel"></p></del><ins class="diffins"></h1></ins><del class="diffdel"></div></del><ins class="diffins"></section></ins>');
+      // Deletes are emitted as one run, then inserts as one run, instead of token-by-token
+      // interleaving.
+      expect(result).to.equal('<del class="diffdel"><div></del><del class="diffdel"><p></del><ins class="diffins"><section></ins><ins class="diffins"><h1></ins>Hello<del class="diffdel"></p></del><del class="diffdel"></div></del><ins class="diffins"></h1></ins><ins class="diffins"></section></ins>');
     });
 
     it('should handle insertion at the beginning', () => {
@@ -204,7 +211,69 @@ describe('HTML Diff', () => {
       const oldHtml = '<p>The quick brown fox jumps</p>';
       const newHtml = '<p>A slow red cat walks</p>';
       const result = htmlDiff(oldHtml, newHtml);
-      expect(result).to.equal('<p><del class="diffdel">The</del><ins class="diffins">A</ins> <del class="diffdel">quick</del><ins class="diffins">slow</ins> <del class="diffdel">brown</del><ins class="diffins">red</ins> <del class="diffdel">fox</del><ins class="diffins">cat</ins> <del class="diffdel">jumps</del><ins class="diffins">walks</ins></p>');
+      // No words match so the whole run collapses into one delete + one insert rather than
+      // five interleaved word-pair markers.
+      expect(result).to.equal('<p><del class="diffdel">The quick brown fox jumps</del><ins class="diffins">A slow red cat walks</ins></p>');
+    });
+  });
+
+  describe('block-level segmentation', () => {
+    it('isolates per-paragraph changes so neighbours stay untouched', () => {
+      const oldHtml = '<p>One</p><p>Two</p><p>Three</p>';
+      const newHtml = '<p>One</p><p>Two changed</p><p>Three</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      expect(result).to.equal('<p>One</p><p>Two<ins class="diffins"> changed</ins></p><p>Three</p>');
+    });
+
+    it('marks an inserted paragraph as a single ins block', () => {
+      const oldHtml = '<p>One</p><p>Three</p>';
+      const newHtml = '<p>One</p><p>Two</p><p>Three</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      expect(result).to.equal('<p>One</p><ins class="diffins"><p>Two</p></ins><p>Three</p>');
+    });
+
+    it('marks a deleted paragraph as a single del block', () => {
+      const oldHtml = '<p>One</p><p>Two</p><p>Three</p>';
+      const newHtml = '<p>One</p><p>Three</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      expect(result).to.equal('<p>One</p><del class="diffdel"><p>Two</p></del><p>Three</p>');
+    });
+
+    it('pairs siblings of the same tag even with no shared words', () => {
+      const oldHtml = '<h1>Original Title</h1><p>Body content here</p>';
+      const newHtml = '<h1>Brand New Heading</h1><p>Body content here</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      // h1 paired with h1 by tag-name signal, body paragraph stays as-is.
+      expect(result).to.equal('<h1><del class="diffdel">Original Title</del><ins class="diffins">Brand New Heading</ins></h1><p>Body content here</p>');
+    });
+  });
+
+  describe('attribute normalization', () => {
+    it('treats reordered attributes as equal', () => {
+      const oldHtml = '<p class="a" id="x">Hello</p>';
+      const newHtml = '<p id="x" class="a">Hello</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      // Different string, same attribute set — no diff is emitted; the new-side string is
+      // returned verbatim because that's the current state of the document.
+      expect(result).to.equal(newHtml);
+    });
+  });
+
+  describe('semantic cleanup', () => {
+    it('coalesces edits separated only by trivial whitespace', () => {
+      const oldHtml = '<p>foo bar baz</p>';
+      const newHtml = '<p>FOO BAR baz</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      // foo→FOO and bar→BAR are merged across the single space anchor.
+      expect(result).to.equal('<p><del class="diffdel">foo bar</del><ins class="diffins">FOO BAR</ins> baz</p>');
+    });
+
+    it('keeps anchor words between unrelated edits', () => {
+      const oldHtml = '<p>alpha SHARED beta</p>';
+      const newHtml = '<p>gamma SHARED delta</p>';
+      const result = htmlDiff(oldHtml, newHtml);
+      // SHARED is a real word equal between two edits — it must anchor and split them.
+      expect(result).to.equal('<p><del class="diffdel">alpha</del><ins class="diffins">gamma</ins> SHARED <del class="diffdel">beta</del><ins class="diffins">delta</ins></p>');
     });
   });
 });


### PR DESCRIPTION
Improve the html diffing used in regional edits.

Add ability to do a diff of a version to the current file.

Before:
<img width="848" height="302" alt="before" src="https://github.com/user-attachments/assets/640119e4-689d-4d03-948f-716db28ff4a2" />

After:
<img width="840" height="212" alt="after" src="https://github.com/user-attachments/assets/734824bb-bc47-48ff-8b9b-4885ff09870f" />

---
Improved version interface:

- Tables now render properly
- Version Title now displayed
- New "Compare" button added

<img width="1216" height="810" alt="Screenshot 2026-05-01 at 2 51 44 PM" src="https://github.com/user-attachments/assets/963f0778-3e27-4d87-b32a-155e73254442" />

---

Version compare:

<img width="1105" height="923" alt="Screenshot 2026-05-01 at 2 52 53 PM" src="https://github.com/user-attachments/assets/6a97d25e-abb6-4c59-b45e-918a4ca8897c" />
