### PR TITLE
fix: preserve chronological order of audit groups in version history

### DIFF
--- a/blocks/edit/da-versions/helpers.js
+++ b/blocks/edit/da-versions/helpers.js
@@ -20,20 +20,16 @@ export function formatVersions(json) {
     };
   });
 
-  // Group everything by date
+  // Group consecutive audit entries by date, but never across a version boundary
   return ungrouped.reduce((acc, entry) => {
-    // Elevate versions to the top
     if (entry.isVersion) {
       acc.push(entry);
     } else {
-      // Group audits by date
-      const notVerSameDate = acc.find(
-        (accEntry) => !accEntry.isVersion && accEntry.date === entry.date,
-      );
-      if (!notVerSameDate) {
-        acc.push({ date: entry.date, audits: [entry] });
+      const last = acc[acc.length - 1];
+      if (last && !last.isVersion && last.date === entry.date) {
+        last.audits.push(entry);
       } else {
-        notVerSameDate.audits.push(entry);
+        acc.push({ date: entry.date, audits: [entry] });
       }
     }
     return acc;

--- a/test/unit/blocks/edit/da-versions/helpers.test.js
+++ b/test/unit/blocks/edit/da-versions/helpers.test.js
@@ -65,20 +65,13 @@ describe('Versions helper', () => {
     const formatted = formatVersions(versions);
 
     const expected = [{
+      // Audit AFTER the version (newer, same day)
       date: new Date(1715766906908).toLocaleDateString([], DATE_OPTS),
       audits: [{
         date: new Date(1715766906908).toLocaleDateString([], DATE_OPTS),
         time: new Date(1715766906908).toLocaleTimeString([], TIME_OPTS),
         users: [{ email: 'furb@acme.com' }, { email: 'anonymous' }],
         timestamp: 1715766906908,
-        path: 'da-aem-boilerplate/blah7.html',
-        isVersion: false,
-      },
-      {
-        date: new Date(1715766405165).toLocaleDateString([], DATE_OPTS),
-        time: new Date(1715766405165).toLocaleTimeString([], TIME_OPTS),
-        users: [{ email: 'joe@acme.com' }],
-        timestamp: 1715766405165,
         path: 'da-aem-boilerplate/blah7.html',
         isVersion: false,
       }],
@@ -91,6 +84,17 @@ describe('Versions helper', () => {
       path: 'da-aem-boilerplate/blah7.html',
       label: 'hello',
       isVersion: true,
+    }, {
+      // Audit BEFORE the version (older, same day — separate group)
+      date: new Date(1715766405165).toLocaleDateString([], DATE_OPTS),
+      audits: [{
+        date: new Date(1715766405165).toLocaleDateString([], DATE_OPTS),
+        time: new Date(1715766405165).toLocaleTimeString([], TIME_OPTS),
+        users: [{ email: 'joe@acme.com' }],
+        timestamp: 1715766405165,
+        path: 'da-aem-boilerplate/blah7.html',
+        isVersion: false,
+      }],
     }, {
       date: new Date(1715701875589).toLocaleDateString([], DATE_OPTS),
       audits: [{
@@ -120,5 +124,47 @@ describe('Versions helper', () => {
     }];
 
     expect(formatted).to.deep.equal(expected);
+  });
+
+  it('Does not group audit entries across a labelled version on the same day', () => {
+    // All three entries are on 2024-05-18 UTC, but the version sits between the two audits:
+    // ts_after (12:00) | ts_version (11:00, labelled) | ts_before (10:00)
+    const TS_AFTER = 1716033600000;
+    const TS_VERSION = 1716030000000;
+    const TS_BEFORE = 1716026400000;
+
+    const versions = [{
+      users: [{ email: 'after@acme.com' }],
+      timestamp: TS_AFTER,
+      path: 'org/repo/doc.html',
+    }, {
+      url: '/versionsource/org/v1.html',
+      users: [{ email: 'tagger@acme.com' }],
+      timestamp: TS_VERSION,
+      path: 'org/repo/doc.html',
+      label: 'v1',
+    }, {
+      users: [{ email: 'before@acme.com' }],
+      timestamp: TS_BEFORE,
+      path: 'org/repo/doc.html',
+    }];
+
+    const formatted = formatVersions(versions);
+
+    expect(formatted).to.have.length(3);
+
+    // First block: audit group AFTER the version
+    expect(formatted[0].isVersion).to.be.undefined;
+    expect(formatted[0].audits).to.have.length(1);
+    expect(formatted[0].audits[0].users[0].email).to.equal('after@acme.com');
+
+    // Second block: the labelled version
+    expect(formatted[1].isVersion).to.be.true;
+    expect(formatted[1].label).to.equal('v1');
+
+    // Third block: audit group BEFORE the version (same date, but separate group)
+    expect(formatted[2].isVersion).to.be.undefined;
+    expect(formatted[2].audits).to.have.length(1);
+    expect(formatted[2].audits[0].users[0].email).to.equal('before@acme.com');
   });
 });


### PR DESCRIPTION
## Summary

When two audit entries fell on the same calendar day but were separated by a labelled version, they were incorrectly merged into a single group — breaking the chronological block structure of the history panel.

- Audit entries are now only grouped with the immediately preceding audit block; a labelled version always starts a new block below it
- Updated the existing test to reflect the corrected behaviour and added a dedicated regression test for the cross-version grouping scenario

## Test plan

Before:
- https://main--da-live--adobe.aem.live/edit#/kptdobe/daplayground/surf
After
- https://vgrpfix--da-live--adobe.aem.live/edit#/kptdobe/daplayground/surf

Open the version history and check the May 5th ordering:
- before: Previewed, all edit sessions, rest of the Previewed
- now: edit session then Previewed, edit session then Previewed....

- [ ] Open the version history panel for a document that has audit entries both before and after a labelled version on the same day — verify they appear in two separate groups with the labelled version between them
- [ ] Verify that consecutive audit entries on the same day (with no version in between) are still grouped together as before
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)