### PR TITLE
fix: route collab error map messages to appropriate console levels

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -57,12 +57,7 @@ export async function createConnection(path) {
 
   let lastSentToken = token || null;
   provider.on('connection-close', async (event) => {
-    // Server close codes: 4401 = token expired (refresh + retry), 4403 = forbidden (stop).
-    if (event?.code === 4403) {
-      provider.shouldConnect = false;
-      return;
-    }
-    if (event?.code === 4401) {
+    if (event?.code === 4401 || event?.code === 4403) {
       provider.shouldConnect = false;
       // Force imslib to attempt a refresh before deciding to give up.
       try { await window.adobeIMS?.refreshToken?.(); } catch { /* ignore */ }
@@ -327,8 +322,17 @@ function registerErrorHandler(ydoc) {
   ydoc.on('update', () => {
     const errorMap = ydoc.getMap('error');
     if (errorMap && errorMap.size > 0) {
-      // eslint-disable-next-line no-console
-      console.log('Error from server', JSON.stringify(errorMap));
+      const message = errorMap.get('message') || JSON.stringify(errorMap.toJSON());
+      if (message.startsWith('401')) {
+        // eslint-disable-next-line no-console
+        console.warn(`Message from collab: ${message}`);
+      } else if (message.startsWith('403 ')) {
+        // eslint-disable-next-line no-console
+        console.log(`Message from collab: ${message}`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(`Error message from collab: ${message}`, errorMap.toJSON());
+      }
       errorMap.clear();
     }
   });

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -574,6 +574,137 @@ describe('prose/index initProse default export', () => {
   });
 });
 
+// ---- registerErrorHandler tests ----
+
+describe('prose/index registerErrorHandler', () => {
+  let fakeContent;
+  let fakeTitle;
+  let savedQuery;
+  let savedFetch;
+
+  function setupFakeContent() {
+    Object.defineProperty(fakeContent, 'proseEl', {
+      configurable: true,
+      set(v) {
+        v.getRootNode = () => ({ host: document.createElement('div') });
+        this._proseEl = v;
+      },
+      get() { return this._proseEl; },
+    });
+  }
+
+  async function initAndGetYDoc() {
+    const ydoc = new Y.Doc();
+    const provider = buildFakeWsProvider({ withSynced: false });
+    setupFakeContent();
+    await initProse({
+      path: 'https://admin.da.live/source/o/r/p.html',
+      permissions: ['read'],
+      doc: null,
+      daContent: fakeContent,
+      wsPromise: Promise.resolve({ wsProvider: provider, ydoc }),
+    });
+    return ydoc;
+  }
+
+  beforeEach(() => {
+    if (window.view) {
+      try { window.view.destroy(); } catch { /* */ }
+      delete window.view;
+    }
+    fakeContent = { proseEl: null, wsProvider: null };
+    fakeTitle = { collabUsers: undefined, collabStatus: undefined };
+    savedQuery = document.querySelector.bind(document);
+    document.querySelector = (sel) => {
+      if (sel === 'da-title') return fakeTitle;
+      if (sel === 'da-content') return null;
+      return savedQuery(sel);
+    };
+    savedFetch = window.fetch;
+    window.fetch = () => Promise.resolve(new Response('{}', { status: 200 }));
+  });
+
+  afterEach(() => {
+    if (window.view) {
+      try { window.view.destroy(); } catch { /* */ }
+      delete window.view;
+    }
+    document.querySelector = savedQuery;
+    window.fetch = savedFetch;
+  });
+
+  it('Routes 401 messages to console.warn', async () => {
+    const ydoc = await initAndGetYDoc();
+    const calls = [];
+    const saved = console.warn;
+    console.warn = (...args) => calls.push(args);
+    try {
+      ydoc.getMap('error').set('message', '401 Unauthorized');
+      expect(calls).to.have.lengthOf(1);
+      expect(calls[0][0]).to.equal('Message from collab: 401 Unauthorized');
+    } finally {
+      console.warn = saved;
+    }
+  });
+
+  it('Routes 403 messages to console.log', async () => {
+    const ydoc = await initAndGetYDoc();
+    const calls = [];
+    const saved = console.log;
+    console.log = (...args) => calls.push(args);
+    try {
+      ydoc.getMap('error').set('message', '403 Forbidden');
+      expect(calls).to.have.lengthOf(1);
+      expect(calls[0][0]).to.equal('Message from collab: 403 Forbidden');
+    } finally {
+      console.log = saved;
+    }
+  });
+
+  it('Routes other messages to console.error with toJSON payload', async () => {
+    const ydoc = await initAndGetYDoc();
+    const calls = [];
+    const saved = console.error;
+    console.error = (...args) => calls.push(args);
+    try {
+      ydoc.getMap('error').set('message', '500 Internal Server Error');
+      expect(calls).to.have.lengthOf(1);
+      expect(calls[0][0]).to.equal('Error message from collab: 500 Internal Server Error');
+      expect(calls[0][1]).to.deep.equal({ message: '500 Internal Server Error' });
+    } finally {
+      console.error = saved;
+    }
+  });
+
+  it('Clears the error map after logging', async () => {
+    const ydoc = await initAndGetYDoc();
+    const saved = console.warn;
+    console.warn = () => {};
+    try {
+      const errorMap = ydoc.getMap('error');
+      errorMap.set('message', '401 Unauthorized');
+      expect(errorMap.size).to.equal(0);
+    } finally {
+      console.warn = saved;
+    }
+  });
+
+  it('Falls back to JSON when no message key is set', async () => {
+    const ydoc = await initAndGetYDoc();
+    const calls = [];
+    const saved = console.error;
+    console.error = (...args) => calls.push(args);
+    try {
+      ydoc.getMap('error').set('code', 'UNKNOWN');
+      expect(calls).to.have.lengthOf(1);
+      expect(calls[0][0]).to.equal('Error message from collab: {"code":"UNKNOWN"}');
+      expect(calls[0][1]).to.deep.equal({ code: 'UNKNOWN' });
+    } finally {
+      console.error = saved;
+    }
+  });
+});
+
 // ---- forceSave tests ----
 
 function buildFakeWs({ connected = true, responseOk = true, responseError = '', delayMs = 0 } = {}) {


### PR DESCRIPTION
## Summary
- `401` messages → `console.warn` (auth info, not an error)
- `403 ` messages → `console.log` (permission info, not an error)
- All other messages → `console.error` with `errorMap.toJSON()` payload for full context
- Message is read from `errorMap.get('message')`, falling back to `JSON.stringify(errorMap.toJSON())` when no `message` key is set

This aligns with https://github.com/adobe/da-collab/pull/157 - no need for an ugly error message in case of an expired token (403). 401 is more unexpected (some removed author full access to the file ?) but still warning is enough.

If message received is 403: sign up popup appears. If author signs in, latest changes are even restored and persisted
If message received is 401: redirected to the 404 page.


## Test plan
- [ ] `Routes 401 messages to console.warn` — verifies warn path and message prefix
- [ ] `Routes 403 messages to console.log` — verifies log path and message prefix
- [ ] `Routes other messages to console.error with toJSON payload` — verifies error path + payload
- [ ] `Clears the error map after logging` — verifies `errorMap.clear()` is always called
- [ ] `Falls back to JSON when no message key is set` — verifies fallback serialisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)