### PR TITLE
fix: bound y-websocket reconnect rate on transient post-open closes

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -29,6 +29,16 @@ import { getDiffClass, checkForLocNodes, addActiveView } from './diff/diff-utils
 import { debounce, initDaMetadata } from '../utils/helpers.js';
 import { forceSave } from './forcesave.js';
 
+// Rapid-reconnect guard (COR-44): y-websocket resets its backoff counter on
+// every successful onopen, so a close that follows a brief successful
+// handshake reschedules at 100ms. Single users behind corporate proxies can
+// sustain thousands of WS upgrades/sec/IP through this path. The guard below
+// detects open-then-close cycles shorter than MIN_HEALTHY_SESSION_MS and
+// applies a manual exponential backoff before letting the provider reconnect.
+const MIN_HEALTHY_SESSION_MS = 5000;
+const SHORT_SESSION_BASE_MS = 1000;
+const SHORT_SESSION_MAX_MS = 30000;
+
 async function checkDoc(path) {
   return daFetch(path, { method: 'HEAD' });
 }
@@ -56,6 +66,13 @@ export async function createConnection(path) {
   provider.maxBackoffTime = 30000;
 
   let lastSentToken = token || null;
+  let lastOpenAt = 0;
+  let failedShortSessions = 0;
+
+  provider.on('status', (st) => {
+    if (st?.status === 'connected') lastOpenAt = Date.now();
+  });
+
   provider.on('connection-close', async (event) => {
     if (event?.code === 4401 || event?.code === 4403) {
       provider.shouldConnect = false;
@@ -78,6 +95,28 @@ export async function createConnection(path) {
       provider.connect();
       return;
     }
+
+    // Non-auth close: rapid-reconnect guard. y-websocket's own 100ms
+    // setTimeout(setupWS) still fires from onclose, but provider.disconnect()
+    // flips shouldConnect=false so that timer's setupWS call no-ops. The
+    // manual setTimeout below is what re-arms the connection.
+    const sessionMs = lastOpenAt ? Date.now() - lastOpenAt : 0;
+    if (sessionMs >= MIN_HEALTHY_SESSION_MS) {
+      failedShortSessions = 0;
+    } else {
+      const delay = Math.min(
+        2 ** failedShortSessions * SHORT_SESSION_BASE_MS,
+        SHORT_SESSION_MAX_MS,
+      );
+      failedShortSessions += 1;
+      provider.shouldConnect = false;
+      provider.disconnect();
+      setTimeout(() => {
+        provider.shouldConnect = true;
+        provider.connect();
+      }, delay);
+    }
+
     const fresh = await getAuthToken();
     provider.protocols = fresh ? ['yjs', fresh] : ['yjs'];
     lastSentToken = fresh;

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import { Y } from 'da-y-wrapper';
 import { setNx } from '../../../../../scripts/utils.js';
 import initProse, {
@@ -277,7 +278,7 @@ describe('prose/index createConnection', () => {
     }
   });
 
-  it('Non-auth close with no token reconnects as anonymous', async () => {
+  it('Non-auth close with no token keeps anonymous protocols and engages rapid-reconnect guard', async () => {
     window.localStorage.removeItem('nx-ims');
     const savedIMS = window.adobeIMS;
     delete window.adobeIMS;
@@ -290,11 +291,259 @@ describe('prose/index createConnection', () => {
       wsProvider.emit('connection-close', [{ code: 1006 }, wsProvider]);
       await new Promise((r) => { setTimeout(r, 0); });
 
+      // Protocols stay anonymous (no IMS token in this scenario).
       expect(wsProvider.protocols).to.deep.equal(['yjs']);
-      expect(wsProvider.shouldConnect).to.equal(true);
+      // COR-44 rapid-reconnect guard: this close was not preceded by a
+      // long-lived 'status' connected event, so the guard treats
+      // it as a short session and parks the provider in manual-reconnect
+      // mode.
+      expect(wsProvider.shouldConnect).to.equal(false);
 
       wsProvider.disconnect({ data: 'Client navigation' });
       wsProvider.destroy?.();
+      ydoc.destroy();
+    } finally {
+      if (savedIMS === undefined) delete window.adobeIMS; else window.adobeIMS = savedIMS;
+    }
+  });
+});
+
+describe('prose/index createConnection rapid-reconnect guard (COR-44)', () => {
+  let originalSetTimeout;
+  let originalClearTimeout;
+  let originalDateNow;
+  let originalWebSocket;
+  let timers;
+  let now;
+
+  function installFakes() {
+    now = 1000000;
+    timers = [];
+    originalDateNow = Date.now;
+    Date.now = () => now;
+    originalSetTimeout = window.setTimeout;
+    originalClearTimeout = window.clearTimeout;
+    window.setTimeout = (fn, delay) => {
+      const id = timers.length + 1;
+      timers.push({ id, fn, delay: delay || 0, cancelled: false });
+      return id;
+    };
+    window.clearTimeout = (id) => {
+      const t = timers.find((x) => x.id === id);
+      if (t) t.cancelled = true;
+    };
+    originalWebSocket = window.WebSocket;
+    window.WebSocket = function FakeWebSocket() {
+      this.readyState = 0;
+      this.close = () => {};
+      this.send = () => {};
+    };
+  }
+
+  function uninstallFakes() {
+    if (originalSetTimeout) window.setTimeout = originalSetTimeout;
+    if (originalClearTimeout) window.clearTimeout = originalClearTimeout;
+    if (originalDateNow) Date.now = originalDateNow;
+    if (originalWebSocket) window.WebSocket = originalWebSocket;
+  }
+
+  function advance(ms) { now += ms; }
+  function clearTimers() { timers = []; }
+  function lastManualBackoff() {
+    return [...timers].reverse().find((t) => !t.cancelled && t.delay >= 1000);
+  }
+
+  function flushMicrotasks() {
+    return new Promise((resolve) => { originalSetTimeout.call(window, resolve, 0); });
+  }
+
+  beforeEach(() => {
+    installFakes();
+    window.localStorage.removeItem('nx-ims');
+  });
+
+  afterEach(() => {
+    uninstallFakes();
+    window.localStorage.removeItem('nx-ims');
+    document.querySelectorAll('da-dialog.da-auth-banner').forEach((el) => el.remove());
+  });
+
+  it('Healthy reconnect: long-lived session does not trigger manual backoff', async () => {
+    const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+    clearTimers();
+    const disconnectSpy = sinon.spy(wsProvider, 'disconnect');
+
+    wsProvider.emit('status', [{ status: 'connected' }]);
+    advance(6000);
+    wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+    await flushMicrotasks();
+
+    expect(disconnectSpy.called).to.equal(false);
+    expect(lastManualBackoff()).to.equal(undefined);
+
+    disconnectSpy.restore();
+    ydoc.destroy();
+  });
+
+  it('Single short session arms a 1s manual backoff and reconnects', async () => {
+    const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+    clearTimers();
+    const disconnectSpy = sinon.spy(wsProvider, 'disconnect');
+    const connectSpy = sinon.spy(wsProvider, 'connect');
+
+    wsProvider.emit('status', [{ status: 'connected' }]);
+    advance(200);
+    wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+    await flushMicrotasks();
+
+    expect(disconnectSpy.called).to.equal(true);
+    expect(wsProvider.shouldConnect).to.equal(false);
+    const t = lastManualBackoff();
+    expect(t).to.exist;
+    expect(t.delay).to.equal(1000);
+
+    t.fn();
+    expect(wsProvider.shouldConnect).to.equal(true);
+    expect(connectSpy.called).to.equal(true);
+
+    disconnectSpy.restore();
+    connectSpy.restore();
+    ydoc.destroy();
+  });
+
+  it('Repeated short sessions back off exponentially: 1s, 2s, 4s', async () => {
+    const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+    clearTimers();
+    const delays = [];
+
+    for (let i = 0; i < 3; i += 1) {
+      wsProvider.emit('status', [{ status: 'connected' }]);
+      advance(200);
+      wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks();
+      const t = lastManualBackoff();
+      delays.push(t.delay);
+      t.cancelled = true;
+    }
+
+    expect(delays).to.deep.equal([1000, 2000, 4000]);
+
+    ydoc.destroy();
+  });
+
+  it('Backoff caps at 30s after many short sessions', async () => {
+    const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+    clearTimers();
+
+    for (let i = 0; i < 6; i += 1) {
+      wsProvider.emit('status', [{ status: 'connected' }]);
+      advance(200);
+      wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks();
+      const t = lastManualBackoff();
+      if (t) t.cancelled = true;
+    }
+
+    // 7th short close: pre-increment value is 6, so 2 ** 6 * 1000 = 64000,
+    // capped at SHORT_SESSION_MAX_MS = 30000.
+    wsProvider.emit('status', [{ status: 'connected' }]);
+    advance(200);
+    wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+    await flushMicrotasks();
+    const last = lastManualBackoff();
+    expect(last.delay).to.equal(30000);
+
+    ydoc.destroy();
+  });
+
+  it('Long-lived session resets the counter so next short close is 1s again', async () => {
+    const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+    clearTimers();
+
+    for (let i = 0; i < 2; i += 1) {
+      wsProvider.emit('status', [{ status: 'connected' }]);
+      advance(200);
+      wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+      // eslint-disable-next-line no-await-in-loop
+      await flushMicrotasks();
+      const t = lastManualBackoff();
+      if (t) t.cancelled = true;
+    }
+
+    // One healthy session: open, live > 5s, then close. No manual backoff.
+    wsProvider.emit('status', [{ status: 'connected' }]);
+    advance(6000);
+    wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+    await flushMicrotasks();
+    expect(lastManualBackoff()).to.equal(undefined);
+
+    // Next short close should use the base delay again.
+    wsProvider.emit('status', [{ status: 'connected' }]);
+    advance(200);
+    wsProvider.emit('connection-close', [{ code: 1011 }, wsProvider]);
+    await flushMicrotasks();
+    expect(lastManualBackoff().delay).to.equal(1000);
+
+    ydoc.destroy();
+  });
+
+  it('Auth-close (4401) does NOT engage rapid-reconnect guard', async () => {
+    window.localStorage.setItem('nx-ims', 'true');
+    const savedIMS = window.adobeIMS;
+    let tokenIndex = 0;
+    const tokens = ['T-old', 'T-new'];
+    window.adobeIMS = {
+      getAccessToken: () => ({ token: tokens[tokenIndex] }),
+      refreshToken: async () => { tokenIndex = 1; },
+    };
+
+    try {
+      const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+      clearTimers();
+      const disconnectSpy = sinon.spy(wsProvider, 'disconnect');
+
+      wsProvider.emit('status', [{ status: 'connected' }]);
+      advance(200);
+      wsProvider.emit('connection-close', [{ code: 4401, reason: 'auth' }, wsProvider]);
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(wsProvider.protocols).to.deep.equal(['yjs', 'T-new']);
+      expect(disconnectSpy.called).to.equal(false);
+      expect(lastManualBackoff()).to.equal(undefined);
+
+      disconnectSpy.restore();
+      ydoc.destroy();
+    } finally {
+      if (savedIMS === undefined) delete window.adobeIMS; else window.adobeIMS = savedIMS;
+    }
+  });
+
+  it('Auth-close (4401) with stale token still stops the loop and shows the banner', async () => {
+    window.localStorage.setItem('nx-ims', 'true');
+    const savedIMS = window.adobeIMS;
+    window.adobeIMS = {
+      getAccessToken: () => ({ token: 'T-same' }),
+      refreshToken: async () => {},
+    };
+
+    try {
+      const { wsProvider, ydoc } = await createConnection('https://admin.da.live/source/o/r/p.html');
+      clearTimers();
+      const connectSpy = sinon.spy(wsProvider, 'connect');
+
+      wsProvider.emit('status', [{ status: 'connected' }]);
+      advance(200);
+      wsProvider.emit('connection-close', [{ code: 4401, reason: 'auth' }, wsProvider]);
+      await new Promise((r) => { originalSetTimeout.call(window, r, 100); });
+
+      expect(wsProvider.shouldConnect).to.equal(false);
+      expect(connectSpy.called).to.equal(false);
+      expect(document.querySelector('da-dialog.da-auth-banner')).to.exist;
+
+      connectSpy.restore();
       ydoc.destroy();
     } finally {
       if (savedIMS === undefined) delete window.adobeIMS; else window.adobeIMS = savedIMS;


### PR DESCRIPTION
## Summary

- y-websocket resets its `wsUnsuccessfulReconnects` counter on every successful `onopen`, so any close that follows a brief successful handshake reschedules at ~100 ms. The 4401/4403 guard from #943 does not cover non-auth paths (1011 from `initSession` catch, 1005 from `closeConn`, 1006 from socket reset), and single users behind corporate Zscaler proxies have sustained 5k+ WS upgrades/sec/IP because of it (see COR-43).
- Add a rapid-reconnect guard to `createConnection`: track open-then-close intervals on the provider and apply manual exponential backoff (1s/2s/4s/… capped at `SHORT_SESSION_MAX_MS = 30 s`) when sessions shorter than `MIN_HEALTHY_SESSION_MS = 5 s` repeat. A healthy session (≥ 5 s lived) resets the counter so a routine reconnect after a long session still reconnects via y-websocket's own timer.
- The auth path from #943 is unchanged and the new guard never increments on 4401/4403 closes — the auth flow has its own loop guard via `lastSentToken`.

## Implementation notes

- The new constants live as module-private consts in `blocks/edit/prose/index.js`.
- The guard sits BEFORE the existing token-refresh `provider.protocols` reassignment so a token refresh still happens for the next manual `provider.connect()` after the backoff.
- y-websocket's internal 100 ms `setTimeout(setupWS)` still fires from `onclose`, but `provider.disconnect()` flips `shouldConnect = false`, so that timer's `setupWS` call no-ops. The manual `setTimeout` is what re-arms the connection.
- No changes to da-y-wrapper or upstream y-websocket — the fix sits at the consuming-call site so it ships with da-live's normal release cadence.

## Test plan

- [x] `npm run lint` clean on the touched files
- [x] Focused unit tests pass: `npx wtr "./test/unit/blocks/edit/prose/index.test.js"` — 35/35 green, including the new `prose/index createConnection rapid-reconnect guard (COR-44)` suite (7 new scenarios) plus an updated existing test that now reflects the post-guard `shouldConnect = false` parking state.
- [ ] After merge, query Coralogix and confirm the dominant da-collab URLs from the COR-1 daily review drop out of the >95% exception-ratio bucket and that the populated `"Network connection lost."` exception count returns to baseline (<10k/24h) within 48 h.

## Refs

- Issue: COR-44 (rapid-reconnect guard)
- Parent: COR-43 (investigation that surfaced the y-websocket reset behavior)
- Prior PR: #943 (auth-close 4401/4403 guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
