### PR TITLE
feat: force-save before Preview/Publish

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -264,6 +264,22 @@ export default class DaTitle extends LitElement {
 
     // AEM Actions
     if (action === 'preview' || action === 'publish') {
+      // Force-flush pending collab saves to da-admin before writing to AEM.
+      // This ensures that what the user sees in the editor matches what AEM gets.
+      // Only applies to the prose editor (edit view) — sheets/configs save synchronously above.
+      if (view === 'edit') {
+        const daContent = document.querySelector('da-content');
+        if (daContent?.forceSave) {
+          const flushResult = await daContent.forceSave();
+          if (!flushResult.ok) {
+            const msg = flushResult.error || 'Unable to confirm save. Please retry or reload the editor.';
+            this._status = { message: msg };
+            this._isSending = false;
+            return;
+          }
+        }
+      }
+
       let json = await saveToAem(aemPath, 'preview');
       if (json.error) {
         this.handleError(json, 'preview');

--- a/blocks/edit/prose/forcesave.js
+++ b/blocks/edit/prose/forcesave.js
@@ -1,0 +1,89 @@
+// ---- Force-save protocol ----
+// Matches da-collab messageFlushRequest / messageFlushResponse constants.
+const MSG_FLUSH_REQUEST = 2;
+const MSG_FLUSH_RESPONSE = 3;
+const FLUSH_TIMEOUT_MS = 8000;
+const FLUSH_MAX_RETRIES = 3;
+
+function decodeFlushAck(data) {
+  const ok = data[1] === 1;
+  if (ok) return { ok: true };
+  // Decode varint-prefixed error string written by lib0/encoding.writeVarString
+  let offset = 2;
+  let len = 0;
+  let shift = 0;
+  while (offset < data.length) {
+    const b = data[offset];
+    offset += 1;
+    // eslint-disable-next-line no-bitwise
+    len |= (b & 0x7f) << shift;
+    // eslint-disable-next-line no-bitwise
+    if ((b & 0x80) === 0) break;
+    shift += 7;
+  }
+  const error = new TextDecoder().decode(data.slice(offset, offset + len));
+  return { ok: false, error };
+}
+
+function sendFlushRequest(ws) {
+  return new Promise((resolve) => {
+    let timer;
+
+    const onMessage = (event) => {
+      const data = new Uint8Array(event.data);
+      if (data[0] !== MSG_FLUSH_RESPONSE) return;
+      clearTimeout(timer);
+      ws.removeEventListener('message', onMessage);
+      resolve(decodeFlushAck(data));
+    };
+
+    timer = setTimeout(() => {
+      ws.removeEventListener('message', onMessage);
+      resolve({ ok: false, timeout: true });
+    }, FLUSH_TIMEOUT_MS);
+
+    ws.addEventListener('message', onMessage);
+    ws.send(new Uint8Array([MSG_FLUSH_REQUEST]));
+  });
+}
+
+function waitForWsConnection(provider) {
+  return new Promise((resolve, reject) => {
+    if (provider.wsconnected) {
+      resolve();
+      return;
+    }
+    let timer;
+
+    const onStatus = ({ status }) => {
+      if (status === 'connected') {
+        clearTimeout(timer);
+        provider.off('status', onStatus);
+        resolve();
+      }
+    };
+
+    timer = setTimeout(() => {
+      provider.off('status', onStatus);
+      reject(new Error('connection timeout'));
+    }, FLUSH_TIMEOUT_MS);
+
+    provider.on('status', onStatus);
+  });
+}
+
+export async function forceSave(provider) {
+  for (let attempt = 0; attempt < FLUSH_MAX_RETRIES; attempt += 1) {
+    try {
+      if (!provider.wsconnected) {
+        await waitForWsConnection(provider);
+      }
+      const result = await sendFlushRequest(provider.ws);
+      if (result.ok) return { ok: true };
+      if (!result.timeout) return result; // server-side error, no retry
+    } catch {
+      // connection wait timed out, try again
+    }
+  }
+  return { ok: false, error: 'Unable to confirm save. Please retry or reload the editor.' };
+}

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -89,6 +89,96 @@ export async function createConnection(path) {
   return { wsProvider: provider, ydoc };
 }
 
+// ---- Force-save protocol ----
+// Matches da-collab messageFlushRequest / messageFlushResponse constants.
+const MSG_FLUSH_REQUEST = 2;
+const MSG_FLUSH_RESPONSE = 3;
+const FLUSH_TIMEOUT_MS = 8000;
+const FLUSH_MAX_RETRIES = 3;
+
+function decodeFlushAck(data) {
+  const ok = data[1] === 1;
+  if (ok) return { ok: true };
+  // Decode varint-prefixed error string written by lib0/encoding.writeVarString
+  let offset = 2;
+  let len = 0;
+  let shift = 0;
+  while (offset < data.length) {
+    const b = data[offset];
+    offset += 1;
+    // eslint-disable-next-line no-bitwise
+    len |= (b & 0x7f) << shift;
+    // eslint-disable-next-line no-bitwise
+    if ((b & 0x80) === 0) break;
+    shift += 7;
+  }
+  const error = new TextDecoder().decode(data.slice(offset, offset + len));
+  return { ok: false, error };
+}
+
+function sendFlushRequest(ws) {
+  return new Promise((resolve) => {
+    let timer;
+
+    const onMessage = (event) => {
+      const data = new Uint8Array(event.data);
+      if (data[0] !== MSG_FLUSH_RESPONSE) return;
+      clearTimeout(timer);
+      ws.removeEventListener('message', onMessage);
+      resolve(decodeFlushAck(data));
+    };
+
+    timer = setTimeout(() => {
+      ws.removeEventListener('message', onMessage);
+      resolve({ ok: false, timeout: true });
+    }, FLUSH_TIMEOUT_MS);
+
+    ws.addEventListener('message', onMessage);
+    ws.send(new Uint8Array([MSG_FLUSH_REQUEST]));
+  });
+}
+
+function waitForWsConnection(provider) {
+  return new Promise((resolve, reject) => {
+    if (provider.wsconnected) {
+      resolve();
+      return;
+    }
+    let timer;
+
+    const onStatus = ({ status }) => {
+      if (status === 'connected') {
+        clearTimeout(timer);
+        provider.off('status', onStatus);
+        resolve();
+      }
+    };
+
+    timer = setTimeout(() => {
+      provider.off('status', onStatus);
+      reject(new Error('connection timeout'));
+    }, FLUSH_TIMEOUT_MS);
+
+    provider.on('status', onStatus);
+  });
+}
+
+export async function forceSave(provider) {
+  for (let attempt = 0; attempt < FLUSH_MAX_RETRIES; attempt += 1) {
+    try {
+      if (!provider.wsconnected) {
+        await waitForWsConnection(provider);
+      }
+      const result = await sendFlushRequest(provider.ws);
+      if (result.ok) return { ok: true };
+      if (!result.timeout) return result; // server-side error, no retry
+    } catch {
+      // connection wait timed out, try again
+    }
+  }
+  return { ok: false, error: 'Unable to confirm save. Please retry or reload the editor.' };
+}
+
 async function loadCustomPlugins() {
   const [
     keyHandlers,
@@ -539,4 +629,5 @@ export default async function initProse({ path, permissions, doc, daContent, wsP
 
   daContent.proseEl = editor;
   daContent.wsProvider = wsProvider;
+  daContent.forceSave = () => forceSave(wsProvider);
 }

--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -27,6 +27,7 @@ import { COLLAB_ORIGIN, DA_ORIGIN } from '../../shared/constants.js';
 import { daFetch, getAuthToken } from '../../shared/utils.js';
 import { getDiffClass, checkForLocNodes, addActiveView } from './diff/diff-utils.js';
 import { debounce, initDaMetadata } from '../utils/helpers.js';
+import { forceSave } from './forcesave.js';
 
 async function checkDoc(path) {
   return daFetch(path, { method: 'HEAD' });
@@ -87,96 +88,6 @@ export async function createConnection(path) {
   });
 
   return { wsProvider: provider, ydoc };
-}
-
-// ---- Force-save protocol ----
-// Matches da-collab messageFlushRequest / messageFlushResponse constants.
-const MSG_FLUSH_REQUEST = 2;
-const MSG_FLUSH_RESPONSE = 3;
-const FLUSH_TIMEOUT_MS = 8000;
-const FLUSH_MAX_RETRIES = 3;
-
-function decodeFlushAck(data) {
-  const ok = data[1] === 1;
-  if (ok) return { ok: true };
-  // Decode varint-prefixed error string written by lib0/encoding.writeVarString
-  let offset = 2;
-  let len = 0;
-  let shift = 0;
-  while (offset < data.length) {
-    const b = data[offset];
-    offset += 1;
-    // eslint-disable-next-line no-bitwise
-    len |= (b & 0x7f) << shift;
-    // eslint-disable-next-line no-bitwise
-    if ((b & 0x80) === 0) break;
-    shift += 7;
-  }
-  const error = new TextDecoder().decode(data.slice(offset, offset + len));
-  return { ok: false, error };
-}
-
-function sendFlushRequest(ws) {
-  return new Promise((resolve) => {
-    let timer;
-
-    const onMessage = (event) => {
-      const data = new Uint8Array(event.data);
-      if (data[0] !== MSG_FLUSH_RESPONSE) return;
-      clearTimeout(timer);
-      ws.removeEventListener('message', onMessage);
-      resolve(decodeFlushAck(data));
-    };
-
-    timer = setTimeout(() => {
-      ws.removeEventListener('message', onMessage);
-      resolve({ ok: false, timeout: true });
-    }, FLUSH_TIMEOUT_MS);
-
-    ws.addEventListener('message', onMessage);
-    ws.send(new Uint8Array([MSG_FLUSH_REQUEST]));
-  });
-}
-
-function waitForWsConnection(provider) {
-  return new Promise((resolve, reject) => {
-    if (provider.wsconnected) {
-      resolve();
-      return;
-    }
-    let timer;
-
-    const onStatus = ({ status }) => {
-      if (status === 'connected') {
-        clearTimeout(timer);
-        provider.off('status', onStatus);
-        resolve();
-      }
-    };
-
-    timer = setTimeout(() => {
-      provider.off('status', onStatus);
-      reject(new Error('connection timeout'));
-    }, FLUSH_TIMEOUT_MS);
-
-    provider.on('status', onStatus);
-  });
-}
-
-export async function forceSave(provider) {
-  for (let attempt = 0; attempt < FLUSH_MAX_RETRIES; attempt += 1) {
-    try {
-      if (!provider.wsconnected) {
-        await waitForWsConnection(provider);
-      }
-      const result = await sendFlushRequest(provider.ws);
-      if (result.ok) return { ok: true };
-      if (!result.timeout) return result; // server-side error, no retry
-    } catch {
-      // connection wait timed out, try again
-    }
-  }
-  return { ok: false, error: 'Unable to confirm save. Please retry or reload the editor.' };
 }
 
 async function loadCustomPlugins() {

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -5,8 +5,8 @@ import { setNx } from '../../../../../scripts/utils.js';
 import initProse, {
   createConnection,
   createAwarenessStatusWidget,
-  forceSave,
 } from '../../../../../blocks/edit/prose/index.js';
+import { forceSave } from '../../../../../blocks/edit/prose/forcesave.js';
 
 // initProse lazily imports da-library.js, which (a) builds URLs from
 // `${getNx()}/...` and (b) calls loadLibrary() at module import time.

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -5,6 +5,7 @@ import { setNx } from '../../../../../scripts/utils.js';
 import initProse, {
   createConnection,
   createAwarenessStatusWidget,
+  forceSave,
 } from '../../../../../blocks/edit/prose/index.js';
 
 // initProse lazily imports da-library.js, which (a) builds URLs from
@@ -491,5 +492,124 @@ describe('prose/index initProse default export', () => {
     });
     await initProse({ path: 'https://admin.da.live/source/o/r/p.html', permissions: ['read'], doc: null, daContent: fakeContent, wsPromise: Promise.resolve({ wsProvider: provider, ydoc }) });
     expect(destroyed).to.equal(1);
+  });
+});
+
+// ---- forceSave tests ----
+
+function buildFakeWs({ connected = true, responseOk = true, responseError = '', delayMs = 0 } = {}) {
+  const listeners = [];
+  const sent = [];
+
+  const ws = {
+    sent,
+    addEventListener(type, cb) { if (type === 'message') listeners.push(cb); },
+    removeEventListener(type, cb) {
+      if (type !== 'message') return;
+      const i = listeners.indexOf(cb);
+      if (i > -1) listeners.splice(i, 1);
+    },
+    send(data) {
+      sent.push(data);
+      if (!connected) return;
+      // Simulate server response after optional delay
+      setTimeout(() => {
+        // Build MSG_FLUSH_RESPONSE (3) + ok flag + optional error string
+        let resp;
+        if (responseOk) {
+          resp = new Uint8Array([3, 1]);
+        } else {
+          const errBytes = new TextEncoder().encode(responseError);
+          resp = new Uint8Array([3, 0, errBytes.length, ...errBytes]);
+        }
+        listeners.forEach((cb) => cb({ data: resp.buffer }));
+      }, delayMs);
+    },
+  };
+  return ws;
+}
+
+function buildFakeProvider({ wsconnected = true, ws = null } = {}) {
+  const listeners = new Map();
+  return {
+    wsconnected,
+    ws,
+    on(event, cb) {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(cb);
+    },
+    off(event, cb) {
+      const arr = listeners.get(event);
+      if (!arr) return;
+      const i = arr.indexOf(cb);
+      if (i > -1) arr.splice(i, 1);
+    },
+    _emit(event, ...args) {
+      (listeners.get(event) || []).forEach((cb) => cb(...args));
+    },
+  };
+}
+
+describe('forceSave', () => {
+  it('returns ok:true when server acks the flush', async () => {
+    const ws = buildFakeWs({ responseOk: true });
+    const provider = buildFakeProvider({ wsconnected: true, ws });
+
+    const result = await forceSave(provider);
+    expect(result.ok).to.be.true;
+    expect(ws.sent).to.have.length(1);
+    expect(ws.sent[0][0]).to.equal(2); // MSG_FLUSH_REQUEST
+  });
+
+  it('returns ok:false with error message when server reports failure', async () => {
+    const ws = buildFakeWs({ responseOk: false, responseError: 'save failed' });
+    const provider = buildFakeProvider({ wsconnected: true, ws });
+
+    const result = await forceSave(provider);
+    expect(result.ok).to.be.false;
+    expect(result.error).to.equal('save failed');
+  });
+
+  it('waits for connection then sends flush when initially disconnected', async () => {
+    const ws = buildFakeWs({ responseOk: true });
+    const provider = buildFakeProvider({ wsconnected: false, ws });
+
+    // Simulate reconnect after a tick
+    setTimeout(() => {
+      provider.wsconnected = true;
+      provider._emit('status', { status: 'connected' });
+    }, 5);
+
+    const result = await forceSave(provider);
+    expect(result.ok).to.be.true;
+    expect(ws.sent).to.have.length(1);
+  });
+
+  it('ignores unrelated message types while waiting for ack', async () => {
+    const listeners = [];
+    const sent = [];
+
+    const ws = {
+      sent,
+      addEventListener(type, cb) { if (type === 'message') listeners.push(cb); },
+      removeEventListener(type, cb) {
+        if (type !== 'message') return;
+        const i = listeners.indexOf(cb);
+        if (i > -1) listeners.splice(i, 1);
+      },
+      send(data) {
+        sent.push(data);
+        // Send a yjs sync message (type 0) first, then the real ack
+        setTimeout(() => {
+          listeners.forEach((cb) => cb({ data: new Uint8Array([0, 0]).buffer }));
+        }, 5);
+        setTimeout(() => {
+          listeners.forEach((cb) => cb({ data: new Uint8Array([3, 1]).buffer }));
+        }, 10);
+      },
+    };
+    const provider = buildFakeProvider({ wsconnected: true, ws });
+    const result = await forceSave(provider);
+    expect(result.ok).to.be.true;
   });
 });


### PR DESCRIPTION
## Problem

When a user drags and drops an image in the DA editor, the upload is a two-step process:

1. An FPO placeholder is inserted immediately into the collaborative document.
2. A debounced PUT to da-admin fires ~2 seconds later to persist the change.

If the user clicks **Preview** or **Publish** before that debounced save completes, the Cloudflare Durable Object (DO) backing the collab session may have migrated to a different machine in the meantime. The result: the preview/publish pipeline reads the old version of the document from da-admin — without the newly dropped image.

## Solution

Before triggering a Preview or Publish action, the client now sends a WebSocket **flush request** (`MSG_FLUSH_REQUEST = 2`) to da-collab, asking it to immediately flush any pending in-memory changes to da-admin. The client then:

- Waits up to 8 seconds for the collab server to acknowledge with `MSG_FLUSH_RESPONSE = 3`.
- If the WebSocket is not yet connected, waits for reconnection before sending the flush.
- Retries up to 3 times on timeout (e.g. transient network blips).
- On server-reported error or exhausted retries, surfaces a clear user-facing error message in the title bar and aborts the preview/publish — preventing a silent stale-content push.
- On success, proceeds normally with the AEM preview/publish call.

## Dependencies

> **These da-collab PRs must be merged first**, otherwise the Preview/Publish action will stall waiting for a flush ack that the server does not understand.

- https://github.com/adobe/da-collab/pull/152 — server-side flush protocol
- https://github.com/adobe/da-collab/pull/153 — CF storage lastsync fix

## Changes

- **`blocks/edit/prose/forcesave.js`** *(new)* — force-save protocol: `MSG_FLUSH_REQUEST/RESPONSE` constants, `decodeFlushAck`, `sendFlushRequest`, `waitForWsConnection`, and the exported `forceSave(provider)` function.
- **`blocks/edit/prose/index.js`** — imports `forceSave` from `./forcesave.js`; attaches `daContent.forceSave` at the end of `initProse`.
- **`blocks/edit/da-title/da-title.js`** — calls `daContent.forceSave()` in `handleAction` before `saveToAem`, only for the prose edit view.
- **`test/unit/blocks/edit/prose/index.test.js`** — 4 `forceSave` unit tests; imports `forceSave` from `./forcesave.js`.

## Test plan

Test page: https://flushsav--da-live--adobe.aem.live/

- [ ] All existing unit tests pass (`npm test` — 1355 passed, 0 failed)
- [ ] `npm run lint` passes with no errors
- [ ] Manual: drag-drop an image, immediately click Preview — verify the image appears in the preview
- [ ] Manual: simulate a slow network; verify the UI shows the flush error message and does not open a stale preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)