### PR TITLE
fix: fullsize dialog — fill iframe and show extension icon in header

### DIFF
--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -230,6 +230,7 @@ export async function fetchExtensions(org, site) {
       sources: calculateSources(org, site, row.path),
       experience: row.experience || 'inline',
       format: row.format || '',
+      icon: row.icon || '',
       ootb: OOTB_PLUGINS.has(name),
     });
     return acc;
@@ -416,6 +417,7 @@ function extensionToPanelView(ext, section) {
     firstParty: ext.ootb,
     experience: ext.experience,
     sources: ext.sources,
+    icon: ext.icon,
     load: async () => {
       await import('./ew-panel-extensions.js');
       const el = document.createElement('ew-panel-extension');

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -98,6 +98,7 @@
   justify-content: space-between;
   padding: 12px 16px;
   border-bottom: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-600));
+  color: light-dark(var(--s2-gray-800), var(--s2-gray-200));
   flex-shrink: 0;
 }
 

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -79,7 +79,6 @@
   height: 80vh;
   margin: auto;
   padding: 0;
-  color-scheme: light dark;
   border: 1px solid light-dark(var(--s2-gray-300), var(--s2-gray-600));
   border-radius: 8px;
   background: light-dark(var(--s2-gray-50), var(--s2-gray-800));

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -79,6 +79,7 @@
   height: 80vh;
   margin: auto;
   padding: 0;
+  color-scheme: light dark;
   border: 1px solid light-dark(var(--s2-gray-300), var(--s2-gray-600));
   border-radius: 8px;
   background: light-dark(var(--s2-gray-50), var(--s2-gray-800));
@@ -127,9 +128,11 @@
   width: 28px;
   height: 28px;
   padding: 0;
+  appearance: none;
   border: none;
   border-radius: 4px;
   background: none;
+  box-shadow: none;
   cursor: pointer;
   font-size: 16px;
   color: inherit;

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -102,9 +102,22 @@
 }
 
 .tool-panel-fullsize-dialog-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0;
   font-size: 14px;
   font-weight: 600;
+
+  p {
+    margin: 0;
+  }
+}
+
+.tool-panel-dialog-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
 }
 
 .tool-panel-fullsize-dialog-close {
@@ -131,4 +144,10 @@
   position: relative;
   min-height: 0;
   overflow: hidden;
+
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+  }
 }

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -104,7 +104,7 @@
 .tool-panel-fullsize-dialog-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-100);
   margin: 0;
   font-size: 14px;
   font-weight: 600;

--- a/blocks/canvas/ew-tool-panel/tool-panel.css
+++ b/blocks/canvas/ew-tool-panel/tool-panel.css
@@ -104,7 +104,7 @@
 .tool-panel-fullsize-dialog-title {
   display: flex;
   align-items: center;
-  gap: var(--spacing-100);
+  gap: var(--s2-spacing-100);
   margin: 0;
   font-size: 14px;
   font-weight: 600;

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -173,6 +173,7 @@ class EwToolPanel extends LitElement {
   render() {
     const items = this._pickerItemsFromViews();
     const dialogTitle = this._fullsizeDialogView?.label ?? 'Extension';
+    const dialogIcon = this._fullsizeDialogView?.icon;
 
     return html`
       <div class="tool-panel-header">
@@ -194,7 +195,13 @@ class EwToolPanel extends LitElement {
           @close=${this._onFullsizeDialogClose}
         >
           <div class="tool-panel-fullsize-dialog-header">
-            <p class="tool-panel-fullsize-dialog-title">${dialogTitle}</p>
+            <div class="tool-panel-fullsize-dialog-title">
+              ${dialogIcon ? (dialogIcon.startsWith('#')
+                ? html`<svg class="tool-panel-dialog-icon" aria-hidden="true"><use href="${dialogIcon}"></use></svg>`
+                : html`<img class="tool-panel-dialog-icon" src="${dialogIcon}" alt="">`)
+                : nothing}
+              <p>${dialogTitle}</p>
+            </div>
             <button type="button" class="tool-panel-fullsize-dialog-close" aria-label="Close"
               @click=${(e) => e.target.closest('dialog').close()}>✕</button>
           </div>

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -162,6 +162,12 @@ class EwToolPanel extends LitElement {
     if (actions) zone.append(actions);
   }
 
+  _renderDialogIcon(icon) {
+    if (!icon) return nothing;
+    if (icon.startsWith('#')) return html`<svg class="tool-panel-dialog-icon" aria-hidden="true"><use href="${icon}"></use></svg>`;
+    return html`<img class="tool-panel-dialog-icon" src="${icon}" alt="">`;
+  }
+
   _close() {
     this.dispatchEvent(new CustomEvent('nx-panel-close', { bubbles: true, composed: true }));
   }
@@ -196,10 +202,7 @@ class EwToolPanel extends LitElement {
         >
           <div class="tool-panel-fullsize-dialog-header">
             <div class="tool-panel-fullsize-dialog-title">
-              ${dialogIcon ? (dialogIcon.startsWith('#')
-                ? html`<svg class="tool-panel-dialog-icon" aria-hidden="true"><use href="${dialogIcon}"></use></svg>`
-                : html`<img class="tool-panel-dialog-icon" src="${dialogIcon}" alt="">`)
-                : nothing}
+              ${this._renderDialogIcon(dialogIcon)}
               <p>${dialogTitle}</p>
             </div>
             <button type="button" class="tool-panel-fullsize-dialog-close" aria-label="Close"


### PR DESCRIPTION
## Description

fixes: https://jira.corp.adobe.com/browse/SITES-45377

* fix styles for full size extensions
* add missing icons if configured

before:
<img width="1220" height="789" alt="Screenshot 2026-05-26 at 14 08 18" src="https://github.com/user-attachments/assets/e7e34675-ca60-4f7a-bd25-b1047a5779dc" />

after:
<img width="1249" height="803" alt="Screenshot 2026-05-26 at 14 06 33" src="https://github.com/user-attachments/assets/ac9d321d-b5cc-4a53-9bc3-e4d87cac7df3" />

Test:
* https://extfull--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/index
