### PR TITLE
fix: fetch extensions config from org and site level

### DIFF
--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -219,16 +219,19 @@ function mergePlugin(list, plugin) {
 }
 
 export async function fetchExtensions(org, site) {
-  const configs = fetchDaConfigs({ org, site });
-  const siteConfig = await configs[configs.length - 1];
-  if (siteConfig?.error) return [];
+  const configs = await Promise.all(fetchDaConfigs({ org, site }));
+  const validConfigs = configs.filter((c) => !c?.error).reverse();
+  if (!validConfigs.length) return [];
 
-  const rows = siteConfig?.library?.data;
-  if (!Array.isArray(rows)) return [];
+  const rows = validConfigs.flatMap((c) => c?.library?.data || []);
+  if (!rows.length) return [];
 
+  const seen = new Set();
   const extensions = rows.reduce((acc, row) => {
     if (!row.title || !getIsPluginAllowed(row.ref)) return acc;
     const name = row.title.trim().toLowerCase().replaceAll(' ', '-');
+    if (seen.has(name)) return acc;
+    seen.add(name);
     acc.push({
       name,
       title: row.title.trim(),
@@ -242,8 +245,8 @@ export async function fetchExtensions(org, site) {
   }, []);
 
   try {
-    const siteEntries = getFirstSheet(siteConfig) || [];
-    const hasRepo = siteEntries.find((e) => e.key === 'aem.repositoryId')?.value;
+    const entries = validConfigs.flatMap((c) => getFirstSheet(c) || []);
+    const hasRepo = entries.find((e) => e.key === 'aem.repositoryId')?.value;
     if (hasRepo) {
       const { getAssetsPlugin } = await import('./aem-assets.js');
       const plugin = getAssetsPlugin({ org, site });

--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -246,7 +246,7 @@ export async function fetchExtensions(org, site) {
 
   try {
     const entries = validConfigs.flatMap((conf) => getFirstSheet(conf) || []);
-    const hasRepo = entries.find((e) => e.key === 'aem.repositoryId')?.value;
+    const hasRepo = entries.find((entry) => entry.key === 'aem.repositoryId')?.value;
     if (hasRepo) {
       const { getAssetsPlugin } = await import('./aem-assets.js');
       const plugin = getAssetsPlugin({ org, site });

--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -220,10 +220,10 @@ function mergePlugin(list, plugin) {
 
 export async function fetchExtensions(org, site) {
   const configs = await Promise.all(fetchDaConfigs({ org, site }));
-  const validConfigs = configs.filter((c) => !c?.error).reverse();
+  const validConfigs = configs.filter((conf) => !conf?.error).reverse();
   if (!validConfigs.length) return [];
 
-  const rows = validConfigs.flatMap((c) => c?.library?.data || []);
+  const rows = validConfigs.flatMap((conf) => conf?.library?.data || []);
   if (!rows.length) return [];
 
   const seen = new Set();
@@ -245,7 +245,7 @@ export async function fetchExtensions(org, site) {
   }, []);
 
   try {
-    const entries = validConfigs.flatMap((c) => getFirstSheet(c) || []);
+    const entries = validConfigs.flatMap((conf) => getFirstSheet(conf) || []);
     const hasRepo = entries.find((e) => e.key === 'aem.repositoryId')?.value;
     if (hasRepo) {
       const { getAssetsPlugin } = await import('./aem-assets.js');


### PR DESCRIPTION
Align fetchExtensions with the editor pattern: await both org and site configs via Promise.all, reverse so site takes precedence, and merge library rows and config entries from both levels with deduplication.

fixes: https://jira.corp.adobe.com/browse/SITES-45814

For testing I moved the assets config from site level to org level for our Frescopa site. With that, current main doesn't return the asset picker, but with the fix from the branch, it does.

<img width="329" height="498" alt="Screenshot 2026-06-09 at 10 59 08" src="https://github.com/user-attachments/assets/774a6508-cb97-4322-8afa-570a57ef213c" />


Test:
-  https://acfg--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/drafts/mhaack/something-not-here

