### PR TITLE
fix: Load editor tabs after content has loaded

### DIFF
--- a/blocks/edit/da-content/da-content.js
+++ b/blocks/edit/da-content/da-content.js
@@ -86,7 +86,6 @@ export default class DaContent extends LitElement {
           .permissions=${this.permissions}
           .proseEl=${this.proseEl}
           .wsProvider=${this.wsProvider}
-          @proseloaded=${this.handleEditorLoaded}
           @versionreset=${this.handleVersionReset}>
         </da-editor>
         ${this._editorLoaded ? html`

--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -113,6 +113,9 @@ async function setUI(el) {
       wsPromise,
     });
 
+    // Load editor tabs (live preview, versions, etc.)
+    setTimeout(() => daContent.handleEditorLoaded(), 1000);
+
     // set the live preview cookie async
     livePreviewLogin(owner, repo);
   }

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -222,15 +222,6 @@ function onWsSync(wsProvider, callback) {
   wsProvider.on('synced', handleSynced);
 }
 
-function handleProseLoaded(editor, wsProvider) {
-  onWsSync(wsProvider, () => {
-    const daEditor = editor.getRootNode().host;
-    const opts = { bubbles: true, composed: true };
-    const event = new CustomEvent('proseloaded', opts);
-    daEditor.dispatchEvent(event);
-  });
-}
-
 function handleAwarenessUpdates(wsProvider, daTitle, win, path) {
   const users = new Set();
 
@@ -504,8 +495,6 @@ export default async function initProse({ path, permissions, doc, daContent, wsP
 
   // yMap for storing document metadata (not synced to ProseMirror doc.attrs)
   initDaMetadata(ydoc.getMap('daMetadata'));
-
-  handleProseLoaded(editor, wsProvider);
 
   const pluginsPromise = loadCustomPlugins();
   applyDelayedPlugins(pluginsPromise, schema, canWrite, {


### PR DESCRIPTION
The wssync approach would intermittently fail.  This avoids that race condition by load 1s after content.
