### PR TITLE
fix: handle section metadata for live preview, quick-edit and experience workspace

### DIFF
--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -177,7 +177,8 @@ export function getInstrumentedHTML(view) {
   clonedTables.forEach((table, index) => {
     const firstRow = table.querySelector('tr');
     const firstCellText = firstRow?.cells?.[0]?.textContent?.trim().toLowerCase();
-    if (firstCellText === 'metadata') return;
+    const isPageOrSectionMetadata = firstCellText === 'metadata' || firstCellText === 'section metadata' || firstCellText === 'section-metadata';
+    if (isPageOrSectionMetadata) return;
     const div = table.parentElement;
     const blockMarker = document.createElement('div');
     blockMarker.className = 'block-marker';

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -203,7 +203,9 @@ function applySectionMetadata(editor) {
         .replace(/^-+|-+$/g, '');
       if (!key) return;
       if (key === 'style') {
-        toBlockCSSClassNames(cols[1].textContent.trim())
+        cols[1].textContent.trim().split(',')
+          .map((s) => s.trim().toLowerCase().replace(/[^0-9a-z]+/g, '-').replace(/^-+|-+$/g, ''))
+          .filter(Boolean)
           .forEach((cls) => section.classList.add(cls));
       } else {
         const camelKey = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -192,6 +192,33 @@ function removeMetadata(editor) {
   editor.querySelector('.metadata')?.remove();
 }
 
+function applySectionMetadata(editor) {
+  editor.querySelectorAll('.section-metadata').forEach((block) => {
+    const section = block.parentElement;
+    block.querySelectorAll(':scope > div').forEach((row) => {
+      const cols = row.querySelectorAll(':scope > div');
+      if (cols.length < 2) return;
+      const key = cols[0].textContent.trim().toLowerCase()
+        .replace(/[^0-9a-z]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      if (!key) return;
+      if (key === 'style') {
+        toBlockCSSClassNames(cols[1].textContent.trim())
+          .forEach((cls) => section.classList.add(cls));
+      } else {
+        const camelKey = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+        const linkEl = cols[1].querySelector('a');
+        const imgEl = cols[1].querySelector('img');
+        let value = cols[1].textContent.trim();
+        if (linkEl) value = linkEl.href;
+        else if (imgEl) value = imgEl.src;
+        section.dataset[camelKey] = value;
+      }
+    });
+    block.remove();
+  });
+}
+
 const iconRegex = /(?<!(?:https?|urn)[^\s<>]*):(#?[a-z_-]+[a-z\d]*):/gi; // matches icon pattern but not in URLs
 function parseIcons(editor) {
   if (!iconRegex.test(editor.innerHTML)) return;
@@ -251,6 +278,7 @@ export default function prose2aem(editor, livePreview, isFragment = false) {
 
   if (!isFragment) {
     makeSections(editor);
+    if (livePreview) applySectionMetadata(editor);
   }
 
   if (isFragment) {

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -94,20 +94,21 @@ describe('prose2aem section-metadata handling', () => {
     expect(section.classList.contains('highlight')).to.be.true;
   });
 
-  it('applies multiple style classes from the name (variant) notation', () => {
+  it('applies multiple style classes from comma-separated values', () => {
     const editor = makeEditor(`
       <p>Content</p>
       <div class="tableWrapper">
         <table>
           <tr><td>Section Metadata</td></tr>
-          <tr><td>Style</td><td>highlight (contained)</td></tr>
+          <tr><td>Style</td><td>divider, light</td></tr>
         </table>
       </div>
     `);
     const main = parseMain(prose2aem(editor, true, false));
     const section = main.querySelector(':scope > div');
-    expect(section.classList.contains('highlight')).to.be.true;
-    expect(section.classList.contains('contained')).to.be.true;
+    expect(section.classList.contains('divider')).to.be.true;
+    expect(section.classList.contains('light')).to.be.true;
+    expect(section.classList.contains('divider-light')).to.be.false;
   });
 
   it('removes the section-metadata block from the output', () => {

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -67,6 +67,125 @@ describe('aem2prose', () => {
   });
 });
 
+describe('prose2aem section-metadata handling', () => {
+  function makeEditor(innerHtml) {
+    const editor = document.createElement('div');
+    editor.innerHTML = innerHtml;
+    return editor;
+  }
+
+  function parseMain(html) {
+    const parsed = new DOMParser().parseFromString(html, 'text/html');
+    return parsed.querySelector('main');
+  }
+
+  it('applies style value as CSS class on the parent section', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Style</td><td>highlight</td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, true, false));
+    const section = main.querySelector(':scope > div');
+    expect(section.classList.contains('highlight')).to.be.true;
+  });
+
+  it('applies multiple style classes from the name (variant) notation', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Style</td><td>highlight (contained)</td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, true, false));
+    const section = main.querySelector(':scope > div');
+    expect(section.classList.contains('highlight')).to.be.true;
+    expect(section.classList.contains('contained')).to.be.true;
+  });
+
+  it('removes the section-metadata block from the output', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Style</td><td>highlight</td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, true, false));
+    expect(main.querySelector('.section-metadata')).to.not.exist;
+  });
+
+  it('sets non-style keys as data attributes on the parent section', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Background</td><td>dark</td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, true, false));
+    const section = main.querySelector(':scope > div');
+    expect(section.dataset.background).to.equal('dark');
+  });
+
+  it('uses link href as the data attribute value when the cell contains a link', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Source</td><td><a href="https://example.com/page">Label</a></td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, true, false));
+    const section = main.querySelector(':scope > div');
+    expect(section.dataset.source).to.equal('https://example.com/page');
+  });
+
+  it('uses image src as the data attribute value when the cell contains an image', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Image</td><td><img src="https://example.com/bg.jpg"></td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, true, false));
+    const section = main.querySelector(':scope > div');
+    expect(section.dataset.image).to.equal('https://example.com/bg.jpg');
+  });
+
+  it('does not apply section metadata when livePreview is false', () => {
+    const editor = makeEditor(`
+      <p>Content</p>
+      <div class="tableWrapper">
+        <table>
+          <tr><td>Section Metadata</td></tr>
+          <tr><td>Style</td><td>highlight</td></tr>
+        </table>
+      </div>
+    `);
+    const main = parseMain(prose2aem(editor, false, false));
+    const section = main.querySelector(':scope > div');
+    expect(main.querySelector('.section-metadata')).to.exist;
+    expect(section.classList.contains('highlight')).to.be.false;
+  });
+});
+
 describe('prose2aem with isFragment parameter', () => {
   let originalDoc;
 


### PR DESCRIPTION
## Description

Section metadata is not being applied in DA's built-in live preview, Quick Edit and the Experience Workspace layout mode for sites that don't have [client-side section-metadata processing](https://github.com/adobe/aem-boilerplate/commit/26af708f813fe1aef8dbd4372ee80c8e85857022), regardless of whether server side processing via helix-html-pipeline is auto-enabled (site created after May 1st, 2026) or via feature flag `features.rendering.version: 2`. All three generate their preview HTML via `prose2aem`, so we need to handle it there.

## How Has This Been Tested?

Tested on https://sm-fix--da-live--usman-khalid.aem.page/ and directly on da.live with browser overrides for all three cases (quick-edit, EW, DA live preview)

## Screenshots (if appropriate):

Before (EW):
<img width="1313" height="720" alt="image" src="https://github.com/user-attachments/assets/665aad6f-8625-40ba-bd03-e8d8ca737143" />

After:
<img width="1728" height="755" alt="image" src="https://github.com/user-attachments/assets/127db365-310d-491b-9a81-e53334f22c94" />

Also removes `section-metadata` from the page outline right rail in experience workspace as it's not a real block.

<img width="413" height="900" alt="image" src="https://github.com/user-attachments/assets/7489ca9f-60e9-4d98-9a70-724badad96d5" />



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
