### PR TITLE
feat: add skills editor page with ew provider block

### DIFF
--- a/apps/skills.md
+++ b/apps/skills.md
@@ -1,0 +1,5 @@
+# Skills Editor
+
+Full-page catalog of agents, skills, MCP servers, and tools. Pick your site using the hash: `#/{org}/{site}` (for example `#/anfibiacreativa/aem-aerofly-demo`).
+
+<div class="ew-skills"></div>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -48,10 +48,23 @@ link.setAttribute('rel', 'stylesheet');
 link.setAttribute('href', `${nx}${nxCSS}`);
 document.head.appendChild(link);
 
+const EW_ORIGINS = {
+  dev: 'http://localhost:3001',
+  stage: 'https://main--ew-extensions--adobe-rnd.aem.page',
+  prod: 'https://main--ew-extensions--adobe-rnd.aem.live',
+};
+
+const ewEnv = (() => {
+  const { host } = window.location;
+  if (host.includes('local')) return 'dev';
+  if (host.includes('.aem.')) return 'stage';
+  return 'prod';
+})();
+
 const CONFIG = {
   hostnames: ['da.live', 'da.page'],
   codeBase: import.meta.url.replace('/scripts/scripts.js', ''),
-  providers: { da: window.location.origin },
+  providers: { da: window.location.origin, ew: EW_ORIGINS[ewEnv] },
   decorateArea,
   imsClientId: 'darkalley',
   imsScope: 'ab.manage,AdobeID,gnav,openid,org.read,read_organizations,session,aem.frontend.all,additional_info.ownerOrg,additional_info.projectedProductContext,account_cluster.read',


### PR DESCRIPTION
## Summary
- Adds `apps/skills.md` as the `/apps/skills` page in da-live
- Uses `ew-skills` block class so `loadBlock` resolves via `providers.ew` to ew-extensions (da-skills)

## Why
- The skills editor moved from da-nx to da-skills (ew-extensions)
- da-nx #446 added `providers.ew` routing in `loadBlock`, but the consumer page needs the `ew-` prefix for the resolution to work
- The old `nx-skills-editor` class pointed at a block that no longer exists in da-nx

## What Changed
- **`apps/skills.md`** (new file) -- page shell with `<div class="ew-skills"></div>` so `loadBlock` matches the `ew` provider and loads `blocks/skills/skills.js` from ew-extensions

## Test Plan
- [ ] Start da-live (:3000), da-nx (:6456 on `ew-provider-support-v2`), da-skills (:3001)
- [ ] Navigate to `http://localhost:3000/apps/skills?nx=local&nxver=2#/{org}/{site}`
- [ ] Verify the skills editor loads from `:3001/blocks/skills/skills.js`
- [ ] Also update the content bus page at `content.da.live/adobe/da-live/apps/skills` to use `ew-skills`

## Risks / Follow-ups
- The content bus at `content.da.live` still serves the old `nx-skills-editor` class. Until that authored page is updated, the AEM CLI dev server will serve stale content from the remote mount, not this local file.
- Depends on [da-nx #446](https://github.com/adobe/da-nx/pull/446) for `providers.ew` support
- Depends on da-skills `ew-block-contract` branch for `blocks/skills/skills.js` entry point
