### PR TITLE
fix: update versions test to handle multiple audit groups after #931

### DIFF
--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -62,7 +62,9 @@ test('Create Version and Restore from it', async ({ page }, workerInfo) => {
 
   // Check that there is an audit entry for the last edit (which we didn't)
   // expliticly create a version for.
-  const audit = await page.locator('.da-version-entry.is-audit');
+  // Use .first() because PR #931 keeps audit groups separate across version boundaries,
+  // so there may be multiple is-audit entries (one before and one after 'ver 1').
+  const audit = await page.locator('.da-version-entry.is-audit').first();
   await audit.click();
 
   const expectedUser = process.env.SKIP_AUTH ? 'anonymous' : 'da-test@adobetest.com';


### PR DESCRIPTION
PR #931 changed formatVersions to keep audit entries in separate groups when split by a labeled version boundary. The test now finds two .is-audit elements (one before and one after 'ver 1'), causing a strict mode violation. Use .first() to target the most recent audit group.
