### PR TITLE
feat: preview single + bulk on browse

### DIFF
--- a/blocks/browse/da-actionbar/da-actionbar.css
+++ b/blocks/browse/da-actionbar/da-actionbar.css
@@ -55,6 +55,10 @@ button {
   gap: 8px;
 }
 
+.da-action-bar .preview-button img {
+  filter: brightness(0) invert(1);
+}
+
 .da-action-bar.hide,
 .da-action-bar .hide {
   display: none;

--- a/blocks/browse/da-actionbar/da-actionbar.js
+++ b/blocks/browse/da-actionbar/da-actionbar.js
@@ -80,6 +80,12 @@ export default class DaActionBar extends LitElement {
     this.dispatchEvent(event);
   }
 
+  handlePreview() {
+    const opts = { bubbles: true, composed: true };
+    const event = new CustomEvent('onpreview', opts);
+    this.dispatchEvent(event);
+  }
+
   async handleShare() {
     const { items2Clipboard } = await import('../da-list/helpers/utils.js');
     items2Clipboard(this.items);
@@ -98,6 +104,11 @@ export default class DaActionBar extends LitElement {
   get _canWrite() {
     if (!this.permissions) return false;
     return this.permissions.some((permission) => permission === 'write');
+  }
+
+  get _canPreview() {
+    const hasFile = this.items.some((item) => item.ext && item.ext !== 'link');
+    return hasFile && !this._isCopying;
   }
 
   get _canShare() {
@@ -156,6 +167,12 @@ export default class DaActionBar extends LitElement {
             class="delete-button ${this._canWrite ? '' : 'hide'} ${this._isCopying ? 'hide' : ''}">
             <img src="/blocks/browse/da-browse/img/Smock_Delete_18_N.svg" alt="" aria-hidden="true"/>
             <span>Delete</span>
+          </button>
+          <button
+            @click=${this.handlePreview}
+            class="preview-button ${this._canPreview ? '' : 'hide'}">
+            <img src="/blocks/edit/img/S2_Icon_Preview_20_N.svg" alt="" aria-hidden="true"/>
+            <span>Preview</span>
           </button>
           <button
             @click=${this.handleShare}

--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -873,7 +873,14 @@ export default class DaList extends LitElement {
     const closeHandler = hasResults ? this.handleClear : this.handleConfirmClose;
 
     const action = hasResults
-      ? { style: 'accent', label: 'Close', click: () => this.handleClear() }
+      ? {
+        style: 'accent',
+        label: 'Copy URLs',
+        click: () => {
+          const text = results.map(({ url }) => url).join('\n');
+          navigator.clipboard.writeText(text);
+        },
+      }
       : {
         style: 'accent',
         label: 'Preview',
@@ -882,9 +889,9 @@ export default class DaList extends LitElement {
       };
 
     const body = hasResults
-      ? html`<ul>${results.map(({ name, url }) => html`
-          <li><a href="${url}" target="_blank">${name}</a></li>
-        `)}</ul>`
+      ? html`${results.map(({ name, url }) => html`
+          <p><a href="${url}" target="_blank">${name}</a></p>
+        `)}`
       : html`<p>Preview the ${count} selected ${count === 1 ? 'item' : 'items'}?</p>`;
 
     return html`
@@ -914,8 +921,8 @@ export default class DaList extends LitElement {
         .action=${action}
         @close=${this.handleErrorClose}>
         ${this._itemErrors.map((item) => html`
-          <p class="error-item-message">${item.message}</p>
-          <p class="error-item-name">${item.name}</p>
+          <p class="dialog-item-label">${item.message}</p>
+          <p class="dialog-item-name">${item.name}</p>
         `)}
       </da-dialog>
     `;

--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -885,7 +885,7 @@ export default class DaList extends LitElement {
       ? html`<ul>${results.map(({ name, url }) => html`
           <li><a href="${url}" target="_blank">${name}</a></li>
         `)}</ul>`
-      : html`<p>Preview the selected ${count} ${count === 1 ? 'item' : 'items'}?</p>`;
+      : html`<p>Preview the ${count} selected ${count === 1 ? 'item' : 'items'}?</p>`;
 
     return html`
       <da-dialog

--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -1,7 +1,7 @@
 import { LitElement, html, repeat, nothing } from 'da-lit';
 import { DA_ORIGIN } from '../../shared/constants.js';
 import { getNx, sanitizePathParts } from '../../../scripts/utils.js';
-import { daFetch, aemAdmin } from '../../shared/utils.js';
+import { daFetch, aemAdmin, aemAction, saveDaVersion } from '../../shared/utils.js';
 
 import '../da-list-item/da-list-item.js';
 
@@ -471,6 +471,39 @@ export default class DaList extends LitElement {
     setTimeout(() => { this.setStatus(); }, 3000);
   }
 
+  handlePreview() {
+    this._confirm = { type: 'preview', results: null };
+  }
+
+  async handleConfirmPreview() {
+    const { Queue } = await import(`${getNx()}/public/utils/tree.js`);
+
+    const items = this._selectedItems.filter((item) => item.ext && item.ext !== 'link');
+    this._itemsRemaining = items.length;
+    const results = [];
+
+    const callback = async (item) => {
+      const json = await aemAction(item.path, 'preview');
+      if (json.error) {
+        this._itemErrors.push({ ...item, message: json.error.message || "Couldn't preview item" });
+      } else {
+        saveDaVersion(item.path, 'Previewed');
+        results.push({ name: item.name, url: json.preview?.url });
+      }
+      this._itemsRemaining -= 1;
+      if (this._itemsRemaining === 0) {
+        if (results.length > 0) {
+          this._confirm = { type: 'preview', results };
+        } else {
+          this.handleConfirmClose();
+        }
+      }
+    };
+
+    const queue = new Queue(callback, 5);
+    await Promise.all(items.map((item) => queue.push(item)));
+  }
+
   dragenter(e) {
     e.stopPropagation();
     e.target.closest('.da-browse-panel').classList.add('is-dragged-over');
@@ -686,10 +719,10 @@ export default class DaList extends LitElement {
           placeholder="YES"
           autofocus=""
           @input=${(e) => {
-            const upper = e.target.value.toUpperCase();
-            if (e.target.value !== upper) e.target.value = upper;
-            this._confirmText = upper;
-          }}
+        const upper = e.target.value.toUpperCase();
+        if (e.target.value !== upper) e.target.value = upper;
+        this._confirmText = upper;
+      }}
           aria-label="Type YES to confirm"
           value=${this._confirmText ?? ''}></sl-input>
       </div>
@@ -828,6 +861,43 @@ export default class DaList extends LitElement {
     `;
   }
 
+  renderPreviewConfirm() {
+    const { results } = this._confirm;
+    const hasResults = results !== null;
+    const items = this._selectedItems.filter((item) => item.ext && item.ext !== 'link');
+    const count = items.length;
+    const hasRemaining = this._itemsRemaining !== 0;
+
+    const title = hasResults ? 'Preview complete' : 'Preview';
+    const message = hasRemaining ? `${this._itemsRemaining} remaining` : nothing;
+    const closeHandler = hasResults ? this.handleClear : this.handleConfirmClose;
+
+    const action = hasResults
+      ? { style: 'accent', label: 'Close', click: () => this.handleClear() }
+      : {
+        style: 'accent',
+        label: 'Preview',
+        click: async () => this.handleConfirmPreview(),
+        disabled: hasRemaining,
+      };
+
+    const body = hasResults
+      ? html`<ul>${results.map(({ name, url }) => html`
+          <li><a href="${url}" target="_blank">${name}</a></li>
+        `)}</ul>`
+      : html`<p>Preview the selected ${count} ${count === 1 ? 'item' : 'items'}?</p>`;
+
+    return html`
+      <da-dialog
+        title=${title}
+        .message=${message}
+        .action=${action}
+        @close=${closeHandler}>
+        ${body}
+      </da-dialog>
+    `;
+  }
+
   renderErrors() {
     const action = {
       style: 'accent',
@@ -962,12 +1032,14 @@ export default class DaList extends LitElement {
         @rename=${this.handleRename}
         @onpaste=${this.handlePaste}
         @ondelete=${this.handleDelete}
+        @onpreview=${this.handlePreview}
         @onshare=${this.handleShare}
         currentPath="${this.fullpath}"
         role="row"
         data-visible="${this._selectedItems?.length > 0}"></da-actionbar>
       ${this._status ? this.renderStatus() : nothing}
-      ${this._confirm ? this.renderConfirm() : nothing}
+      ${this._confirm === 'delete' ? this.renderConfirm() : nothing}
+      ${this._confirm?.type === 'preview' ? this.renderPreviewConfirm() : nothing}
       ${this._dropConflicts?.length ? this.renderDropConfirm() : nothing}
       ${!this._confirm && this._itemErrors.length ? this.renderErrors() : nothing}
       `;

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -2,12 +2,10 @@ import { LitElement, html, nothing } from 'da-lit';
 import {
   requestRole,
   saveToDa,
-  saveToAem,
   saveDaConfig,
-  saveDaVersion,
   getAemHrefs,
 } from '../utils/helpers.js';
-import { delay, fetchDaConfigs, getFirstSheet } from '../../shared/utils.js';
+import { delay, fetchDaConfigs, getFirstSheet, aemAction, saveDaVersion } from '../../shared/utils.js';
 import inlinesvg from '../../shared/inlinesvg.js';
 import getSheet from '../../shared/sheet.js';
 
@@ -280,30 +278,14 @@ export default class DaTitle extends LitElement {
         }
       }
 
-      let json = await saveToAem(aemPath, 'preview');
-      if (json.error) {
-        this.handleError(json, 'preview');
+      const onScheduled = (schedule) => this.setScheduledDialog(schedule);
+      const json = await aemAction(aemPath, action, { onScheduled });
+      if (json.cancelled) {
+        this._isSending = false;
         return;
       }
-
-      // Anything related to publish
-      if (action === 'publish') {
-        // If lazy setup has not finished, check the schedule manually
-        this._scheduled ??= await this.getSchedule(org, site, path);
-        if (this._scheduled?.scheduled) {
-          const shouldContinue = await this.setScheduledDialog(this._scheduled);
-          if (!shouldContinue) {
-            this._isSending = false;
-            return;
-          }
-        }
-        // Publish to AEM
-        json = await saveToAem(aemPath, 'live');
-      }
-
-      // Handle all AEM errors
       if (json.error) {
-        this.handleError(json, 'publish');
+        this.handleError(json, json.error.action);
         return;
       }
 

--- a/blocks/edit/utils/helpers.js
+++ b/blocks/edit/utils/helpers.js
@@ -1,8 +1,10 @@
 import { DOMSerializer, Y } from 'da-y-wrapper';
 import { aem2doc, getSchema, yDocToProsemirror } from 'da-parser';
-import { AEM_ORIGIN, DA_ORIGIN } from '../../shared/constants.js';
+import { DA_ORIGIN } from '../../shared/constants.js';
 import prose2aem from '../../shared/prose2aem.js';
 import { daFetch, getSidekickConfig } from '../../shared/utils.js';
+
+export { saveToAem, saveDaVersion } from '../../shared/utils.js';
 
 export function isURL(text) {
   try {
@@ -14,31 +16,6 @@ export function isURL(text) {
 }
 
 const AEM_PERMISSION_TPL = '{"users":{"total":1,"limit":1,"offset":0,"data":[]},"data":{"total":1,"limit":1,"offset":0,"data":[{}]},":names":["users","data"],":version":3,":type":"multi-sheet"}';
-
-/* eslint-disable max-len */
-/**
- * [admin] Unable to preview '.../page.md': source contains large image: error fetching resource at http.../hello: Image 1 exceeds allowed limit of 10.00MB
- * [admin] Unable to preview '.../doc.pdf': PDF is larger than 10MB: 24.0MB
- * [admin] Unable to preview '.../video.mp4': MP4 is longer than 2 minutes: 2m 44s
- * [admin] Unable to preview '.../video.mp4': MP4 has a higher bitrate than 300 KB/s: 494 kilobytes
- * [admin] not authenticated
- * [admin] not authorized
- */
-/* eslint-enable max-len */
-function parseAemError(xError) {
-  if (xError.includes('PDF')) {
-    const [seg1, seg2] = xError.split(': ').slice(-2);
-    return `${seg1}: ${seg2}`;
-  }
-  if (xError.includes('MP4')) {
-    const [seg1] = xError.split(': ').slice(-2);
-    return seg1;
-  }
-  if (xError.includes('Image')) {
-    return xError.split(': ').pop().replace('.00', '');
-  }
-  return xError.replace('[admin] ', '');
-}
 
 export async function getAemHrefs({ path }) {
   // Mine the path for different parts
@@ -65,27 +42,6 @@ export async function getAemHrefs({ path }) {
   }
 
   return hrefs;
-}
-
-export async function saveToAem(path, action) {
-  const [owner, repo, ...parts] = path.slice(1).toLowerCase().split('/');
-  const aemPath = parts.join('/');
-
-  const url = `${AEM_ORIGIN}/${action}/${owner}/${repo}/main/${aemPath}`;
-  const resp = await daFetch(url, { method: 'POST' });
-  // eslint-disable-next-line no-console
-  if (!resp.ok) {
-    const { status, headers } = resp;
-    const authErr = [401, 403].some((s) => s === status);
-    const message = authErr ? `Not authorized to ${action}` : `Error during ${action}`;
-    const xerror = headers.get('x-error');
-
-    const error = { action, status, type: 'error', message };
-    if (xerror && !authErr) error.details = parseAemError(xerror);
-
-    return { error };
-  }
-  return resp.json();
 }
 
 async function saveHtml(fullPath) {
@@ -209,22 +165,6 @@ export function saveToDa(pathname, sheet) {
 export function saveDaConfig(pathname, sheet) {
   const fullPath = `${DA_ORIGIN}/config${pathname}`;
   return saveJson(fullPath, sheet, null, 'config');
-}
-
-export async function saveDaVersion(pathname, label = 'Published') {
-  const fullPath = `${DA_ORIGIN}/versionsource${pathname}`;
-
-  const opts = {
-    method: 'POST',
-    body: JSON.stringify({ label }),
-  };
-
-  try {
-    await daFetch(fullPath, opts);
-  } catch {
-    // eslint-disable-next-line no-console
-    console.log(`Error creating auto version (${label}).`);
-  }
 }
 
 async function getRoleRequestDetails(action) {

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -143,6 +143,87 @@ export async function aemAdmin(path, api, method = 'POST') {
   }
 }
 
+/* eslint-disable max-len */
+/**
+ * [admin] Unable to preview '.../page.md': source contains large image: error fetching resource at http.../hello: Image 1 exceeds allowed limit of 10.00MB
+ * [admin] Unable to preview '.../doc.pdf': PDF is larger than 10MB: 24.0MB
+ * [admin] Unable to preview '.../video.mp4': MP4 is longer than 2 minutes: 2m 44s
+ * [admin] Unable to preview '.../video.mp4': MP4 has a higher bitrate than 300 KB/s: 494 kilobytes
+ * [admin] not authenticated
+ * [admin] not authorized
+ */
+/* eslint-enable max-len */
+function parseAemError(xError) {
+  if (xError.includes('PDF')) {
+    const [seg1, seg2] = xError.split(': ').slice(-2);
+    return `${seg1}: ${seg2}`;
+  }
+  if (xError.includes('MP4')) {
+    const [seg1] = xError.split(': ').slice(-2);
+    return seg1;
+  }
+  if (xError.includes('Image')) {
+    return xError.split(': ').pop().replace('.00', '');
+  }
+  return xError.replace('[admin] ', '');
+}
+
+export async function saveToAem(path, action) {
+  const [owner, repo, ...parts] = path.slice(1).toLowerCase().split('/');
+  const aemPath = parts.join('/');
+  const url = `${AEM_ORIGIN}/${action}/${owner}/${repo}/main/${aemPath}`;
+  const resp = await daFetch(url, { method: 'POST' });
+  if (!resp.ok) {
+    const { status, headers } = resp;
+    const authErr = [401, 403].some((s) => s === status);
+    const message = authErr ? `Not authorized to ${action}` : `Error during ${action}`;
+    const xerror = headers.get('x-error');
+    const error = { action, status, type: 'error', message };
+    if (xerror && !authErr) error.details = parseAemError(xerror);
+    return { error };
+  }
+  return resp.json();
+}
+
+const SNAPSHOT_SCHEDULER_URL = 'https://helix-snapshot-scheduler-prod.adobeaem.workers.dev';
+
+export async function getExistingSchedule(org, site, path) {
+  try {
+    const resp = await daFetch(`${SNAPSHOT_SCHEDULER_URL}/schedule/${org}/${site}?path=${encodeURIComponent(path)}`);
+    if (!resp.ok) return null;
+    return resp.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function saveDaVersion(pathname, label = 'Published') {
+  const fullPath = `${DA_ORIGIN}/versionsource${pathname}`;
+  const opts = { method: 'POST', body: JSON.stringify({ label }) };
+  try {
+    await daFetch(fullPath, opts);
+  } catch {
+    // eslint-disable-next-line no-console
+    console.log(`Error creating auto version (${label}).`);
+  }
+}
+
+export async function aemAction(path, action, opts = {}) {
+  const previewJson = await saveToAem(path, 'preview');
+  if (previewJson.error) return previewJson;
+  if (action === 'preview') return previewJson;
+
+  const [, org, site, ...rest] = path.toLowerCase().split('/');
+  const pagePath = `/${rest.join('/')}`.replace(/\.html$/, '');
+  const schedule = await getExistingSchedule(org, site, pagePath);
+  if (schedule?.scheduled) {
+    const proceed = opts.onScheduled ? await opts.onScheduled(schedule) : false;
+    if (!proceed) return { cancelled: true };
+  }
+
+  return saveToAem(path, 'live');
+}
+
 export async function saveToDa({ path, formData, blob, props, preview = false }) {
   if (!path || !path.startsWith('/') || path.includes('://')) return undefined;
 

--- a/test/unit/blocks/browse/da-actionbar/da-actionbar.test.js
+++ b/test/unit/blocks/browse/da-actionbar/da-actionbar.test.js
@@ -197,6 +197,16 @@ describe('DaActionBar', () => {
     });
   });
 
+  describe('handlePreview', () => {
+    it('Dispatches an onpreview event', () => {
+      const el = new DaActionBar();
+      let dispatched;
+      el.dispatchEvent = (e) => { dispatched = e; };
+      el.handlePreview();
+      expect(dispatched.type).to.equal('onpreview');
+    });
+  });
+
   describe('handleShare', () => {
     it('Imports the helper module, runs items2Clipboard, and dispatches onshare', async () => {
       const el = new DaActionBar();

--- a/test/unit/blocks/browse/da-list/da-list.test.js
+++ b/test/unit/blocks/browse/da-list/da-list.test.js
@@ -503,6 +503,14 @@ describe('DaList helpers', () => {
     });
   });
 
+  describe('handlePreview', () => {
+    it('Sets _confirm to preview type with null results', () => {
+      const el = makeList();
+      el.handlePreview();
+      expect(el._confirm).to.deep.equal({ type: 'preview', results: null });
+    });
+  });
+
   describe('handleShare', () => {
     it('Sets a copied status and clears it after 3s', async () => {
       const el = makeList();

--- a/test/unit/blocks/edit/da-title/da-title.test.js
+++ b/test/unit/blocks/edit/da-title/da-title.test.js
@@ -514,10 +514,18 @@ describe('DaTitle', () => {
         dialogShown = true;
         return false; // user cancels
       };
-      window.fetch = () => Promise.resolve(new Response(
-        JSON.stringify({ preview: { url: 'https://x' }, webPath: '/test/page' }),
-        { status: 200 },
-      ));
+      window.fetch = (url) => {
+        if (url.includes('snapshot-scheduler')) {
+          return Promise.resolve(new Response(
+            JSON.stringify({ scheduled: true, scheduledPublish: '2026-12-31' }),
+            { status: 200 },
+          ));
+        }
+        return Promise.resolve(new Response(
+          JSON.stringify({ preview: { url: 'https://x' }, webPath: '/test/page' }),
+          { status: 200 },
+        ));
+      };
       const opens = [];
       const savedOpen = window.open;
       window.open = (...args) => { opens.push(args); };

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -4,7 +4,9 @@ import {
   daFetch,
   etcFetch,
   aemAdmin,
+  aemAction,
   saveToDa,
+  saveDaVersion,
   getSheetByIndex,
   getSheetByName,
   getFirstSheet,
@@ -680,6 +682,69 @@ describe('fetchDaConfigs', () => {
     const resolved = await results[0];
     expect(resolved).to.equal(null);
     expect(fetchCalled).to.be.false;
+  });
+});
+
+describe('saveDaVersion', () => {
+  let savedFetch;
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  it('POSTs to the versionsource endpoint with the correct path and label', async () => {
+    let capturedUrl;
+    let capturedOpts;
+    window.fetch = (url, opts) => {
+      capturedUrl = url;
+      capturedOpts = opts;
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    };
+
+    await saveDaVersion('/org/site/doc', 'Previewed');
+    expect(capturedUrl).to.include('/versionsource/org/site/doc');
+    expect(capturedOpts.method).to.equal('POST');
+    expect(JSON.parse(capturedOpts.body)).to.deep.equal({ label: 'Previewed' });
+  });
+
+  it('Silently swallows fetch errors', async () => {
+    window.fetch = () => Promise.reject(new Error('network error'));
+    await saveDaVersion('/org/site/doc', 'Published');
+  });
+});
+
+describe('aemAction', () => {
+  let savedFetch;
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    window.localStorage.removeItem('nx-ims');
+  });
+  afterEach(() => {
+    window.fetch = savedFetch;
+    window.localStorage.removeItem('nx-ims');
+  });
+
+  it('Returns a human-readable error message when the AEM preview fetch fails', async () => {
+    window.fetch = () => Promise.resolve(new Response('forbidden', { status: 403 }));
+
+    const result = await aemAction('/org/site/doc', 'preview');
+    expect(result.error).to.exist;
+    expect(result.error.type).to.equal('error');
+    expect(result.error.message).to.equal('Not authorized to preview');
+  });
+
+  it('Returns cancelled when publish is blocked by onScheduled returning false', async () => {
+    const scheduleJson = { scheduled: true, scheduledPublish: new Date().toISOString() };
+    window.fetch = (url) => {
+      if (url.includes('/preview/')) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ preview: { url: 'https://x.hlx.page/' }, webPath: '/' }),
+          { status: 200 },
+        ));
+      }
+      return Promise.resolve(new Response(JSON.stringify(scheduleJson), { status: 200 }));
+    };
+
+    const result = await aemAction('/org/site/doc', 'publish', { onScheduled: async () => false });
+    expect(result.cancelled).to.be.true;
   });
 });
 


### PR DESCRIPTION
## Description

- Introduces Preview in the action bar on single and multiple files selection
- Follows same pattern as delete for the confirm dialog 
- Refreshes the dialog on completion to show the urls 
- Extracts reusable logic from preview within the edit view

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

- Users can preview directly from browse without stepping into edit and can preview multiple files easily

## How Has This Been Tested?

- Introduced unit tests consistent with existing tests

## Screenshots (if appropriate):
<img width="1323" height="639" alt="Screenshot 2026-05-20 at 17 48 21" src="https://github.com/user-attachments/assets/47335fab-b74f-4cb9-b3ed-b3d8dcb3e22f" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
