### PR TITLE
fix: block y-websocket auto-reconnect during async IMS refresh

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -62,13 +62,13 @@ export async function createConnection(path) {
       return;
     }
     if (event?.code === 4401) {
+      provider.shouldConnect = false;
       // Force imslib to attempt a refresh before deciding to give up.
       try { await window.adobeIMS?.refreshToken?.(); } catch { /* ignore */ }
       const fresh = await getAuthToken();
       if (!fresh || fresh === lastSentToken) {
         // No new token to try — retrying would loop on the same 4401. Stop
         // the reconnect loop, and surface the modal if the user was signed in.
-        provider.shouldConnect = false;
         if (lastSentToken) {
           try {
             const { showAuthBanner } = await import('../../shared/da-auth-banner/da-auth-banner.js');
@@ -79,6 +79,7 @@ export async function createConnection(path) {
       }
       provider.protocols = ['yjs', fresh];
       lastSentToken = fresh;
+      provider.connect();
       return;
     }
     const fresh = await getAuthToken();
@@ -284,7 +285,8 @@ function handleAwarenessUpdates(wsProvider, daTitle, win, path) {
   if (wsProvider.wsconnected) daTitle.collabStatus = 'connected';
   else daTitle.collabStatus = 'connecting';
 
-  wsProvider.on('connection-close', async () => {
+  wsProvider.on('connection-close', async (event) => {
+    if (event?.code === 4401 || event?.code === 4403) return;
     const resp = await checkDoc(path);
     if (resp.status === 404) {
       const { hash } = window.location;

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -229,6 +229,53 @@ describe('prose/index createConnection', () => {
     }
   });
 
+  it('Blocks y-websocket auto-reconnect during the in-flight refresh on 4401', async () => {
+    // Regression: y-websocket's onclose schedules setTimeout(setupWS, 100ms)
+    // synchronously; if shouldConnect stays true through the await
+    // refreshToken() round-trip the auto-reconnect fires with the stale token
+    // and burns a HEAD 401 on da-admin. shouldConnect must flip to false
+    // synchronously before the first await.
+    window.localStorage.setItem('nx-ims', 'true');
+    const savedIMS = window.adobeIMS;
+    let refreshResolve;
+    const refreshPromise = new Promise((r) => { refreshResolve = r; });
+    let tokenIndex = 0;
+    const tokens = ['T-old', 'T-new'];
+    window.adobeIMS = {
+      getAccessToken: () => ({ token: tokens[tokenIndex] }),
+      refreshToken: () => refreshPromise,
+    };
+
+    try {
+      const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/org/repo/page.html');
+      expect(wsProvider.shouldConnect).to.equal(true);
+
+      // Fire 4401 — handler runs sync up to first await, then yields.
+      wsProvider.emit('connection-close', [{ code: 4401, reason: 'auth' }, wsProvider]);
+      // Microtask boundary: handler has hit `await refreshToken()` and yielded.
+      await Promise.resolve();
+
+      // During the in-flight refresh, shouldConnect MUST be false so a stale
+      // y-websocket reconnect timer fires as a no-op.
+      expect(wsProvider.shouldConnect).to.equal(false);
+
+      // Resolve the refresh; rotate the token so getAuthToken() returns T-new.
+      tokenIndex = 1;
+      refreshResolve();
+      await new Promise((r) => { setTimeout(r, 0); });
+
+      // After refresh: fresh token applied and reconnect explicitly re-enabled.
+      expect(wsProvider.protocols).to.deep.equal(['yjs', 'T-new']);
+      expect(wsProvider.shouldConnect).to.equal(true);
+
+      wsProvider.disconnect({ data: 'Client navigation' });
+      wsProvider.destroy?.();
+      ydoc.destroy();
+    } finally {
+      if (savedIMS === undefined) delete window.adobeIMS; else window.adobeIMS = savedIMS;
+    }
+  });
+
   it('Non-auth close with no token reconnects as anonymous', async () => {
     window.localStorage.removeItem('nx-ims');
     const savedIMS = window.adobeIMS;
@@ -304,6 +351,38 @@ describe('prose/index createAwarenessStatusWidget', () => {
     expect(fakeTitle.collabStatus).to.equal('connected');
     provider._emit('status', { status: 'disconnected' });
     expect(fakeTitle.collabStatus).to.equal('disconnected');
+  });
+
+  it('Skips checkDoc HEAD on auth-close codes (4401/4403)', async () => {
+    // checkDoc is intended to detect doc-deleted-externally (404). On 4401/4403
+    // the doc is fine — da-collab signalled an auth failure. Firing checkDoc
+    // here just doubles the HEAD 401 traffic to da-admin via daFetch's
+    // refresh-and-retry, so it must be skipped.
+    const provider = buildFakeWsProvider();
+    const fakeWin = { document, addEventListener: () => {} };
+    const fetchCalls = [];
+    const savedFetch = window.fetch;
+    window.fetch = (...args) => {
+      fetchCalls.push(args);
+      return Promise.resolve(new Response('', { status: 200, headers: {} }));
+    };
+    try {
+      createAwarenessStatusWidget(provider, fakeWin, 'https://admin.da.live/source/o/r/p.html');
+
+      provider._emit('connection-close', { code: 4401, reason: 'auth' }, provider);
+      provider._emit('connection-close', { code: 4403, reason: 'forbidden' }, provider);
+      await new Promise((r) => { setTimeout(r, 0); });
+
+      expect(fetchCalls.filter(([, o]) => o?.method === 'HEAD'))
+        .to.have.lengthOf(0);
+
+      // Sanity: a non-auth close still does fire checkDoc.
+      provider._emit('connection-close', { code: 1006 }, provider);
+      await new Promise((r) => { setTimeout(r, 0); });
+      expect(fetchCalls.some(([, o]) => o?.method === 'HEAD')).to.equal(true);
+    } finally {
+      window.fetch = savedFetch;
+    }
   });
 
   it('On focus reconnects, on blur schedules disconnect', async () => {


### PR DESCRIPTION
## Why

Three remaining bugs around the IMS token refresh path that survived #937 / #941. Together they explain a continuous baseline of HEAD 401s on da-admin (660k/day in Coralogix) even after those PRs landed.

### Bug 1 — Race between async refresh and y-websocket's 100ms reconnect timer

`y-websocket`'s `onclose` schedules `setTimeout(setupWS, 2^wsUnsuccessfulReconnects * 100ms)` synchronously. On a `4401` close the upgrade returns `101` + immediate close, so `onopen` briefly fires and `wsUnsuccessfulReconnects` stays at `0` — backoff is **100ms**, shorter than a typical `adobeIMS.refreshToken()` round-trip. The auto-reconnect fired with the still-stale token and burned 2–3 HEAD 401s on da-admin per token expiry per tab.

### Bug 2 — Concurrent close handlers racing `lastSentToken`

Because bug 1 produced multiple 4401 closes back-to-back, multiple async handlers ran concurrently. Handler A finishes first and writes `lastSentToken = X2`. Handler B (started during A's await) then sees `fresh === lastSentToken` (`X2 === X2`) and incorrectly concludes "no new token", sets `shouldConnect = false`, and shows the auth banner — even though the refresh worked.

### Bug 3 — `checkDoc` doubles the HEAD volume on auth-close

`createAwarenessStatusWidget` has a second `connection-close` listener that calls `checkDoc(path)` → `daFetch(path, { method: 'HEAD' })` on **every** close. On a 4401/4403 the doc is fine — da-collab signalled an auth failure — so this just fires another HEAD on da-admin which `daFetch`'s refresh-and-retry compounds further.

## What

- **Flip `shouldConnect=false` synchronously before the first await** in the close handler. The pending `setTimeout(setupWS)` becomes a no-op, eliminating bugs 1 and 2 (no concurrent close handlers because no auto-reconnects fire during the refresh window).
- **Drive the reconnect ourselves** via `provider.connect()` once we have the fresh token.
- **Skip `checkDoc`** when the close code is `4401`/`4403`.

## Trust model

Unchanged. `4403` still stops reconnection. `4401` with no new token still bails and surfaces the modal. Anonymous users still bail without showing the modal.

## Tests

- New: `Blocks y-websocket auto-reconnect during the in-flight refresh on 4401` — controls `refreshToken` via an unresolved promise and asserts `shouldConnect===false` during the await, then `true` after.
- New: `Skips checkDoc HEAD on auth-close codes (4401/4403)` — patches `window.fetch` and asserts no HEAD is issued on 4401/4403, but is on 1006.
- All existing close-handler tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)