### PR TITLE
fix: support single-sheet and multi-sheet configs via getSheetByName

### DIFF
--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
 import { DOMParser } from 'da-y-wrapper';
 import getPathDetails from '../../../shared/pathDetails.js';
-import { daFetch, aemAdmin, fetchDaConfigs, getFirstSheet } from '../../../shared/utils.js';
+import { daFetch, aemAdmin, fetchDaConfigs, getFirstSheet, getSheetByName } from '../../../shared/utils.js';
 import { openAssets } from '../../da-assets/da-assets.js';
 import { fetchKeyAutocompleteData } from '../../prose/plugins/slashMenu/keyAutocomplete.js';
 import { sanitizeName } from '../../../../scripts/utils.js';
@@ -109,9 +109,11 @@ function calculateSources(org, repo, sheetPath) {
 
 async function fetchLibraryConfig(org, site) {
   const configs = await fetchDaConfigs({ org, site });
-  const { library } = await configs[1];
-  if (!library) return [];
-  return library.data.reduce((acc, row) => {
+  const config = await configs[1];
+  if (!config) return [];
+  const libraryData = getSheetByName(config, 'library');
+  if (!libraryData) return [];
+  return libraryData.reduce((acc, row) => {
     // Determine if a plugin should be visible based on query param
     const allowed = getIsPluginAllowed(row.ref);
     if (allowed) {

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -128,6 +128,13 @@ export const getSheetByIndex = (json, index = 0) => {
   return json[Object.keys(json)[index]]?.data;
 };
 
+export const getSheetByName = (json, name) => {
+  if (json[':type'] !== 'multi-sheet') {
+    return json[':sheetname'] === name ? json.data : undefined;
+  }
+  return json[name]?.data;
+};
+
 export const getFirstSheet = (json) => getSheetByIndex(json, 0);
 
 export async function contentLogin(owner, repo) {

--- a/test/unit/blocks/edit/prose/plugins/imageFocalPoint.test.js
+++ b/test/unit/blocks/edit/prose/plugins/imageFocalPoint.test.js
@@ -33,6 +33,7 @@ describe('imageFocalPoint Plugin', () => {
         return {
           ok: true,
           json: async () => ({
+            ':type': 'multi-sheet',
             library: {
               data: [
                 { title: 'Blocks', path: '/blocks.json', ref: 'main' },

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -5,6 +5,7 @@ import {
   aemAdmin,
   saveToDa,
   getSheetByIndex,
+  getSheetByName,
   getFirstSheet,
   delay,
   getSidekickConfig,
@@ -38,6 +39,38 @@ describe('getSheetByIndex', () => {
     // index 0 is ':type' which has no .data, so returns undefined
     const json = { ':type': 'multi-sheet', sheet1: { data: [{ x: 99 }] } };
     expect(getSheetByIndex(json)).to.equal(undefined);
+  });
+});
+
+describe('getSheetByName', () => {
+  it('Returns data for the named sheet in a multi-sheet config', () => {
+    const json = { ':type': 'multi-sheet', library: { data: [{ title: 'Blocks', path: '/blocks' }] }, settings: { data: [{ key: 'x' }] } };
+    expect(getSheetByName(json, 'library')).to.deep.equal([{ title: 'Blocks', path: '/blocks' }]);
+  });
+
+  it('Returns undefined when the named sheet does not exist in a multi-sheet config', () => {
+    const json = { ':type': 'multi-sheet', settings: { data: [{ key: 'x' }] } };
+    expect(getSheetByName(json, 'library')).to.equal(undefined);
+  });
+
+  it('Returns data for a single-sheet config when :sheetname matches', () => {
+    const json = { ':type': 'sheet', ':sheetname': 'library', data: [{ title: 'Blocks', path: '/blocks' }] };
+    expect(getSheetByName(json, 'library')).to.deep.equal([{ title: 'Blocks', path: '/blocks' }]);
+  });
+
+  it('Returns undefined for a single-sheet config when :sheetname does not match', () => {
+    const json = { ':type': 'sheet', ':sheetname': 'settings', data: [{ title: 'Blocks', path: '/blocks' }] };
+    expect(getSheetByName(json, 'library')).to.equal(undefined);
+  });
+
+  it('Returns undefined for a single-sheet config with no :sheetname', () => {
+    const json = { ':type': 'sheet', data: [{ title: 'Blocks', path: '/blocks' }] };
+    expect(getSheetByName(json, 'library')).to.equal(undefined);
+  });
+
+  it('Returns undefined for a single-sheet config with matching :sheetname but no data', () => {
+    const json = { ':type': 'sheet', ':sheetname': 'library' };
+    expect(getSheetByName(json, 'library')).to.equal(undefined);
   });
 });
 


### PR DESCRIPTION
## Issue

Customer reported issue: library (blocks, templates, icons...) is not loaded if the repo config has only one "library" sheet.

## Summary
- Adds `getSheetByName(json, name)` utility to `blocks/shared/utils.js` that resolves a named sheet from both single-sheet configs (validated via `':sheetname'`) and multi-sheet configs (via named key)
- Fixes `fetchLibraryConfig` in `da-library/helpers/helpers.js` which previously destructured `library` directly from the config, breaking when the config is a single-sheet file
- Adds null guard for missing site config (`configs[1]`)

## Test plan
- [ ] `getSheetByName` unit tests covering: multi-sheet hit, multi-sheet miss, single-sheet name match, single-sheet name mismatch, single-sheet no `:sheetname`, single-sheet no `data`
- [ ] All 1311 existing tests continue to pass


Test page: https://sheetfix--da-live--adobe.aem.live/edit#/doe-app-svc/da-sws-tester2/index

🤖 Generated with [Claude Code](https://claude.com/claude-code)