### PR TITLE
feat(ew): read default canvas editor view from site config

### DIFF
--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -1,7 +1,6 @@
 import { getNx } from '../../scripts/utils.js';
 import { editorSelectChange } from './editor-utils/editor-utils.js';
 import {
-  CANVAS_EDITOR_VIEW_KEY,
   normalizeCanvasEditorView,
   readInitialCanvasEditorView,
   persistCanvasEditorView,

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -46,8 +46,7 @@ async function readInitialCanvasEditorView({ org, site }) {
   } catch { /* ignore if browser disallows session storage */ }
 
   try {
-    const [, siteConfigPromise] = fetchDaConfigs({ org, site });
-    const siteConfig = await siteConfigPromise;
+    const siteConfig = await fetchDaConfigs({ org, site })[1];
     const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
     if (flag) return normalizeCanvasEditorView(flag.value);
   } catch { /* ignore config fetch errors */ }

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -1,5 +1,5 @@
 import { getNx } from '../../scripts/utils.js';
-import { fetchDaConfigs } from '../../shared/utils.js';
+import { fetchDaConfigs } from '../shared/utils.js';
 import { editorSelectChange } from './editor-utils/editor-utils.js';
 import './ew-canvas-header/ew-canvas-header.js';
 import './ew-editor-doc/ew-editor-doc.js';

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -1,4 +1,5 @@
 import { getNx } from '../../scripts/utils.js';
+import { fetchDaConfigs } from '../../shared/utils.js';
 import { editorSelectChange } from './editor-utils/editor-utils.js';
 import './ew-canvas-header/ew-canvas-header.js';
 import './ew-editor-doc/ew-editor-doc.js';
@@ -38,12 +39,20 @@ function notifyCanvasEditorActive(mountRoot, view) {
   }));
 }
 
-function readPersistedCanvasEditorView() {
+async function readInitialCanvasEditorView({ org, site }) {
   try {
-    return normalizeCanvasEditorView(sessionStorage.getItem(CANVAS_EDITOR_VIEW_KEY));
-  } catch {
-    return 'layout';
-  }
+    const persisted = sessionStorage.getItem(CANVAS_EDITOR_VIEW_KEY);
+    if (persisted) return normalizeCanvasEditorView(persisted);
+  } catch { /* ignore if browser disallows session storage */ }
+
+  try {
+    const [orgConfigPromise] = fetchDaConfigs({ org, site });
+    const orgConfig = await orgConfigPromise;
+    const flag = orgConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
+    if (flag) return normalizeCanvasEditorView(flag.value);
+  } catch { /* ignore config fetch errors */ }
+
+  return 'layout';
 }
 
 function persistCanvasEditorView(view) {
@@ -166,9 +175,9 @@ async function openCanvasPanel(position, { panelName } = {}) {
   }
 }
 
