### PR TITLE
fix: add fallback for path sanitization logic

### DIFF
--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -4,14 +4,13 @@ import { htmlToProse } from '../utils/helpers.js';
 import { getNx, sanitizePathParts } from '../../../scripts/utils.js';
 import getSheet from '../../shared/sheet.js';
 import inlinesvg from '../../shared/inlinesvg.js';
-import { daFetch } from '../../shared/utils.js';
 import searchFor from './helpers/search.js';
 import {
   OOTB_PLUGINS,
   loadLibrary,
   getItemDetails,
   getPreviewStatus,
-  aemToContentUrl,
+  daFetchLibrary,
   ref,
 } from './helpers/helpers.js';
 
@@ -191,7 +190,7 @@ class DaLibrary extends LitElement {
   }
 
   async handleTemplateClick(item) {
-    const resp = await daFetch(aemToContentUrl(item.value));
+    const { resp } = await daFetchLibrary(item.value, { skipRewrite: item.usedFallback });
     if (!resp.ok) return;
     let text = await resp.text();
 

--- a/blocks/edit/da-library/helpers/helpers.js
+++ b/blocks/edit/da-library/helpers/helpers.js
@@ -61,17 +61,28 @@ export function aemToContentUrl(url) {
   }
 }
 
+// Try the content.da.live rewrite first; fall back to the original URL on 404
+export async function daFetchLibrary(url, { skipRewrite = false } = {}) {
+  if (skipRewrite) {
+    return { resp: await daFetch(url, { noRedirect: true }), usedFallback: true };
+  }
+  const contentUrl = aemToContentUrl(url);
+  const resp = await daFetch(contentUrl, { noRedirect: true });
+  if (resp.status === 404 && contentUrl !== url) {
+    return { resp: await daFetch(url, { noRedirect: true }), usedFallback: true };
+  }
+  return { resp, usedFallback: false };
+}
+
 export async function getItems(sources, format) {
   const items = [];
   for (const source of sources) {
     try {
-      const resp = await daFetch(aemToContentUrl(source));
+      const { resp, usedFallback } = await daFetchLibrary(source);
       const json = await resp.json();
-      if (json.data) {
-        items.push(...formatData(json.data, format));
-      } else {
-        items.push(...json);
-      }
+      const sheet = json[':type'] === 'multi-sheet' ? json[json[':names']?.[0]] : json;
+      const formatted = sheet?.data ? formatData(sheet.data, format) : json;
+      items.push(...formatted.map((item) => ({ ...item, usedFallback })));
     } catch {
       // couldn't fetch source
     }

--- a/blocks/edit/da-library/helpers/index.js
+++ b/blocks/edit/da-library/helpers/index.js
@@ -1,6 +1,6 @@
 import { daFetch, getFirstSheet } from '../../../shared/utils.js';
 import { getMetadata } from '../../utils/helpers.js';
-import { parseDom, aemToContentUrl } from './helpers.js';
+import { parseDom, aemToContentUrl, daFetchLibrary } from './helpers.js';
 
 const AEM_ORIGIN = ['hlx.page', 'hlx.live', 'aem.page', 'aem.live'];
 
@@ -69,17 +69,24 @@ function getBlockTableHtml(block) {
   return table;
 }
 
-async function fetchAndParseHtml(path, isAemHosted) {
-  const postfix = isAemHosted ? '.plain.html' : '';
+function isAemHosted(path) {
   try {
-    const resp = await daFetch(`${path}${postfix}`);
-    if (!resp.ok) return null;
+    const { origin } = new URL(path);
+    return AEM_ORIGIN.some((aemOrigin) => origin.endsWith(aemOrigin));
+  } catch {
+    return false;
+  }
+}
 
+async function fetchAndParseHtml(path) {
+  const url = isAemHosted(path) ? `${path}.plain.html` : path;
+  try {
+    const resp = await daFetch(url);
+    if (!resp.ok) return { doc: null, notFound: resp.status === 404 };
     const html = await resp.text();
-    const parser = new DOMParser();
-    return parser.parseFromString(html, 'text/html');
-  } catch (e) {
-    return null;
+    return { doc: new DOMParser().parseFromString(html, 'text/html') };
+  } catch {
+    return { doc: null };
   }
 }
 
@@ -161,23 +168,21 @@ function transformBlock(block) {
   return item;
 }
 
-export async function getBlockVariants(path) {
-  let isAemHosted = false;
-  try {
-    const { origin } = new URL(path);
-    isAemHosted = AEM_ORIGIN.some((aemOrigin) => origin.endsWith(aemOrigin));
-  } catch {
-    // path is relative — not AEM hosted
-  }
-
-  const doc = await fetchAndParseHtml(path, isAemHosted);
-  if (!doc) return [];
-
+function buildVariants(doc, path) {
   decorateImages(doc.body, path);
-
   const blocks = getSectionsAndBlocks(doc);
-  const groupedBlocks = groupBlocks(blocks);
-  return groupedBlocks.map(transformBlock);
+  return groupBlocks(blocks).map(transformBlock);
+}
+
+export async function getBlockVariants(originalPath, { skipRewrite = false } = {}) {
+  const contentUrl = skipRewrite ? originalPath : aemToContentUrl(originalPath);
+  const { doc, notFound } = await fetchAndParseHtml(contentUrl);
+  if (doc) return buildVariants(doc, contentUrl);
+  if (notFound && contentUrl !== originalPath) {
+    const { doc: fallbackDoc } = await fetchAndParseHtml(originalPath);
+    if (fallbackDoc) return buildVariants(fallbackDoc, originalPath);
+  }
+  return [];
 }
 
 export const urlCache = new Map();
@@ -191,26 +196,26 @@ export async function getBlocks(sources) {
         }
 
         try {
-          const resp = await daFetch(aemToContentUrl(url), { noRedirect: true });
+          const { resp, usedFallback } = await daFetchLibrary(url);
           if (!resp.ok) throw new Error('Something went wrong.');
-          const data = await resp.json();
-          urlCache.set(url, data);
-          return data;
+          const entry = { data: await resp.json(), usedFallback };
+          urlCache.set(url, entry);
+          return entry;
         } catch {
           return null;
         }
       }),
     );
 
-    return sourcesData.reduce((acc, blockData) => {
-      if (blockData) {
-        const data = getFirstSheet(blockData);
+    return sourcesData.reduce((acc, entry) => {
+      if (entry) {
+        const data = getFirstSheet(entry.data);
         if (data) {
           data.forEach((block) => {
             if (block.name && block.path) {
               acc.push({
                 ...block,
-                loadVariants: getBlockVariants(aemToContentUrl(block.path)),
+                loadVariants: getBlockVariants(block.path, { skipRewrite: entry.usedFallback }),
               });
             }
           });

--- a/test/unit/blocks/edit/da-library/helpers.test.js
+++ b/test/unit/blocks/edit/da-library/helpers.test.js
@@ -9,6 +9,7 @@ const {
   getPreviewUrl,
   getAemUrlVars,
   aemToContentUrl,
+  daFetchLibrary,
   getItemDetails,
   getItems,
   getPreviewStatus,
@@ -170,6 +171,91 @@ describe('da-library/helpers exports', () => {
     });
   });
 
+  describe('daFetchLibrary', () => {
+    let savedFetch;
+    beforeEach(() => { savedFetch = window.fetch; });
+    afterEach(() => { window.fetch = savedFetch; });
+
+    it('Skips the rewrite-and-retry when the URL is not an AEM host', async () => {
+      const calls = [];
+      window.fetch = (url) => {
+        calls.push(url);
+        return Promise.resolve(new Response('nope', { status: 404 }));
+      };
+      const { resp, usedFallback } = await daFetchLibrary('https://example.com/page');
+      expect(resp.status).to.equal(404);
+      expect(usedFallback).to.be.false;
+      expect(calls).to.deep.equal(['https://example.com/page']);
+    });
+
+    it('Returns the rewritten response when it succeeds (no fallback)', async () => {
+      const calls = [];
+      window.fetch = (url) => {
+        calls.push(url);
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      };
+      const { resp, usedFallback } = await daFetchLibrary('https://main--repo--org.aem.live/page');
+      expect(resp.status).to.equal(200);
+      expect(usedFallback).to.be.false;
+      expect(calls).to.deep.equal(['https://content.da.live/org/repo/page']);
+    });
+
+    it('Falls back to the original URL on 404 from the rewrite', async () => {
+      const calls = [];
+      window.fetch = (url) => {
+        calls.push(url);
+        const status = url.startsWith('https://content.da.live/') ? 404 : 200;
+        return Promise.resolve(new Response('', { status }));
+      };
+      const { resp, usedFallback } = await daFetchLibrary('https://main--repo--org.aem.live/page');
+      expect(resp.status).to.equal(200);
+      expect(usedFallback).to.be.true;
+      expect(calls).to.deep.equal([
+        'https://content.da.live/org/repo/page',
+        'https://main--repo--org.aem.live/page',
+      ]);
+    });
+
+    it('Does not fall back on non-404 failures from the rewrite', async () => {
+      const calls = [];
+      window.fetch = (url) => {
+        calls.push(url);
+        return Promise.resolve(new Response('boom', { status: 500 }));
+      };
+      const { resp, usedFallback } = await daFetchLibrary('https://main--repo--org.aem.live/page');
+      expect(resp.status).to.equal(500);
+      expect(usedFallback).to.be.false;
+      expect(calls).to.deep.equal(['https://content.da.live/org/repo/page']);
+    });
+
+    it('With skipRewrite, goes straight to the original URL and reports usedFallback', async () => {
+      const calls = [];
+      window.fetch = (url) => {
+        calls.push(url);
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      };
+      const { resp, usedFallback } = await daFetchLibrary(
+        'https://main--repo--org.aem.live/page',
+        { skipRewrite: true },
+      );
+      expect(resp.status).to.equal(200);
+      expect(usedFallback).to.be.true;
+      expect(calls).to.deep.equal(['https://main--repo--org.aem.live/page']);
+    });
+
+    it('Forwards opts to daFetch on both attempts', async () => {
+      const optsSeen = [];
+      window.fetch = (url, opts) => {
+        optsSeen.push(opts);
+        return Promise.resolve(new Response('', { status: 404 }));
+      };
+      await daFetchLibrary('https://main--repo--org.aem.live/page');
+      expect(optsSeen.length).to.equal(2);
+      expect(optsSeen[0]?.noRedirect).to.be.true;
+      expect(optsSeen[1]?.noRedirect).to.be.true;
+    });
+  });
+
   describe('getItems', () => {
     let savedFetch;
     beforeEach(() => { savedFetch = window.fetch; });
@@ -182,6 +268,25 @@ describe('da-library/helpers exports', () => {
       ));
       const result = await getItems(['/source.json']);
       expect(result.length).to.equal(2);
+    });
+
+    it('Handles multi-sheet responses by reading the first sheet', async () => {
+      const savedView = window.view;
+      window.view = { state: { schema: { text: (s) => ({ text: s }) } } };
+      try {
+        window.fetch = () => Promise.resolve(new Response(
+          JSON.stringify({
+            ':type': 'multi-sheet',
+            ':names': ['default'],
+            default: { data: [{ key: 'one' }, { key: 'two' }] },
+          }),
+          { status: 200 },
+        ));
+        const result = await getItems(['/source.json']);
+        expect(result.map((i) => i.key)).to.deep.equal(['one', 'two']);
+      } finally {
+        window.view = savedView;
+      }
     });
 
     it('Skips a source whose fetch fails (catch branch)', async () => {
@@ -279,6 +384,62 @@ describe('da-library/helpers/index getBlocks', () => {
     expect(captured).to.equal('https://content.da.live/org/repo/blocks.json');
   });
 
+  it('Falls back to the original AEM URL when content.da.live 404s', async () => {
+    const calls = [];
+    window.fetch = (url) => {
+      calls.push(url);
+      if (url.startsWith('https://content.da.live/')) {
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ ':type': 'sheet', data: [] }),
+        { status: 200 },
+      ));
+    };
+    await getBlocks(['https://main--repo--org.aem.page/blocks.json']);
+    expect(calls).to.deep.equal([
+      'https://content.da.live/org/repo/blocks.json',
+      'https://main--repo--org.aem.page/blocks.json',
+    ]);
+  });
+
+  it('Does not fall back on non-404 failures', async () => {
+    const calls = [];
+    window.fetch = (url) => {
+      calls.push(url);
+      return Promise.resolve(new Response('boom', { status: 500 }));
+    };
+    await getBlocks(['https://main--repo--org.aem.page/blocks.json']);
+    expect(calls).to.deep.equal(['https://content.da.live/org/repo/blocks.json']);
+  });
+
+  it('When the source falls back, variants skip the content.da.live attempt', async () => {
+    const calls = [];
+    window.fetch = (url) => {
+      calls.push(url);
+      if (url === 'https://content.da.live/org/repo/blocks.json') {
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      }
+      if (url === 'https://main--repo--org.aem.page/blocks.json') {
+        return Promise.resolve(new Response(
+          JSON.stringify({
+            ':type': 'sheet',
+            data: [{ name: 'hero', path: 'https://main--repo--org.aem.page/blocks/hero' }],
+          }),
+          { status: 200 },
+        ));
+      }
+      return Promise.resolve(new Response('', { status: 500 }));
+    };
+    const result = await getBlocks(['https://main--repo--org.aem.page/blocks.json']);
+    await Promise.all(result.map((b) => b.loadVariants));
+    expect(calls).to.deep.equal([
+      'https://content.da.live/org/repo/blocks.json',
+      'https://main--repo--org.aem.page/blocks.json',
+      'https://main--repo--org.aem.page/blocks/hero.plain.html',
+    ]);
+  });
+
   it('Caches fetched source data so subsequent calls do not refetch', async () => {
     let calls = 0;
     window.fetch = () => {
@@ -322,13 +483,26 @@ describe('da-library/helpers/index getBlockVariants', () => {
     expect(captured).to.equal('https://example.com/page');
   });
 
-  it('Adds the .plain.html suffix for known AEM origins', async () => {
-    let captured;
+  it('Tries content.da.live first, then falls back to original AEM URL with .plain.html on 404', async () => {
+    const calls = [];
     window.fetch = (url) => {
-      captured = url;
-      return Promise.resolve(new Response('boom', { status: 500 }));
+      calls.push(url);
+      const status = url.startsWith('https://content.da.live/') ? 404 : 500;
+      return Promise.resolve(new Response('', { status }));
     };
     await getBlockVariants('https://main--repo--org.aem.live/page');
-    expect(captured).to.contain('.plain.html');
+    expect(calls[0]).to.equal('https://content.da.live/org/repo/page');
+    expect(calls[1]).to.equal('https://main--repo--org.aem.live/page.plain.html');
+  });
+
+  it('Does not fall back when content.da.live returns non-404', async () => {
+    const calls = [];
+    window.fetch = (url) => {
+      calls.push(url);
+      return Promise.resolve(new Response('boom', { status: 500 }));
+    };
+    const result = await getBlockVariants('https://main--repo--org.aem.live/page');
+    expect(result).to.deep.equal([]);
+    expect(calls).to.deep.equal(['https://content.da.live/org/repo/page']);
   });
 });


### PR DESCRIPTION
PR [#928](https://github.com/adobe/da-live/issues/928) rewrote aem.page/aem.live library URLs to content.da.live, which 404s for sources that genuinely live on the AEM host and were never copied to DA. This adds a 404-only fallback so mixed libraries work again.

daFetchLibrary wrapper: rewritten URL first, original on 404 only (auth/5xx still surface). Used by getItems, getBlocks, handleTemplateClick.
getBlockVariants does the same fallback inline (it can't share the wrapper because of the .plain.html suffix). fetchAndParseHtml now returns { doc, notFound } so 404 is distinguishable.

Tested against milo (library on sharepoint) and on client that has locked aem.page library