### PR TITLE
apply site-level image modifiers to AEM Assets delivery URLs

### DIFF
--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -5,6 +5,7 @@ import {
   buildAuthorUrl, buildDmUrl, buildDeliveryUrl,
   getAssetAlt, getDmApprovalStatus, getScene7PublishStatus,
 } from './helpers/urls.js';
+import { applySiteImageModifiers } from './helpers/imageModifiers.js';
 import { insertImage, insertLink, insertFragment, createImageNode, getBlockName } from './helpers/insert.js';
 import showSmartCropDialog from './helpers/smart-crop.js';
 
@@ -41,15 +42,20 @@ export function buildFeatureSet(isDmEnabled) {
 }
 
 export function resolveAssetUrl(asset, repoConfig) {
-  const { tierType, assetOrigin, assetBasePath, isDmEnabled, mimeRenditionOverrides } = repoConfig;
+  const {
+    tierType, assetOrigin, assetBasePath, isDmEnabled,
+    mimeRenditionOverrides, siteImageModifiers,
+  } = repoConfig;
   const renditionOptions = { mimeRenditionOverrides };
+  let url;
   if (tierType === 'delivery') {
-    return buildDeliveryUrl(asset, assetOrigin, assetBasePath, renditionOptions);
+    url = buildDeliveryUrl(asset, assetOrigin, assetBasePath, renditionOptions);
+  } else if (isDmEnabled) {
+    url = buildDmUrl(asset, assetOrigin, assetBasePath, renditionOptions);
+  } else {
+    url = buildAuthorUrl(asset, assetOrigin);
   }
-  if (isDmEnabled) {
-    return buildDmUrl(asset, assetOrigin, assetBasePath, renditionOptions);
-  }
-  return buildAuthorUrl(asset, assetOrigin);
+  return applySiteImageModifiers(url, siteImageModifiers);
 }
 
 function showErrorPanel(container, onBack, onCancel, message = DM_ERROR_MSG) {
@@ -140,7 +146,11 @@ export function buildHandleSelection(
         responsiveImageConfigPromise,
         onInsert: (srcs) => {
           closeAndReset();
-          const nodes = srcs.map((src) => createImageNode(view, src, alt));
+          const nodes = srcs.map((src) => createImageNode(
+            view,
+            applySiteImageModifiers(src, repoConfig.siteImageModifiers),
+            alt,
+          ));
           insertFragment(view, nodes);
         },
         onBack: resetToAssetPanel,

--- a/blocks/edit/da-assets/helpers/config.js
+++ b/blocks/edit/da-assets/helpers/config.js
@@ -1,5 +1,6 @@
 import { getFirstSheet, fetchDaConfigs } from '../../../shared/utils.js';
 import DEFAULT_ASSET_BASE_PATH from './constants.js';
+import { parseSiteImageModifiers } from './imageModifiers.js';
 
 /**
  * Parses the value of 'aem.asset.mime.renditions' into a mime-type → rendition-type map.
@@ -62,8 +63,15 @@ export async function getResponsiveImageConfig(owner, repo) {
  *   When absent (or empty), built-in prefix defaults apply:
  *     image/* → avif, video/* → /play, everything else → original.
  *
+ * siteImageModifiers (DM / delivery tiers only):
+ *   aem.asset.image.modifiers — optional query-string fragment (no leading
+ *   `?`) merged into every AEM Assets Open API image URL inserted via the
+ *   asset picker, e.g. `width=1920&quality=85`. Only set on URLs that don't
+ *   already carry the same key, so per-asset overrides (smartcrop, future
+ *   per-image presets) win.
+ *
  * @returns {{ repositoryId, tierType, assetOrigin, assetBasePath, isDmEnabled, isSmartCrop,
- *             insertAsLink, mimeRenditionOverrides }}
+ *             insertAsLink, mimeRenditionOverrides, siteImageModifiers }}
  */
 export async function getRepositoryConfig(owner, repo) {
   const configs = await Promise.all(fetchDaConfigs({ org: owner, site: repo }));
@@ -82,6 +90,7 @@ export async function getRepositoryConfig(owner, repo) {
   const isDmEnabled = isSmartCrop || isDmDeliveryFlag || customOrigin?.startsWith('delivery-') || tierType === 'delivery';
   const insertAsLink = getValue('aem.assets.image.type') === 'link';
   const mimeRenditionOverrides = parseMimeRenditions(getValue('aem.asset.mime.renditions'));
+  const siteImageModifiers = parseSiteImageModifiers(getValue('aem.asset.image.modifiers'));
 
   let assetOrigin;
   if (customOrigin) {
@@ -105,5 +114,6 @@ export async function getRepositoryConfig(owner, repo) {
     isSmartCrop,
     insertAsLink,
     mimeRenditionOverrides,
+    siteImageModifiers,
   };
 }

--- a/blocks/edit/da-assets/helpers/imageModifiers.js
+++ b/blocks/edit/da-assets/helpers/imageModifiers.js
@@ -1,0 +1,87 @@
+/**
+ * Site-level image-modifier handling for AEM Assets Open API delivery URLs.
+ *
+ * A site admin sets `aem.asset.image.modifiers` in DA site config to a
+ * query-string fragment (no leading `?`), e.g. `width=1920&quality=85`.
+ * Every image inserted via the AEM Asset picker gets these merged into its
+ * `src` URL at insert time, so the customer's site-wide rendition policy is
+ * applied uniformly without per-image authoring work.
+ *
+ * Scope (deliberately narrow to avoid surprises):
+ *   - Only applied to AEM Assets Open API delivery URLs (`/adobe/assets/...`).
+ *     Drag-drop uploads to the content store and non-DM URLs are untouched.
+ *   - Skips `.../as/<name>/play` (video) paths.
+ *   - "If not present" semantics: existing query params on the URL win, so
+ *     per-asset overrides (e.g. `?smartcrop=Square`) and any future per-image
+ *     authoring continue to take precedence.
+ *
+ * Security: modifier strings come from authenticated DA admin config and are
+ * merged via `URLSearchParams.set()` which percent-encodes values. We never
+ * interpolate them into HTML or JS contexts.
+ */
+
+const IMAGE_EXTENSIONS = new Set(['avif', 'webp', 'jpg', 'jpeg', 'png', 'gif']);
+
+/**
+ * Parses the raw `aem.asset.image.modifiers` config value.
+ *
+ * @param {string|null|undefined} rawValue
+ * @returns {string|null} trimmed modifier string, or null when absent/empty.
+ */
+export function parseSiteImageModifiers(rawValue) {
+  if (typeof rawValue !== 'string') return null;
+  const trimmed = rawValue.trim().replace(/^\?/, '');
+  return trimmed || null;
+}
+
+function isAemAssetsDeliveryImageUrl(url) {
+  if (!url.pathname.includes('/adobe/assets/')) return false;
+  const path = url.pathname.toLowerCase();
+  // Skip video delivery paths like `/as/<name>/play`.
+  if (path.endsWith('/play') || path.endsWith('/play/')) return false;
+  const lastSegment = path.split('/').pop() || '';
+  const dotIdx = lastSegment.lastIndexOf('.');
+  if (dotIdx === -1) return false;
+  const ext = lastSegment.slice(dotIdx + 1);
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Merges site-level modifiers into an AEM Assets Open API image URL.
+ *
+ * Returns the original URL unchanged when:
+ *   - `modifiers` is empty/null
+ *   - `srcUrl` is empty or unparseable
+ *   - `srcUrl` is not an AEM Assets Open API delivery image URL
+ *
+ * For matching URLs, every key in `modifiers` is set ONLY if the URL doesn't
+ * already carry that key. This preserves per-asset overrides (smartcrop,
+ * future per-image presets, etc.).
+ */
+export function applySiteImageModifiers(srcUrl, modifiers) {
+  if (!srcUrl || !modifiers) return srcUrl;
+  let url;
+  try {
+    url = new URL(srcUrl);
+  } catch {
+    return srcUrl;
+  }
+  if (!isAemAssetsDeliveryImageUrl(url)) return srcUrl;
+
+  let modParams;
+  try {
+    modParams = new URLSearchParams(modifiers);
+  } catch {
+    return srcUrl;
+  }
+
+  let mutated = false;
+  modParams.forEach((value, key) => {
+    if (!url.searchParams.has(key)) {
+      url.searchParams.set(key, value);
+      mutated = true;
+    }
+  });
+
+  return mutated ? url.toString() : srcUrl;
+}

--- a/test/unit/blocks/edit/da-assets/config.test.js
+++ b/test/unit/blocks/edit/da-assets/config.test.js
@@ -238,6 +238,37 @@ describe('getRepositoryConfig', () => {
       window.fetch = orgFetch;
     }
   });
+
+  it('siteImageModifiers is null when aem.asset.image.modifiers is absent', async () => {
+    const orgFetch = window.fetch;
+    window.fetch = makeFetch({
+      '/rcfg/nomod/': makeSheet([
+        { key: 'aem.repositoryId', value: 'author-p98-e98.adobeaemcloud.com' },
+      ]),
+    });
+    try {
+      const cfg = await getRepositoryConfig('rcfg', 'nomod');
+      expect(cfg.siteImageModifiers).to.equal(null);
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
+
+  it('parses aem.asset.image.modifiers into siteImageModifiers (trimmed, no leading ?)', async () => {
+    const orgFetch = window.fetch;
+    window.fetch = makeFetch({
+      '/rcfg/withmod/': makeSheet([
+        { key: 'aem.repositoryId', value: 'author-p99-e99.adobeaemcloud.com' },
+        { key: 'aem.asset.image.modifiers', value: '  ?width=1920&quality=85  ' },
+      ]),
+    });
+    try {
+      const cfg = await getRepositoryConfig('rcfg', 'withmod');
+      expect(cfg.siteImageModifiers).to.equal('width=1920&quality=85');
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/blocks/edit/da-assets/da-assets.test.js
+++ b/test/unit/blocks/edit/da-assets/da-assets.test.js
@@ -239,6 +239,21 @@ describe('resolveAssetUrl', () => {
     });
     expect(url).to.include('/original/as/report.docx');
   });
+
+  it('appends siteImageModifiers to AEM Assets Open API image URLs', () => {
+    const url = resolveAssetUrl(DELIVERY_IMAGE, {
+      ...DELIVERY_CONFIG,
+      siteImageModifiers: 'width=1920&quality=85',
+    });
+    const params = new URL(url).searchParams;
+    expect(params.get('width')).to.equal('1920');
+    expect(params.get('quality')).to.equal('85');
+  });
+
+  it('does not modify URLs when siteImageModifiers is null/absent', () => {
+    const url = resolveAssetUrl(DELIVERY_IMAGE, DELIVERY_CONFIG);
+    expect(new URL(url).searchParams.has('width')).to.equal(false);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added support for site-level image modifiers on delivery URLs

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Behr is currently facing an issue with the image sizes. Most of their images are bigger than 20MB, causing the media bus not to ingest them. The size could be reduced if they use the smartcrop originals, but a bug from the Assets repo is preventing them from size reduction. Implemented this as a temporary fix, as Behr is planned to go live in a couple of weeks.

## How Has This Been Tested?

Overridden the script files on Chrome Dev Tools and tested the 

## Screenshots (if appropriate):
<img width="1252" height="1397" alt="Screenshot 2026-06-11 at 3 42 38 PM" src="https://github.com/user-attachments/assets/4dedc219-0c02-4b71-85c3-f19a13cb6e75" />
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
