### PR TITLE
fix: preserve all images in column block cells with multiple images

### DIFF
--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -124,7 +124,7 @@ function makePictures(editor, live) {
     // Determine what to replace
     const imgParent = img.parentElement;
     const imgGrandparent = imgParent.parentElement;
-    if (imgParent.nodeName === 'P' && imgGrandparent?.childElementCount === 1) {
+    if (imgParent.nodeName === 'P' && imgGrandparent?.childElementCount === 1 && imgParent.childElementCount === 1) {
       imgGrandparent.replaceChild(pic, imgParent);
     } else {
       imgParent.replaceChild(pic, img);

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -176,6 +176,38 @@ describe('prose2aem with isFragment parameter', () => {
     expect(result).to.equal('');
   });
 
+  it('Preserves all images in each column when a column block has 3 columns with multiple images per column', () => {
+    const fragment = document.createElement('div');
+    fragment.innerHTML = `
+      <div class="tableWrapper">
+        <table>
+          <tr><td>columns</td></tr>
+          <tr>
+            <td><p><img src="col1-img1.jpg"><img src="col1-img2.jpg"><img src="col1-img3.jpg"></p></td>
+            <td><p><img src="col2-img1.jpg"><img src="col2-img2.jpg"><img src="col2-img3.jpg"></p></td>
+            <td><p><img src="col3-img1.jpg"><img src="col3-img2.jpg"><img src="col3-img3.jpg"></p></td>
+          </tr>
+        </table>
+      </div>
+    `;
+
+    const result = prose2aem(fragment, true, true);
+
+    const container = document.createElement('div');
+    container.innerHTML = result;
+
+    const block = container.querySelector('.columns');
+    expect(block).to.exist;
+
+    const colDivs = block.querySelectorAll(':scope > div > div');
+    expect(colDivs.length).to.equal(3);
+
+    colDivs.forEach((col, i) => {
+      const pictures = col.querySelectorAll('picture');
+      expect(pictures.length, `column ${i + 1} should have 3 pictures`).to.equal(3);
+    });
+  });
+
   it('Preserves pictures in fragment mode', () => {
     const fragment = document.createElement('div');
     fragment.innerHTML = `


### PR DESCRIPTION
## Summary

- `makePictures` in `prose2aem.js` was replacing the entire `<p>` element with the first image's `<picture>` whenever the `<p>` was the sole child of its grandparent — even when that `<p>` contained multiple `<img>` tags
- The remaining sibling images were orphaned and lost, leaving only 1 image per column in a columns block
- Fix: added `imgParent.childElementCount === 1` guard so the `<p>`-unwrap only fires when the `<p>` holds exactly one image

## Test plan

- [ ] New failing test added: `Preserves all images in each column when a column block has 3 columns with multiple images per column`
- [ ] Test confirms bug (1 picture per column instead of 3) before fix, passes after
- [ ] All existing `prose2aem` tests continue to pass (no regressions)
- [ ] Run `npm test` — 1314 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)