### PR TITLE
feat: read default canvas editor view from org config

### DIFF
--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -1,4 +1,5 @@
 import { getNx } from '../../scripts/utils.js';
+import { fetchDaConfigs } from '../../shared/utils.js';
 import { editorSelectChange } from './editor-utils/editor-utils.js';
 import './ew-canvas-header/ew-canvas-header.js';
 import './ew-editor-doc/ew-editor-doc.js';
@@ -38,12 +39,20 @@ function notifyCanvasEditorActive(mountRoot, view) {
   }));
 }
 
-function readPersistedCanvasEditorView() {
+async function readInitialCanvasEditorView({ org, site }) {
   try {
-    return normalizeCanvasEditorView(sessionStorage.getItem(CANVAS_EDITOR_VIEW_KEY));
-  } catch {
-    return 'layout';
-  }
+    const persisted = sessionStorage.getItem(CANVAS_EDITOR_VIEW_KEY);
+    if (persisted) return normalizeCanvasEditorView(persisted);
+  } catch { /* ignore if browser disallows session storage */ }
+
+  try {
+    const [orgConfigPromise] = fetchDaConfigs({ org, site });
+    const orgConfig = await orgConfigPromise;
+    const flag = orgConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
+    if (flag) return normalizeCanvasEditorView(flag.value);
+  } catch { /* ignore config fetch errors */ }
+
+  return 'layout';
 }
 
 function persistCanvasEditorView(view) {
@@ -166,9 +175,9 @@ async function openCanvasPanel(position, { panelName } = {}) {
   }
 }
 
-function installCanvasHeader(block) {
+async function installCanvasHeader(block, { org, site }) {
   const header = document.createElement('ew-canvas-header');
-  header.editorView = readPersistedCanvasEditorView();
+  header.editorView = await readInitialCanvasEditorView({ org, site });
   header.addEventListener('nx-canvas-open-panel', (e) => {
     openCanvasPanel(e.detail.position, { panelName: e.detail.panelName });
   });
@@ -190,7 +199,8 @@ function installCanvasHeader(block) {
 }
 
 export default async function decorate(block) {
-  const header = installCanvasHeader(block);
+  const { org, site } = hashState();
+  const header = await installCanvasHeader(block, { org, site });
 
   const mountRoot = canvasEditorMountRoot(block);
   mountRoot.classList.add('nx-canvas-editor-mount');


### PR DESCRIPTION
## Summary

- Adds support for an `ew.canvasDefaultView` flag in the org DA config to control which view (`content`, `split`, or `layout`) the canvas opens with on first visit
- Session storage (persisted user preference) always takes precedence — the config is only consulted when no persisted value exists
- Invalid or missing flag values fall back to `layout` (existing default)

## How to configure

Add a flag entry to the org config:

| key | value |
|-----|-------|
| `ew.canvasDefaultView` | `content` \| `split` \| `layout` |

## Test plan

- [ ] Open canvas with no session storage and no config flag → lands on `layout`
- [ ] Set `ew.canvasDefaultView = content` in org config, clear session storage → lands on `content`
- [ ] Set `ew.canvasDefaultView = split` in org config, clear session storage → lands on `split`
- [ ] Set an invalid flag value → falls back to `layout`
- [ ] Switch view manually → persists to session storage; config flag no longer applies on next load

🤖 Generated with [Claude Code](https://claude.com/claude-code)