### PR TITLE
feat: fullsize dialog — fill iframe and show extension icon in header

### DIFF
--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -230,6 +230,7 @@ export async function fetchExtensions(org, site) {
       sources: calculateSources(org, site, row.path),
       experience: row.experience || 'inline',
       format: row.format || '',
+      icon: row.icon || '',
       ootb: OOTB_PLUGINS.has(name),
     });
     return acc;
@@ -416,6 +417,7 @@ function extensionToPanelView(ext, section) {
     firstParty: ext.ootb,
     experience: ext.experience,
     sources: ext.sources,
+    icon: ext.icon,
     load: async () => {
       await import('./ew-panel-extensions.js');
       const el = document.createElement('ew-panel-extension');

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -102,9 +102,22 @@
 }
 
 .tool-panel-fullsize-dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0;
   font-size: 14px;
   font-weight: 600;
+
+  p {
+    margin: 0;
+  }
+}
+
+.tool-panel-dialog-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
 }
 
 .tool-panel-fullsize-dialog-close {
@@ -131,4 +144,10 @@
   position: relative;
   min-height: 0;
   overflow: hidden;
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+  }
 }

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -173,6 +173,7 @@ class EwToolPanel extends LitElement {
   render() {
     const items = this._pickerItemsFromViews();
     const dialogTitle = this._fullsizeDialogView?.label ?? 'Extension';
+    const dialogIcon = this._fullsizeDialogView?.icon;
 
     return html`
       <div class="tool-panel-header">
@@ -194,7 +195,13 @@ class EwToolPanel extends LitElement {
           @close=${this._onFullsizeDialogClose}
         >
           <div class="tool-panel-fullsize-dialog-header">
-            <p class="tool-panel-fullsize-dialog-title">${dialogTitle}</p>
+            <div class="tool-panel-fullsize-dialog-title">
+              ${dialogIcon ? (dialogIcon.startsWith('#')
+                ? html`<svg class="tool-panel-dialog-icon" aria-hidden="true"><use href="${dialogIcon}"></use></svg>`
+                : html`<img class="tool-panel-dialog-icon" src="${dialogIcon}" alt="">`)
+                : nothing}
+              <p>${dialogTitle}</p>
+            </div>
             <button type="button" class="tool-panel-fullsize-dialog-close" aria-label="Close"
               @click=${(e) => e.target.closest('dialog').close()}>✕</button>
           </div>


### PR DESCRIPTION
## Description

* fix styles for full size extensions
* add missing icons if configured