### PR TITLE
fix: update toolbar position + open on focus

### DIFF
--- a/blocks/canvas/editor-utils/selection-toolbar.js
+++ b/blocks/canvas/editor-utils/selection-toolbar.js
@@ -63,19 +63,8 @@ export function createSelectionToolbarPlugin() {
       },
     },
     view() {
-      let scrollEl;
-      const tb = getSelectionToolbar();
-      const onScroll = () => {
-        if (tb.view && getSelectionOriginFromIframe(tb.view.state)) return;
-        syncToolbar(tb.view);
-      };
-
       return {
         update(view) {
-          if (!scrollEl) {
-            scrollEl = view.dom.closest('.ew-editor-doc');
-            scrollEl?.addEventListener('scroll', onScroll, { passive: true });
-          }
           const header = document.querySelector('ew-canvas-header');
           const ev = header?.editorView;
           if (ev !== 'content' && ev !== 'split') return;
@@ -83,7 +72,6 @@ export function createSelectionToolbarPlugin() {
           syncToolbar(view);
         },
         destroy() {
-          scrollEl?.removeEventListener('scroll', onScroll);
           hideSelectionToolbar();
         },
       };

--- a/blocks/canvas/editor-utils/selection-toolbar.js
+++ b/blocks/canvas/editor-utils/selection-toolbar.js
@@ -64,11 +64,16 @@ export function createSelectionToolbarPlugin() {
     },
     view() {
       let scrollEl;
-      let blurTarget;
+      let editorDom;
       const tb = getSelectionToolbar();
       const onScroll = () => {
         if (tb.view && getSelectionOriginFromIframe(tb.view.state)) return;
         syncToolbar(tb.view);
+      };
+      const onPointerDown = (e) => {
+        if (!tb.open) return;
+        const path = e.composedPath();
+        if (!path.includes(tb) && !path.includes(editorDom)) hideSelectionToolbar();
       };
 
       return {
@@ -76,8 +81,8 @@ export function createSelectionToolbarPlugin() {
           if (!scrollEl) {
             scrollEl = view.dom.closest('.ew-editor-doc');
             scrollEl?.addEventListener('scroll', onScroll, { passive: true });
-            blurTarget = view.dom;
-            blurTarget.addEventListener('focusout', hideSelectionToolbar);
+            editorDom = view.dom;
+            document.addEventListener('pointerdown', onPointerDown);
           }
           const header = document.querySelector('ew-canvas-header');
           const ev = header?.editorView;
@@ -87,7 +92,7 @@ export function createSelectionToolbarPlugin() {
         },
         destroy() {
           scrollEl?.removeEventListener('scroll', onScroll);
-          blurTarget?.removeEventListener('focusout', hideSelectionToolbar);
+          document.removeEventListener('pointerdown', onPointerDown);
           hideSelectionToolbar();
         },
       };

--- a/blocks/canvas/editor-utils/selection-toolbar.js
+++ b/blocks/canvas/editor-utils/selection-toolbar.js
@@ -15,8 +15,6 @@ function getSelectionOriginFromIframe(state) {
   return selectionToolbarOriginKey.getState(state)?.fromIframe ?? false;
 }
 
-export const TOOLBAR_PADDING_GAP = 64;
-
 let toolbar;
 let componentLoaded;
 
@@ -40,14 +38,14 @@ function isNonTextSelection({ selection }) {
 function syncToolbar(view) {
   if (!view) return;
   const tb = getSelectionToolbar();
-  if (tb.linkDialogOpen) return;
-  if (view.state.selection.empty || isNonTextSelection(view.state)) {
+  if (tb.linkDialogOpen || tb.isInteracting) return;
+  if (isNonTextSelection(view.state)) {
     hideSelectionToolbar();
     return;
   }
-  const start = view.coordsAtPos(view.state.selection.from);
+  if (!view.hasFocus()) return;
   tb.view = view;
-  tb.show({ x: start.left, y: start.top - TOOLBAR_PADDING_GAP });
+  tb.show();
 }
 
 export function createSelectionToolbarPlugin() {
@@ -66,6 +64,7 @@ export function createSelectionToolbarPlugin() {
     },
     view() {
       let scrollEl;
+      let blurTarget;
       const tb = getSelectionToolbar();
       const onScroll = () => {
         if (tb.view && getSelectionOriginFromIframe(tb.view.state)) return;
@@ -77,6 +76,8 @@ export function createSelectionToolbarPlugin() {
           if (!scrollEl) {
             scrollEl = view.dom.closest('.ew-editor-doc');
             scrollEl?.addEventListener('scroll', onScroll, { passive: true });
+            blurTarget = view.dom;
+            blurTarget.addEventListener('focusout', hideSelectionToolbar);
           }
           const header = document.querySelector('ew-canvas-header');
           const ev = header?.editorView;
@@ -86,6 +87,7 @@ export function createSelectionToolbarPlugin() {
         },
         destroy() {
           scrollEl?.removeEventListener('scroll', onScroll);
+          blurTarget?.removeEventListener('focusout', hideSelectionToolbar);
           hideSelectionToolbar();
         },
       };

--- a/blocks/canvas/editor-utils/selection-toolbar.js
+++ b/blocks/canvas/editor-utils/selection-toolbar.js
@@ -64,16 +64,10 @@ export function createSelectionToolbarPlugin() {
     },
     view() {
       let scrollEl;
-      let editorDom;
       const tb = getSelectionToolbar();
       const onScroll = () => {
         if (tb.view && getSelectionOriginFromIframe(tb.view.state)) return;
         syncToolbar(tb.view);
-      };
-      const onPointerDown = (e) => {
-        if (!tb.open) return;
-        const path = e.composedPath();
-        if (!path.includes(tb) && !path.includes(editorDom)) hideSelectionToolbar();
       };
 
       return {
@@ -81,8 +75,6 @@ export function createSelectionToolbarPlugin() {
           if (!scrollEl) {
             scrollEl = view.dom.closest('.ew-editor-doc');
             scrollEl?.addEventListener('scroll', onScroll, { passive: true });
-            editorDom = view.dom;
-            document.addEventListener('pointerdown', onPointerDown);
           }
           const header = document.querySelector('ew-canvas-header');
           const ev = header?.editorView;
@@ -92,7 +84,6 @@ export function createSelectionToolbarPlugin() {
         },
         destroy() {
           scrollEl?.removeEventListener('scroll', onScroll);
-          document.removeEventListener('pointerdown', onPointerDown);
           hideSelectionToolbar();
         },
       };

--- a/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.js
+++ b/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.js
@@ -1,5 +1,4 @@
 import { updateDocument, updateState, getEditor } from '../editor-utils/editor-utils.js';
-import { hideSelectionToolbar } from '../editor-utils/selection-toolbar.js';
 import { handleImageReplace } from './utils/image.js';
 import {
   handleCursorMove,
@@ -10,7 +9,6 @@ import {
 export function createControllerOnMessage(ctx) {
   return function onMessage(e) {
     if (e.data.type === 'cursor-move') {
-      hideSelectionToolbar();
       handleCursorMove(e.data, ctx);
     } else if (e.data.type === 'reload') {
       updateDocument(ctx);

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -1,8 +1,6 @@
 import { TextSelection, yUndo, yRedo } from 'da-y-wrapper';
 import {
   getSelectionToolbar,
-  hideSelectionToolbar,
-  TOOLBAR_PADDING_GAP,
   NX_QUICK_EDIT_IFRAME_SELECTION_META,
   NX_QUICK_EDIT_CLEAR_IFRAME_SELECTION_ORIGIN_META,
 } from '../../editor-utils/selection-toolbar.js';
@@ -126,25 +124,19 @@ export function handleSelectionChange({ anchor, head }, ctx, { fromQuickEditIfra
   }
 }
 
-function positionSelectionToolbarFromIframe(data, ctx) {
+function positionSelectionToolbarFromIframe(ctx) {
   const { view } = ctx;
-  const { anchorX, anchorY } = data;
-  const { iframe } = ctx;
-  if (!iframe) return;
-
-  const iframeRect = iframe.getBoundingClientRect();
-  const x = iframeRect.left + anchorX;
-  const y = iframeRect.top + anchorY - TOOLBAR_PADDING_GAP;
   const tb = getSelectionToolbar();
   tb.view = view;
-  tb.show({ x, y });
+  tb.show();
 }
 
 /** PostMessage `selection-change` from wysiwyg iframe: sync PM selection and toolbar. */
 export function handleIframeSelectionChange(data, ctx) {
   const { anchor, head } = data;
   if (anchor === head) {
-    hideSelectionToolbar();
+    const tb = getSelectionToolbar();
+    if (tb.isInteracting) return;
     const { view } = ctx;
     if (view) {
       const tr = view.state.tr
@@ -157,5 +149,5 @@ export function handleIframeSelectionChange(data, ctx) {
     return;
   }
   if (!handleSelectionChange(data, ctx, { fromQuickEditIframe: true })) return;
-  positionSelectionToolbarFromIframe(data, ctx);
+  positionSelectionToolbarFromIframe(ctx);
 }

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -14,6 +14,8 @@ export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
   if (cursorOffset == null || textCursorOffset == null) {
     delete view.hasFocus;
     wsProvider.awareness.setLocalStateField('cursor', null);
+    const tb = getSelectionToolbar();
+    if (!tb.isInteracting && !tb.linkDialogOpen) tb.hide?.();
     return;
   }
 

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -131,7 +131,7 @@ export function handleSelectionChange({ anchor, head }, ctx, { fromQuickEditIfra
   }
 }
 
-function positionSelectionToolbarFromIframe(ctx) {
+function showToolbarInIFrame(ctx) {
   const { view } = ctx;
   const tb = getSelectionToolbar();
   tb.view = view;
@@ -155,6 +155,8 @@ export function handleIframeSelectionChange(data, ctx) {
     }
     return;
   }
+
   if (!handleSelectionChange(data, ctx, { fromQuickEditIframe: true })) return;
-  positionSelectionToolbarFromIframe(ctx);
+
+  showToolbarInIFrame(ctx);
 }

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -1,6 +1,7 @@
 import { TextSelection, yUndo, yRedo } from 'da-y-wrapper';
 import {
   getSelectionToolbar,
+  hideSelectionToolbar,
   NX_QUICK_EDIT_IFRAME_SELECTION_META,
   NX_QUICK_EDIT_CLEAR_IFRAME_SELECTION_ORIGIN_META,
 } from '../../editor-utils/selection-toolbar.js';
@@ -14,6 +15,7 @@ export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
   if (cursorOffset == null || textCursorOffset == null) {
     delete view.hasFocus;
     wsProvider.awareness.setLocalStateField('cursor', null);
+    hideSelectionToolbar();
     return;
   }
 
@@ -58,6 +60,11 @@ export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
     ctx.suppressRerender = true;
     view.dispatch(tr.scrollIntoView());
     ctx.suppressRerender = false;
+    const tb = getSelectionToolbar();
+    if (!tb.linkDialogOpen && !tb.isInteracting) {
+      tb.view = view;
+      tb.show();
+    }
     const blockIndex = getActiveBlockIndex(view);
     if (blockIndex !== ctx.lastBlockIndex) {
       ctx.lastBlockIndex = blockIndex;

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -1,7 +1,6 @@
 import { TextSelection, yUndo, yRedo } from 'da-y-wrapper';
 import {
   getSelectionToolbar,
-  hideSelectionToolbar,
   NX_QUICK_EDIT_IFRAME_SELECTION_META,
   NX_QUICK_EDIT_CLEAR_IFRAME_SELECTION_ORIGIN_META,
 } from '../../editor-utils/selection-toolbar.js';
@@ -15,7 +14,6 @@ export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
   if (cursorOffset == null || textCursorOffset == null) {
     delete view.hasFocus;
     wsProvider.awareness.setLocalStateField('cursor', null);
-    hideSelectionToolbar();
     return;
   }
 

--- a/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.css
+++ b/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.css
@@ -2,6 +2,25 @@
   display: contents;
 }
 
+.toolbar-wrap {
+  display: none;
+  position: fixed;
+  bottom: 40px;
+  left: var(--toolbar-anchor-x, 50vw);
+  transform: translateX(-50%);
+  z-index: 100;
+  padding: 6px 8px;
+  background: var(--s2-gray-25);
+  border: 1px solid var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-500);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 16%);
+}
+
+:host(.open) .toolbar-wrap {
+  display: flex;
+  align-items: center;
+}
+
 .toolbar-actions {
   display: flex;
   flex-wrap: wrap;

--- a/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
+++ b/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
@@ -47,21 +47,27 @@ class EwSelectionToolbar extends LitElement {
     this.shadowRoot.adoptedStyleSheets = [styles];
   }
 
-  get _popover() { return this.shadowRoot?.querySelector('nx-popover'); }
-
   get _picker() { return this.shadowRoot?.querySelector('nx-picker'); }
 
-  show({ x, y }) {
-    this._popover?.show({ x, y, placement: 'above' });
-    this.requestUpdate();
+  show() {
+    const main = document.querySelector('main');
+    if (main) {
+      const { left, width } = main.getBoundingClientRect();
+      this.style.setProperty('--toolbar-anchor-x', `${left + width / 2}px`);
+    }
+    this.classList.add('open');
   }
 
   hide() {
-    this._popover?.close();
+    this.classList.remove('open');
   }
 
   get open() {
-    return this._popover?.open ?? false;
+    return this.classList.contains('open');
+  }
+
+  get isInteracting() {
+    return this._picker?.open ?? false;
   }
 
   _icon(name) {
@@ -269,14 +275,14 @@ class EwSelectionToolbar extends LitElement {
   render() {
     const disabled = !this.view;
     return html`
-      <nx-popover placement="above">
+      <div class="toolbar-wrap"
+        @mousedown=${(e) => e.preventDefault()}>
         <div class="toolbar-actions" ?data-disabled=${disabled}
-          @mousedown=${(e) => { e.preventDefault(); e.stopPropagation(); }}
           @click=${(e) => this._onToolbarClick(e)}>
           <span class="toolbar-block-type-wrap">
             <nx-picker
               class="toolbar-block-type"
-              placement="below"
+              placement="above"
               ignoreFocus
               .items=${BLOCK_TYPE_PICKER_ITEMS}
               value="paragraph"
@@ -290,7 +296,7 @@ class EwSelectionToolbar extends LitElement {
           <span class="toolbar-sep" aria-hidden="true"></span>
           ${this._renderLinkButtons()}
         </div>
-      </nx-popover>
+      </div>
       ${this._renderLinkDialog()}
     `;
   }

--- a/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
+++ b/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
@@ -70,6 +70,7 @@ class EwSelectionToolbar extends LitElement {
       this.style.setProperty('--toolbar-anchor-x', `${left + width / 2}px`);
     }
     this.classList.add('open');
+    this.requestUpdate();
   }
 
   hide() {

--- a/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
+++ b/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
@@ -45,6 +45,20 @@ class EwSelectionToolbar extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [styles];
+    this._onOutsidePointerDown = (e) => {
+      if (!this.open) return;
+      const path = e.composedPath();
+      if (path.includes(this)) return;
+      const editorDom = this.view?.dom;
+      if (editorDom && path.includes(editorDom)) return;
+      this.hide();
+    };
+    document.addEventListener('pointerdown', this._onOutsidePointerDown);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('pointerdown', this._onOutsidePointerDown);
   }
 
   get _picker() { return this.shadowRoot?.querySelector('nx-picker'); }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Display toolbar on focus
- Position toolbar always at bottom of page instead of anchored to the selection

Preview: https://ew-tlbr--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/index

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
