### PR TITLE
feat: support switch panel from extensions

### DIFF
--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -148,7 +148,7 @@ function hashState() {
   return { org: org || undefined, site: site || undefined };
 }
 
-async function openCanvasPanel(position, { preferredViewId } = {}) {
+async function openCanvasPanel(position, { panelName } = {}) {
   const config = CANVAS_PANELS[position];
   if (!config) return;
   const store = getPanelStore();
@@ -159,8 +159,8 @@ async function openCanvasPanel(position, { preferredViewId } = {}) {
     if (toolPanel) {
       await syncToolPanelViews(toolPanel, hashState());
       await toolPanel.updateComplete;
-      if (preferredViewId && toolPanel.views?.some((v) => v.id === preferredViewId)) {
-        await toolPanel.showView(preferredViewId);
+      if (panelName && toolPanel.views?.some((v) => v.id === panelName)) {
+        await toolPanel.showPanel(panelName);
       }
     }
   }
@@ -170,7 +170,7 @@ function installCanvasHeader(block) {
   const header = document.createElement('ew-canvas-header');
   header.editorView = readPersistedCanvasEditorView();
   header.addEventListener('nx-canvas-open-panel', (e) => {
-    openCanvasPanel(e.detail.position, { preferredViewId: e.detail.viewId });
+    openCanvasPanel(e.detail.position, { panelName: e.detail.panelName });
   });
   header.addEventListener('nx-canvas-editor-view', (e) => {
     const view = normalizeCanvasEditorView(e.detail?.view);

--- a/blocks/canvas/editor-utils/command-defs.js
+++ b/blocks/canvas/editor-utils/command-defs.js
@@ -297,7 +297,7 @@ export const COMMANDS = [
       const evt = new CustomEvent('nx-canvas-open-panel', {
         bubbles: true,
         composed: true,
-        detail: { position: 'after', viewId: 'blocks' },
+        detail: { position: 'after', panelName: 'blocks' },
       });
       document.querySelector('ew-canvas-header')?.dispatchEvent(evt);
     },

--- a/blocks/canvas/ew-panel-extensions/iframe-protocol.js
+++ b/blocks/canvas/ew-panel-extensions/iframe-protocol.js
@@ -93,9 +93,6 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
   }, 750);
 
   const onAgentChange = ({ detail }) => {
-    // eslint-disable-next-line no-console
-    console.log('[iframe-protocol] nx-agent-change', detail, 'iframe ok:', !!iframe.contentWindow);
-
     if (!iframe.contentWindow) return;
     iframe.contentWindow.postMessage({ action: 'agentChange', detail }, '*');
   };

--- a/blocks/canvas/ew-panel-extensions/iframe-protocol.js
+++ b/blocks/canvas/ew-panel-extensions/iframe-protocol.js
@@ -13,7 +13,7 @@ import { getNx } from '../../../scripts/utils.js';
  */
 export async function setupIframeChannel({ iframe, hashState, getView, onClose }) {
   const { org, site, path, view } = hashState;
-  if (!org || !site || !iframe.contentWindow) return { channel: null, destroy() {} };
+  if (!org || !site || !iframe.contentWindow) return { channel: null, destroy() { } };
 
   const channel = new MessageChannel();
 
@@ -39,6 +39,10 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
 
     if (action === 'closeLibrary') {
       onClose();
+    }
+
+    if (action === 'showPanel') {
+      document.dispatchEvent(new CustomEvent('nx-show-panel', { detail: { panelName: details } }));
     }
 
     if (action === 'setPrompt') {
@@ -89,6 +93,9 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
   }, 750);
 
   const onAgentChange = ({ detail }) => {
+    // eslint-disable-next-line no-console
+    console.log('[iframe-protocol] nx-agent-change', detail, 'iframe ok:', !!iframe.contentWindow);
+
     if (!iframe.contentWindow) return;
     iframe.contentWindow.postMessage({ action: 'agentChange', detail }, '*');
   };

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -23,6 +23,13 @@ class EwToolPanel extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
+    this._onShowPanel = ({ detail }) => this.showPanel(detail?.panelName);
+    document.addEventListener('nx-show-panel', this._onShowPanel);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('nx-show-panel', this._onShowPanel);
   }
 
   get _fullsizeDialogView() {
@@ -98,7 +105,7 @@ class EwToolPanel extends LitElement {
 
     if (!this.activeId || !ids.has(this.activeId)) {
       const stored = sessionStorage.getItem(ACTIVE_VIEW_KEY);
-      await this.showView(stored && ids.has(stored) ? stored : this.views[0].id);
+      await this.showPanel(stored && ids.has(stored) ? stored : this.views[0].id);
     }
   }
 
@@ -124,8 +131,8 @@ class EwToolPanel extends LitElement {
     }
   }
 
-  async showView(id) {
-    const consumer = this.views.find((c) => c.id === id);
+  async showPanel(name) {
+    const consumer = this.views.find((c) => c.id === name);
     if (!consumer) return;
     if (consumer.experience === 'window') {
       window.open(
@@ -136,13 +143,13 @@ class EwToolPanel extends LitElement {
       return;
     }
     if (consumer.experience === 'fullsize-dialog') {
-      this._fullsizeDialogViewId = id;
+      this._fullsizeDialogViewId = name;
       return;
     }
-    if (!this._loaded[id]) {
-      this._loaded[id] = await consumer.load();
+    if (!this._loaded[name]) {
+      this._loaded[name] = await consumer.load();
     }
-    this.activeId = id;
+    this.activeId = name;
   }
 
   _syncContent() {
@@ -190,7 +197,7 @@ class EwToolPanel extends LitElement {
           .items=${items}
           .value=${this.activeId}
           placement="below-start"
-          @change=${(e) => this.showView(e.detail.value)}
+          @change=${(e) => this.showPanel(e.detail.value)}
         ></nx-picker>
         <div class="tool-panel-header-actions"></div>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allow switching the active tool panel from extensions, or from the canvas/chat

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Certain actions might need the user to be directed to a specific panel - this could be from an extension, from an action within the canvas, or based on specific chat interactions. This PR introduces support to switch the active panel programmatically based on the panel name.
Extended existing code for setting panel based on picker,user session -> this merely exposes the logic to be usable on demand.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
