### PR TITLE
fix: refresh files on agent update

### DIFF
--- a/blocks/canvas/ew-file-explorer/ew-file-explorer.js
+++ b/blocks/canvas/ew-file-explorer/ew-file-explorer.js
@@ -48,11 +48,24 @@ class EwFileExplorer extends LitElement {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
     this._unsubHash = hashChange.subscribe((state) => this._onHashChange(state));
+    this._onAgentChange = async ({ detail }) => {
+      if (detail?.scope !== 'file') return;
+      const toRefresh = (detail.paths ?? []).filter((p) => this._cache?.[p]);
+      if (!toRefresh.length) return;
+      const updates = await Promise.all(toRefresh.map(async (p) => {
+        const result = await listFolder(p);
+        return Array.isArray(result) ? [p, result] : null;
+      }));
+      const patched = Object.fromEntries(updates.filter(Boolean));
+      if (Object.keys(patched).length) this._cache = { ...this._cache, ...patched };
+    };
+    document.addEventListener('nx-agent-change', this._onAgentChange);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this._unsubHash?.();
+    document.removeEventListener('nx-agent-change', this._onAgentChange);
   }
 
   updated() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes at the file level will trigger refresh of the folder in the right panel -> Files 

Fixes: [SITES-45681: Tool ↔ UI refresh eventing](https://jira.corp.adobe.com/browse/SITES-45681)

Preview at https://ew-event--da-live--adobe.aem.live/canvas?nx=ew-event&nxver=2#/exp-workspace/frescopa/index

Related to https://github.com/adobe/da-nx/pull/477

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
