### PR TITLE
fix: paste copied table cell content into a cell

### DIFF
--- a/blocks/edit/prose/plugins/sectionPasteHandler.js
+++ b/blocks/edit/prose/plugins/sectionPasteHandler.js
@@ -256,8 +256,7 @@ export default function sectionPasteHandler(schema) {
             return html;
           }
 
-          const serializer = new XMLSerializer();
-          return serializer.serializeToString(doc);
+          return doc.body.innerHTML;
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error('Error handling Word paste:', error);

--- a/test/unit/blocks/edit/prose/plugins/sectionPasteHandler.test.js
+++ b/test/unit/blocks/edit/prose/plugins/sectionPasteHandler.test.js
@@ -32,18 +32,8 @@ describe('Section paste handler', () => {
 
     const result = normalizeHTML(wordPasteHandler(inputHTML));
 
-    // Note the added <hr /> tags
-    const expectedHTML = normalizeHTML(`
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-     <meta name="ProgId" content="Word.Document" />
-  </head>
-  <body>
-    <div>Section 1</div><hr />
-    <div>Section 2</div><hr />
-    <p>Section 3</p>
-  </body>
-</html>`);
+    // transformPastedHTML returns the body content only; note the added <hr> tags.
+    const expectedHTML = '<div>Section 1</div> <hr> <div>Section 2</div> <hr> <p>Section 3</p>';
     expect(result).to.equal(expectedHTML);
   });
 
@@ -64,17 +54,8 @@ describe('Section paste handler', () => {
 
     const result = normalizeHTML(wordPasteHandler(inputHTML));
 
-    // Note the added <hr /> tags
-    const expectedHTML = normalizeHTML(`
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-     <meta name="ProgId" content="Word.Document" />
-  </head>
-  <body>
-    <div>Section 1</div><hr />
-    <div>Section 2</div>
-  </body>
-</html>`);
+    // transformPastedHTML returns the body content only; no <hr> after the last element.
+    const expectedHTML = '<div>Section 1</div> <hr> <div>Section 2</div>';
     expect(result).to.equal(expectedHTML);
   });
 
@@ -135,18 +116,13 @@ describe('Section paste handler', () => {
 
     const result = normalizeHTML(wordPasteHandler(inputHTML));
 
-    // Note the added <hr /> tag
+    // transformPastedHTML returns the body content only; note the added <hr> tag.
     const expectedHTML = normalizeHTML(`
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head></head>
-  <body>
     <div><p>
       <span>Section 1</span>
       <span data-ccp-props="{&quot;201341983&quot;:0,&quot;335559739&quot;:160,&quot;335559740&quot;:279,&quot;335572079&quot;:6,&quot;335572080&quot;:1,&quot;335572081&quot;:0,&quot;469789806&quot;:&quot;single&quot;}"></span>
-    </p><hr /></div>
-    <div>Section 2</div>
-  </body>
-</html>`);
+    </p><hr></div>
+    <div>Section 2</div>`);
 
     expect(result).to.equal(expectedHTML);
   });
@@ -197,6 +173,38 @@ describe('Section paste handler', () => {
     const inputHTML = '<p>Just a paragraph</p>';
     const result = pasteHandler(inputHTML);
     expect(result).to.equal(inputHTML);
+  });
+
+  it('keeps copied table content parsable (no document wrapper breaking data-pm-slice)', () => {
+    const plugin = sectionPasteHandler();
+    const pasteHandler = plugin.props.transformPastedHTML;
+
+    // A table cell copied from within the editor. transformPastedHTML must not
+    // wrap the result in an <html>/<head>/<meta> document: the re-introduced
+    // <meta> would become the first child element and derail ProseMirror's
+    // data-pm-slice descent (table > tbody > tr), pasting nothing.
+    const inputHTML = '<meta charset=\'utf-8\'><table data-pm-slice="2 4 -3 [&quot;table&quot;,{&quot;dataId&quot;:null,&quot;daDiffAdded&quot;:null},&quot;table_row&quot;,{}]"><tbody><tr><td><p>Columns block</p><ul><li><p>One</p></li><li><p>Two</p></li><li><p>Three</p></li></ul></td></tr></tbody></table>';
+    const result = pasteHandler(inputHTML);
+
+    expect(result).to.not.contain('<head');
+    expect(result).to.contain('data-pm-slice');
+
+    // Replicate ProseMirror's clipboard descent and confirm it lands on the
+    // table row carrying the copied cell content (i.e. paste won't be empty).
+    const div = document.createElement('div');
+    div.innerHTML = result.replace(/^(\s*<meta [^>]*>)*/, '');
+    const sliceData = /^(\d+) (\d+)(?: -(\d+))? (.*)/
+      .exec(div.querySelector('[data-pm-slice]').getAttribute('data-pm-slice'));
+    let dom = div;
+    for (let i = +sliceData[3]; i > 0; i -= 1) {
+      let child = dom.firstChild;
+      while (child && child.nodeType !== 1) child = child.nextSibling;
+      if (!child) break;
+      dom = child;
+    }
+    expect(dom.nodeName).to.equal('TR');
+    expect(dom.textContent).to.contain('Columns block');
+    expect(dom.textContent).to.contain('One');
   });
 
   it('Plain text paste preserves blank lines', () => {


### PR DESCRIPTION
## What

Pasting content copied from a ProseMirror table (e.g. a cell containing a paragraph and a list) into another cell did nothing — no content was inserted.

## Why

Regression from [#984](https://github.com/adobe/da-live/pull/984). Content copied from within the editor carries a `data-pm-slice` attribute, e.g.:

```
data-pm-slice="2 4 -3 ["table",{...},"table_row",{}]"
```

The `-3` instructs ProseMirror's clipboard parser to **descend 3 first-child elements** (`table` → `tbody` → `tr`) before parsing, then re-wrap the inner cell content using the encoded context.

`transformPastedHTML` runs before that parse. Before #984, a plain table paste matched none of the section-break detectors and hit the early `return html`, so the clipboard was **passed through untouched** and the paste worked. #984 added `handleTableSpacing`, which fires for *any* pasted table and forces the function into its re-serialization path:

```js
const serializer = new XMLSerializer();
return serializer.serializeToString(doc);   // emits <html><head><meta>…</head><body>…
```

That full-document round-trip relocates the clipboard's leading `<meta>` into `<head>`. On re-parse the `<meta>` becomes the **first child element**, so ProseMirror's descent stops at it (no children), parses an **empty slice**, and nothing pastes.

## Fix

`transformPastedHTML` is meant to return paste-able *fragment* HTML, not a synthetic full document. Return `doc.body.innerHTML` instead of serializing the whole document. This drops the `<head>/<meta>` wrapper for **every** paste — no ProseMirror-specific branching — while still appending #984's spacing paragraph after tables.

## Testing

- Updated the three Word/section tests to assert the body-fragment output (the `<html>/<head>` wrapper is no longer emitted).
- Added a regression test that replicates ProseMirror's `data-pm-slice` descent and confirms it lands on the `<tr>` carrying the copied cell content (i.e. the paste won't be empty), and that no `<head>` wrapper is produced.
- Verified end-to-end with a real `EditorView` + ProseMirror clipboard parser: before the fix the slice was empty; after, the cell content pastes correctly.
- Full `sectionPasteHandler` suite passes (24/24); ESLint clean.
- External pastes (Word desktop/online, Excel div line-breaks, table spacing) are unaffected — the section-break/spacing transformations still run; only the wrapper around the returned fragment changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)