### PR TITLE
fix: insert canvas template using value URL

### DIFF
--- a/blocks/canvas/ew-panel-extensions/ew-panel-library.js
+++ b/blocks/canvas/ew-panel-extensions/ew-panel-library.js
@@ -104,7 +104,7 @@ class EwPanelLibrary extends LitElement {
   async _insertTemplate(item) {
     const { view } = getExtensionsBridge();
     if (!view) return;
-    await insertTemplate(view, item.path);
+    await insertTemplate(view, item.value);
   }
 
   async _openPreview(item) {

--- a/test/unit/blocks/canvas/ew-panel-extensions/ew-panel-library.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/ew-panel-library.test.js
@@ -1,0 +1,50 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+import { getExtensionsBridge } from '../../../../../blocks/canvas/editor-utils/extensions-bridge.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+await import('../../../../../blocks/canvas/ew-panel-extensions/ew-panel-library.js');
+
+describe('Ew panel library _insertTemplate', () => {
+  let savedFetch;
+  let savedExtensionsBridge;
+
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    savedExtensionsBridge = getExtensionsBridge().view;
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+    getExtensionsBridge().view = savedExtensionsBridge;
+  });
+
+  it('should not fetch when there is no editor view', async () => {
+    getExtensionsBridge().view = null;
+    let fetched = false;
+    window.fetch = () => {
+      fetched = true;
+      return Promise.resolve(new Response('', { status: 404 }));
+    };
+
+    const el = document.createElement('ew-panel-library');
+    await el._insertTemplate({ key: 'home', value: 'https://content.da.live/org/site/home' });
+
+    expect(fetched).to.be.false;
+  });
+
+  it('should fetch item.value when an editor view is present', async () => {
+    getExtensionsBridge().view = {};
+    let fetchedUrl;
+    window.fetch = (url) => {
+      fetchedUrl = url;
+      return Promise.resolve(new Response('', { status: 404 }));
+    };
+
+    const el = document.createElement('ew-panel-library');
+    await el._insertTemplate({ key: 'home', value: 'https://content.da.live/org/site/home' });
+
+    expect(fetchedUrl).to.equal('https://content.da.live/org/site/home');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Template rows carry URL in the `value` column (`path` is for blocks). 

Fix: read `item.value`, as per [DA Setup Library docs](https://docs.da.live/administrators/guides/setup-library) and the `/edit` reference implementation (`handleTemplateClick`).


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Open `https://da.live/canvas#/{org}/{site}/{page}`.
2. Click on the document so the editor (window.view) has a cursor.
3. Open the right panel and select Templates (under the "Library" section).
4. Click the + (add) icon on a template.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
