### PR TITLE
fix: prevent malformed API paths (double slashes, undefined segments, full URLs)

### DIFF
--- a/blocks/shared/pathDetails.js
+++ b/blocks/shared/pathDetails.js
@@ -148,6 +148,7 @@ export default function getPathDetails(loc) {
   const ext = getExtension(editor, pathParts.slice(-1)[0], isFolder);
 
   const depth = pathParts.length;
+  const cleanParts = [...pathParts];
 
   if (depth === 1) details = getOrgDetails({ editor, pathParts, ext });
 
@@ -155,8 +156,10 @@ export default function getPathDetails(loc) {
 
   if (depth >= 3) details = getFullDetails({ editor, pathParts, ext });
 
-  let path = ext === 'html' && !fullpath.endsWith('.html') ? `${fullpath}.html` : fullpath;
+  const cleanPath = `/${cleanParts.join('/')}`;
+  let path = ext === 'html' && !cleanPath.endsWith('.html') && editor !== 'sheet' ? `${cleanPath}.html` : cleanPath;
   if (editor === 'sheet' && !path.endsWith('.json')) path = `${path}.${ext}`;
+  if (isFolder && !path.endsWith('/')) path = `${path}/`;
 
   details = { ...details, origin: DA_ORIGIN, fullpath: path, depth, view: editor };
 

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -104,6 +104,8 @@ export async function aemAdmin(path, api, method = 'POST') {
 }
 
 export async function saveToDa({ path, formData, blob, props, preview = false }) {
+  if (!path || !path.startsWith('/') || path.includes('://')) return undefined;
+
   const opts = { method: 'PUT' };
 
   const form = formData || new FormData();
@@ -192,6 +194,8 @@ export const fetchDaConfigs = (() => {
   };
 
   return ({ org, site }) => {
+    if (!org) return [Promise.resolve(null)];
+
     // Set the org config promise if it does not exist
     configCache[`/${org}`] ??= fetchConfig(`/${org}`);
 

--- a/test/unit/blocks/shared/pathDetails.test.js
+++ b/test/unit/blocks/shared/pathDetails.test.js
@@ -264,4 +264,27 @@ describe('Path details', () => {
       expect(details.depth).to.equal(3);
     });
   });
+
+  describe('Double slashes in hash', () => {
+    it('Strips double slashes from fullpath for org+repo+path edit', () => {
+      const loc = { pathname: '/edit', hash: '#/adobe/geometrixx//page' };
+      const details = getPathDetails(loc);
+      expect(details.fullpath).to.not.include('//');
+      expect(details.fullpath).to.equal('/adobe/geometrixx/page.html');
+    });
+
+    it('Strips double slashes from fullpath for org+repo browse', () => {
+      const loc = { pathname: '/', hash: '#/adobe//geometrixx/' };
+      const details = getPathDetails(loc);
+      expect(details.fullpath).to.not.include('//');
+      expect(details.fullpath).to.equal('/adobe/geometrixx/');
+    });
+
+    it('Strips double slashes from fullpath for sheet view', () => {
+      const loc = { pathname: '/sheet', hash: '#/adobe/geometrixx//page' };
+      const details = getPathDetails(loc);
+      expect(details.fullpath).to.not.include('//');
+      expect(details.fullpath).to.equal('/adobe/geometrixx/page.json');
+    });
+  });
 });

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -9,6 +9,7 @@ import {
   delay,
   getSidekickConfig,
   sanitizeName,
+  fetchDaConfigs,
 } from '../../../../blocks/shared/utils.js';
 
 describe('getSheetByIndex', () => {
@@ -493,5 +494,120 @@ describe('getSidekickConfig', () => {
     } finally {
       window.fetch = savedFetch;
     }
+  });
+});
+
+describe('fetchDaConfigs', () => {
+  let savedFetch;
+  let savedLocalStorage;
+
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    savedLocalStorage = window.localStorage.getItem('nx-ims');
+    window.localStorage.removeItem('nx-ims');
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+    if (savedLocalStorage) {
+      window.localStorage.setItem('nx-ims', savedLocalStorage);
+    } else {
+      window.localStorage.removeItem('nx-ims');
+    }
+  });
+
+  it('Returns early without calling fetch when org is empty', async () => {
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    const results = fetchDaConfigs({ org: '', site: 'something' });
+    expect(results).to.be.an('array').with.lengthOf(1);
+    const resolved = await results[0];
+    expect(resolved).to.equal(null);
+    expect(fetchCalled).to.be.false;
+  });
+
+  it('Returns early without calling fetch when org is undefined', async () => {
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    const results = fetchDaConfigs({ org: undefined, site: 'something' });
+    expect(results).to.be.an('array').with.lengthOf(1);
+    const resolved = await results[0];
+    expect(resolved).to.equal(null);
+    expect(fetchCalled).to.be.false;
+  });
+});
+
+describe('saveToDa — malformed path guard', () => {
+  let savedFetch;
+  let savedLocalStorage;
+
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    savedLocalStorage = window.localStorage.getItem('nx-ims');
+    window.localStorage.removeItem('nx-ims');
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+    if (savedLocalStorage) {
+      window.localStorage.setItem('nx-ims', savedLocalStorage);
+    } else {
+      window.localStorage.removeItem('nx-ims');
+    }
+  });
+
+  it('Returns undefined without calling fetch when path is a full URL', async () => {
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    const result = await saveToDa({ path: 'https://da.live' });
+    expect(result).to.equal(undefined);
+    expect(fetchCalled).to.be.false;
+  });
+
+  it('Returns undefined without calling fetch when path does not start with /', async () => {
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    const result = await saveToDa({ path: 'org/repo/page' });
+    expect(result).to.equal(undefined);
+    expect(fetchCalled).to.be.false;
+  });
+
+  it('Returns undefined without calling fetch when path is falsy', async () => {
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    const result = await saveToDa({ path: null });
+    expect(result).to.equal(undefined);
+    expect(fetchCalled).to.be.false;
+  });
+
+  it('Proceeds normally when path is a valid relative path', async () => {
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    await saveToDa({ path: '/org/repo/page' });
+    expect(fetchCalled).to.be.true;
   });
 });


### PR DESCRIPTION
## Summary

Fixes three distinct patterns of malformed API paths that caused 400 bad requests against da-admin.

**Fix 1 — Double slashes** (`/list/org/repo//path` etc.) in `blocks/shared/pathDetails.js`: `details.fullpath` was built from the raw hash string, preserving any `//`. Now reconstructed from the sanitized `pathParts` array.

**Fix 2 — `/config//undefined/`** in `blocks/shared/utils.js` (`fetchDaConfigs`): no guard on empty `org`. Now returns early when `org` is falsy.

**Fix 3 — `/source/https://da.live`** in `blocks/shared/utils.js` (`saveToDa`): path was not validated before constructing the API URL. Now rejects paths that are falsy, non-relative, or contain `://`.

## Test plan
- [x] `getPathDetails` with a hash containing `//` returns a `fullpath` with no double slashes
- [x] `fetchDaConfigs({ org: '', site: 'something' })` returns early with no fetch
- [x] `saveToDa({ path: 'https://da.live' })` returns `undefined` without calling `daFetch`
- [x] All 1297 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)