### PR TITLE
fix: update versions test to handle multiple audit groups after #931

### DIFF
--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -62,7 +62,9 @@ test('Create Version and Restore from it', async ({ page }, workerInfo) => {
 
   // Check that there is an audit entry for the last edit (which we didn't)
   // expliticly create a version for.
-  const audit = await page.locator('.da-version-entry.is-audit');
+  // Use .first() because PR #931 keeps audit groups separate across version boundaries,
+  // so there may be multiple is-audit entries (one before and one after 'ver 1').
+  const audit = await page.locator('.da-version-entry.is-audit').first();
   await audit.click();
 
   const expectedUser = process.env.SKIP_AUTH ? 'anonymous' : 'da-test@adobetest.com';


### PR DESCRIPTION
## Summary

- PR [#931](https://github.com/adobe/da-live/pull/931) changed `formatVersions` in `helpers.js` to keep audit entry groups separate when a labeled version boundary falls between them.
- The Playwright test at `test/e2e/tests/versions.spec.js` was using a strict-mode locator (`.da-version-entry.is-audit`) that expected exactly one match, but the test scenario now produces two `.is-audit` entries — one for edits before "ver 1" and one for edits after.
- Fixed by adding `.first()` to select the most recent audit group (the post-"ver 1" edits), which is what the test intends to verify.

## Test plan

- [ ] Playwright versions test passes in chromium, firefox, and webkit
- [ ] No other version-related tests are affected