### PR TITLE
fix: block library missing title for grouped blocks

### DIFF
--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -135,9 +135,11 @@ function getLibraryMetadata(el) {
 
 function transformBlock(block) {
   const prevSib = block.previousElementSibling;
-  const item = isHeading(prevSib) && prevSib.textContent
-    ? { name: prevSib.textContent }
-    : getBlockName(block.className || '');
+  const item = block.dataset.groupheading
+    ? { name: block.dataset.groupheading }
+    : isHeading(prevSib) && prevSib.textContent
+      ? { name: prevSib.textContent }
+      : getBlockName(block.className || '');
   item.dom = block.dataset?.isgroup ? processGroupBlock(block) : getBlockTableHtml(block);
 
   const metaEl = block.nextElementSibling?.classList.contains('library-metadata')

--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -135,11 +135,14 @@ function getLibraryMetadata(el) {
 
 function transformBlock(block) {
   const prevSib = block.previousElementSibling;
-  const item = block.dataset.groupheading
-    ? { name: block.dataset.groupheading }
-    : isHeading(prevSib) && prevSib.textContent
-      ? { name: prevSib.textContent }
-      : getBlockName(block.className || '');
+  let item;
+  if (block.dataset.groupheading) {
+    item = { name: block.dataset.groupheading };
+  } else if (isHeading(prevSib) && prevSib.textContent) {
+    item = { name: prevSib.textContent };
+  } else {
+    item = getBlockName(block.className || '');
+  }
   item.dom = block.dataset?.isgroup ? processGroupBlock(block) : getBlockTableHtml(block);
 
   const metaEl = block.nextElementSibling?.classList.contains('library-metadata')

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -161,7 +161,7 @@ class EwToolPanel extends LitElement {
     const actions = this._loaded[this.activeId]?.getHeaderActions?.();
     if (actions) zone.append(actions);
   }
-
+^
   _renderDialogIcon(icon) {
     if (!icon) return nothing;
     if (icon.startsWith('#')) return html`<svg class="tool-panel-dialog-icon" aria-hidden="true"><use href="${icon}"></use></svg>`;

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -161,7 +161,7 @@ class EwToolPanel extends LitElement {
     const actions = this._loaded[this.activeId]?.getHeaderActions?.();
     if (actions) zone.append(actions);
   }
-^
+
   _renderDialogIcon(icon) {
     if (!icon) return nothing;
     if (icon.startsWith('#')) return html`<svg class="tool-panel-dialog-icon" aria-hidden="true"><use href="${icon}"></use></svg>`;

--- a/test/fixtures/nx/utils/daConfig.js
+++ b/test/fixtures/nx/utils/daConfig.js
@@ -1,0 +1,3 @@
+// Mock NX /utils/daConfig.js utils for tests
+export const fetchDaConfigs = async () => ({});
+export const getFirstSheet = () => null;

--- a/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
@@ -1,0 +1,181 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+let getBlockVariants;
+
+before(async () => {
+  const mod = await import('../../../../../blocks/canvas/ew-panel-extensions/helpers.js');
+  getBlockVariants = mod.getBlockVariants;
+});
+
+describe('EW panel helpers transformBlock', () => {
+  let savedFetch;
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  function mockHtml(html) {
+    window.fetch = () => Promise.resolve(new Response(html, { status: 200 }));
+  }
+
+  it('Uses data-groupheading as the name for grouped blocks', async () => {
+    mockHtml(`
+      <body><div>
+        <h2>My Group</h2>
+        <div class="library-container-start"></div>
+        <div class="hero"><div><div>content</div></div></div>
+        <div class="library-container-end"></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants).to.have.lengthOf(1);
+    expect(variants[0].name).to.equal('My Group');
+  });
+
+  it('Falls back to the preceding heading text when no groupheading', async () => {
+    mockHtml(`
+      <body><div>
+        <h2>Block Title</h2>
+        <div class="hero"><div><div>content</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants).to.have.lengthOf(1);
+    expect(variants[0].name).to.equal('Block Title');
+  });
+
+  it('Falls back to class name when there is no groupheading and no preceding heading', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero wide"><div><div>content</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants).to.have.lengthOf(1);
+    expect(variants[0].name).to.equal('hero');
+    expect(variants[0].variants).to.equal('wide');
+  });
+
+  it('Returns an empty array when the fetch fails', async () => {
+    window.fetch = () => Promise.resolve(new Response('error', { status: 500 }));
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants).to.deep.equal([]);
+  });
+
+  it('Returns a table as item.dom for a regular block', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero"><div><div>content</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].dom).to.be.instanceOf(window.HTMLTableElement);
+  });
+
+  it('Returns a div as item.dom for a grouped block', async () => {
+    mockHtml(`
+      <body><div>
+        <h2>My Group</h2>
+        <div class="library-container-start"></div>
+        <div class="hero"><div><div>content</div></div></div>
+        <div class="library-container-end"></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].dom).to.be.instanceOf(window.HTMLDivElement);
+  });
+
+  it('Sets item.tags from searchtags in nextElementSibling library-metadata', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero"><div><div>content</div></div></div>
+        <div class="library-metadata"><div><div>searchtags</div><div>hero, card</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].tags).to.equal('hero, card');
+  });
+
+  it('Sets item.description from description in nextElementSibling library-metadata', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero"><div><div>content</div></div></div>
+        <div class="library-metadata"><div><div>description</div><div>A hero block</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].description).to.equal('A hero block');
+  });
+
+  it('Sets item.tags from searchtags in embedded library-metadata', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero">
+          <div><div>content</div></div>
+          <div class="library-metadata"><div><div>searchtags</div><div>hero, banner</div></div></div>
+        </div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].tags).to.equal('hero, banner');
+  });
+
+  it('Sets both tags and description when both present in library-metadata', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero"><div><div>content</div></div></div>
+        <div class="library-metadata">
+          <div><div>searchtags</div><div>hero, card</div></div>
+          <div><div>description</div><div>A hero block</div></div>
+        </div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].tags).to.equal('hero, card');
+    expect(variants[0].description).to.equal('A hero block');
+  });
+
+  it('Does not set tags or description when no library-metadata is present', async () => {
+    mockHtml(`
+      <body><div>
+        <div class="hero"><div><div>content</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].tags).to.be.undefined;
+    expect(variants[0].description).to.be.undefined;
+  });
+
+  it('Sets tags from library-metadata appended after library-container-end in a group', async () => {
+    mockHtml(`
+      <body><div>
+        <h2>My Group</h2>
+        <div class="library-container-start"></div>
+        <div class="hero"><div><div>content</div></div></div>
+        <div class="library-container-end"></div>
+        <div class="library-metadata"><div><div>searchtags</div><div>group, hero</div></div></div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].tags).to.equal('group, hero');
+  });
+
+  it('Group dom contains both a table for the block and cloned non-div siblings', async () => {
+    mockHtml(`
+      <main><div>
+        <h2>Hero with text</h2>
+        <div class="library-container-start"><div><div></div></div></div>
+        <div class="hero"><div><div>content</div></div></div>
+        <p>Lorem ipsum</p>
+        <div class="library-container-end"><div><div></div></div></div>
+      </div></main>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    expect(variants[0].name).to.equal('Hero with text');
+    const { dom } = variants[0];
+    expect(dom).to.be.instanceOf(window.HTMLDivElement);
+    expect(dom.querySelector('table')).to.not.be.null;
+    expect(dom.querySelector('p')).to.not.be.null;
+  });
+});


### PR DESCRIPTION
Test:
* https://ew-lib--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/drafts/mhaack/lib-test

fixes: https://jira.corp.adobe.com/browse/SITES-45828

Before:
<img width="479" height="369" alt="Screenshot 2026-05-29 at 11 51 35" src="https://github.com/user-attachments/assets/f39121e2-32ec-43f6-a538-5266500bada7" />


After:
<img width="442" height="384" alt="Screenshot 2026-05-29 at 11 50 36" src="https://github.com/user-attachments/assets/e27c90e7-498a-4c7e-8bb8-04babffeb04c" />