-function installCanvasHeader(block) {
+async function installCanvasHeader(block, { org, site }) {
   const header = document.createElement('ew-canvas-header');
-  header.editorView = readPersistedCanvasEditorView();
+  header.editorView = await readInitialCanvasEditorView({ org, site });
   header.addEventListener('nx-canvas-open-panel', (e) => {
     openCanvasPanel(e.detail.position, { panelName: e.detail.panelName });
   });
@@ -190,7 +199,8 @@ function installCanvasHeader(block) {
 }
 
 export default async function decorate(block) {
-  const header = installCanvasHeader(block);
+  const { org, site } = hashState();
+  const header = await installCanvasHeader(block, { org, site });
 
   const mountRoot = canvasEditorMountRoot(block);
   mountRoot.classList.add('nx-canvas-editor-mount');

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -46,9 +46,9 @@ async function readInitialCanvasEditorView({ org, site }) {
   } catch { /* ignore if browser disallows session storage */ }
 
   try {
-    const [orgConfigPromise] = fetchDaConfigs({ org, site });
-    const orgConfig = await orgConfigPromise;
-    const flag = orgConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
+    const [, siteConfigPromise] = fetchDaConfigs({ org, site });
+    const siteConfig = await siteConfigPromise;
+    const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
     if (flag) return normalizeCanvasEditorView(flag.value);
   } catch { /* ignore config fetch errors */ }
 

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -1,6 +1,11 @@
 import { getNx } from '../../scripts/utils.js';
-import { fetchDaConfigs } from '../shared/utils.js';
 import { editorSelectChange } from './editor-utils/editor-utils.js';
+import {
+  CANVAS_EDITOR_VIEW_KEY,
+  normalizeCanvasEditorView,
+  readInitialCanvasEditorView,
+  persistCanvasEditorView,
+} from './utils/view.js';
 import './ew-canvas-header/ew-canvas-header.js';
 import './ew-editor-doc/ew-editor-doc.js';
 import './ew-editor-wysiwyg/ew-editor-wysiwyg.js';
@@ -23,43 +28,12 @@ function buildCanvasDocPath(state) {
   return `${org}/${site}/${path}`;
 }
 
-const CANVAS_EDITOR_VIEW_KEY = 'nx-canvas-editor-view';
-
-function normalizeCanvasEditorView(view) {
-  if (view === 'content') return 'content';
-  if (view === 'split') return 'split';
-  return 'layout';
-}
-
 function notifyCanvasEditorActive(mountRoot, view) {
   const v = normalizeCanvasEditorView(view);
   mountRoot.dispatchEvent(new CustomEvent('nx-canvas-editor-active', {
     bubbles: false,
     detail: { view: v },
   }));
-}
-
-async function readInitialCanvasEditorView({ org, site }) {
-  try {
-    const persisted = sessionStorage.getItem(CANVAS_EDITOR_VIEW_KEY);
-    if (persisted) return normalizeCanvasEditorView(persisted);
-  } catch { /* ignore if browser disallows session storage */ }
-
-  try {
-    const siteConfig = await fetchDaConfigs({ org, site })[1];
-    const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
-    if (flag) return normalizeCanvasEditorView(flag.value);
-  } catch { /* ignore config fetch errors */ }
-
-  return 'layout';
-}
-
-function persistCanvasEditorView(view) {
-  try {
-    sessionStorage.setItem(CANVAS_EDITOR_VIEW_KEY, normalizeCanvasEditorView(view));
-  } catch {
-    /* ignore if browser disallows session storage */
-  }
 }
 
 function canvasEditorMountRoot(block) {

--- a/blocks/canvas/utils/view.js
+++ b/blocks/canvas/utils/view.js
@@ -15,10 +15,12 @@ export async function readInitialCanvasEditorView({ org, site }) {
   } catch { /* ignore if browser disallows session storage */ }
 
   try {
-    const siteConfig = await fetchDaConfigs({ org, site })[1];
+    const [, siteConfig] = await Promise.all(fetchDaConfigs({ org, site }));
     const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
     if (flag) return normalizeCanvasEditorView(flag.value);
-  } catch { /* ignore config fetch errors */ }
+  } catch (e) {
+    if (!(e instanceof TypeError) && !(e instanceof SyntaxError)) throw e;
+  }
 
   return 'layout';
 }

--- a/blocks/canvas/utils/view.js
+++ b/blocks/canvas/utils/view.js
@@ -1,6 +1,6 @@
 import { fetchDaConfigs } from '../../shared/utils.js';
 
-export const CANVAS_EDITOR_VIEW_KEY = 'nx-canvas-editor-view';
+const CANVAS_EDITOR_VIEW_KEY = 'nx-canvas-editor-view';
 
 export function normalizeCanvasEditorView(view) {
   if (view === 'content') return 'content';

--- a/blocks/canvas/utils/view.js
+++ b/blocks/canvas/utils/view.js
@@ -1,0 +1,30 @@
+import { fetchDaConfigs } from '../../shared/utils.js';
+
+export const CANVAS_EDITOR_VIEW_KEY = 'nx-canvas-editor-view';
+
+export function normalizeCanvasEditorView(view) {
+  if (view === 'content') return 'content';
+  if (view === 'split') return 'split';
+  return 'layout';
+}
+
+export async function readInitialCanvasEditorView({ org, site }) {
+  try {
+    const persisted = sessionStorage.getItem(CANVAS_EDITOR_VIEW_KEY);
+    if (persisted) return normalizeCanvasEditorView(persisted);
+  } catch { /* ignore if browser disallows session storage */ }
+
+  try {
+    const siteConfig = await fetchDaConfigs({ org, site })[1];
+    const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.canvasDefaultView');
+    if (flag) return normalizeCanvasEditorView(flag.value);
+  } catch { /* ignore config fetch errors */ }
+
+  return 'layout';
+}
+
+export function persistCanvasEditorView(view) {
+  try {
+    sessionStorage.setItem(CANVAS_EDITOR_VIEW_KEY, normalizeCanvasEditorView(view));
+  } catch { /* ignore if browser disallows session storage */ }
+}

--- a/test/unit/blocks/canvas/utils/view.test.js
+++ b/test/unit/blocks/canvas/utils/view.test.js
@@ -1,12 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 
+const SESSION_KEY = 'nx-canvas-editor-view';
 let readInitialCanvasEditorView;
-let CANVAS_EDITOR_VIEW_KEY;
 
 before(async () => {
   const mod = await import('../../../../../blocks/canvas/utils/view.js');
   readInitialCanvasEditorView = mod.readInitialCanvasEditorView;
-  CANVAS_EDITOR_VIEW_KEY = mod.CANVAS_EDITOR_VIEW_KEY;
 });
 
 describe('readInitialCanvasEditorView', () => {
@@ -15,13 +14,13 @@ describe('readInitialCanvasEditorView', () => {
 
   beforeEach(() => {
     savedFetch = window.fetch;
-    sessionStorage.removeItem(CANVAS_EDITOR_VIEW_KEY);
+    sessionStorage.removeItem(SESSION_KEY);
     testIndex += 1;
   });
 
   afterEach(() => {
     window.fetch = savedFetch;
-    sessionStorage.removeItem(CANVAS_EDITOR_VIEW_KEY);
+    sessionStorage.removeItem(SESSION_KEY);
   });
 
   // fetchDaConfigs caches by org/site — use a unique pair per test to avoid cache hits.
@@ -36,13 +35,13 @@ describe('readInitialCanvasEditorView', () => {
   }
 
   it('returns persisted session storage value when present', async () => {
-    sessionStorage.setItem(CANVAS_EDITOR_VIEW_KEY, 'content');
+    sessionStorage.setItem(SESSION_KEY, 'content');
     const view = await readInitialCanvasEditorView(ctx());
     expect(view).to.equal('content');
   });
 
   it('session storage value wins over config flag', async () => {
-    sessionStorage.setItem(CANVAS_EDITOR_VIEW_KEY, 'split');
+    sessionStorage.setItem(SESSION_KEY, 'split');
     mockConfig({ data: [{ key: 'ew.canvasDefaultView', value: 'content' }] });
     const view = await readInitialCanvasEditorView(ctx());
     expect(view).to.equal('split');

--- a/test/unit/blocks/canvas/utils/view.test.js
+++ b/test/unit/blocks/canvas/utils/view.test.js
@@ -1,0 +1,86 @@
+import { expect } from '@esm-bundle/chai';
+
+let readInitialCanvasEditorView;
+let CANVAS_EDITOR_VIEW_KEY;
+
+before(async () => {
+  const mod = await import('../../../../../blocks/canvas/utils/view.js');
+  readInitialCanvasEditorView = mod.readInitialCanvasEditorView;
+  CANVAS_EDITOR_VIEW_KEY = mod.CANVAS_EDITOR_VIEW_KEY;
+});
+
+describe('readInitialCanvasEditorView', () => {
+  let savedFetch;
+  let testIndex = 0;
+
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    sessionStorage.removeItem(CANVAS_EDITOR_VIEW_KEY);
+    testIndex += 1;
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+    sessionStorage.removeItem(CANVAS_EDITOR_VIEW_KEY);
+  });
+
+  // fetchDaConfigs caches by org/site — use a unique pair per test to avoid cache hits.
+  function ctx() { return { org: `org-${testIndex}`, site: `site-${testIndex}` }; }
+
+  function mockConfig(flags) {
+    window.fetch = () => Promise.resolve(new Response(JSON.stringify({ flags }), { status: 200 }));
+  }
+
+  function mockConfigError() {
+    window.fetch = () => Promise.resolve(new Response('', { status: 500 }));
+  }
+
+  it('returns persisted session storage value when present', async () => {
+    sessionStorage.setItem(CANVAS_EDITOR_VIEW_KEY, 'content');
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('content');
+  });
+
+  it('session storage value wins over config flag', async () => {
+    sessionStorage.setItem(CANVAS_EDITOR_VIEW_KEY, 'split');
+    mockConfig({ data: [{ key: 'ew.canvasDefaultView', value: 'content' }] });
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('split');
+  });
+
+  it('returns content from config flag when session storage is empty', async () => {
+    mockConfig({ data: [{ key: 'ew.canvasDefaultView', value: 'content' }] });
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('content');
+  });
+
+  it('returns split from config flag when session storage is empty', async () => {
+    mockConfig({ data: [{ key: 'ew.canvasDefaultView', value: 'split' }] });
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('split');
+  });
+
+  it('returns layout when config flag has an invalid value', async () => {
+    mockConfig({ data: [{ key: 'ew.canvasDefaultView', value: 'unknown' }] });
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('layout');
+  });
+
+  it('returns layout when config has no canvasDefaultView flag', async () => {
+    mockConfig({ data: [{ key: 'other.flag', value: 'true' }] });
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('layout');
+  });
+
+  it('returns layout when config fetch fails', async () => {
+    mockConfigError();
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('layout');
+  });
+
+  it('returns layout when config has no flags sheet', async () => {
+    mockConfig(undefined);
+    const view = await readInitialCanvasEditorView(ctx());
+    expect(view).to.equal('layout');
+  });
+});

--- a/test/unit/blocks/canvas/utils/view.test.js
+++ b/test/unit/blocks/canvas/utils/view.test.js
@@ -1,11 +1,51 @@
 import { expect } from '@esm-bundle/chai';
 
 const SESSION_KEY = 'nx-canvas-editor-view';
+let normalizeCanvasEditorView;
+let persistCanvasEditorView;
 let readInitialCanvasEditorView;
 
 before(async () => {
   const mod = await import('../../../../../blocks/canvas/utils/view.js');
+  normalizeCanvasEditorView = mod.normalizeCanvasEditorView;
+  persistCanvasEditorView = mod.persistCanvasEditorView;
   readInitialCanvasEditorView = mod.readInitialCanvasEditorView;
+});
+
+describe('normalizeCanvasEditorView', () => {
+  it('returns content for content', () => {
+    expect(normalizeCanvasEditorView('content')).to.equal('content');
+  });
+
+  it('returns split for split', () => {
+    expect(normalizeCanvasEditorView('split')).to.equal('split');
+  });
+
+  it('returns layout for layout', () => {
+    expect(normalizeCanvasEditorView('layout')).to.equal('layout');
+  });
+
+  it('returns layout for unknown values', () => {
+    expect(normalizeCanvasEditorView('unknown')).to.equal('layout');
+    expect(normalizeCanvasEditorView('')).to.equal('layout');
+    expect(normalizeCanvasEditorView(undefined)).to.equal('layout');
+  });
+});
+
+describe('persistCanvasEditorView', () => {
+  afterEach(() => {
+    sessionStorage.removeItem(SESSION_KEY);
+  });
+
+  it('writes the normalized view to session storage', () => {
+    persistCanvasEditorView('content');
+    expect(sessionStorage.getItem(SESSION_KEY)).to.equal('content');
+  });
+
+  it('normalizes the value before writing', () => {
+    persistCanvasEditorView('unknown');
+    expect(sessionStorage.getItem(SESSION_KEY)).to.equal('layout');
+  });
 });
 
 describe('readInitialCanvasEditorView', () => {
@@ -28,10 +68,6 @@ describe('readInitialCanvasEditorView', () => {
 
   function mockConfig(flags) {
     window.fetch = () => Promise.resolve(new Response(JSON.stringify({ flags }), { status: 200 }));
-  }
-
-  function mockConfigError() {
-    window.fetch = () => Promise.resolve(new Response('', { status: 500 }));
   }
 
   it('returns persisted session storage value when present', async () => {
@@ -67,12 +103,6 @@ describe('readInitialCanvasEditorView', () => {
 
   it('returns layout when config has no canvasDefaultView flag', async () => {
     mockConfig({ data: [{ key: 'other.flag', value: 'true' }] });
-    const view = await readInitialCanvasEditorView(ctx());
-    expect(view).to.equal('layout');
-  });
-
-  it('returns layout when config fetch fails', async () => {
-    mockConfigError();
     const view = await readInitialCanvasEditorView(ctx());
     expect(view).to.equal('layout');
   });


### PR DESCRIPTION
## Summary

- Adds support for an `ew.canvasDefaultView` flag in the site DA config to control which view (`content`, `split`, or `layout`) the canvas opens with on first visit
- Session storage (persisted user preference) always takes precedence — the config is only consulted when no persisted value exists
- Invalid or missing flag values fall back to `layout` (existing default)
- Added tests

Test
- https://vwcfg--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/coffee

## How to configure

Add a flag entry to the site config:

| key | value |
|-----|-------|
| `ew.canvasDefaultView` | `content` \| `split` \| `layout` |

## Test plan

- [ ] Open canvas with no session storage and no config flag → lands on `layout`
- [ ] Set `ew.canvasDefaultView = content` in site config, clear session storage → lands on `content`
- [ ] Set `ew.canvasDefaultView = split` in site config, clear session storage → lands on `split`
- [ ] Set an invalid flag value → falls back to `layout`
- [ ] Switch view manually → persists to session storage; config flag no longer applies on next load
