### PR TITLE
fix: pass WS auth token via sub-protocol instead of query param in canvas editor

### DIFF
--- a/blocks/canvas/ew-editor-doc/prose.js
+++ b/blocks/canvas/ew-editor-doc/prose.js
@@ -86,7 +86,7 @@ export default async function initProse({
   if (typeof getToken === 'function') {
     const t = getToken();
     if (t) {
-      wsOpts.params = { Authorization: `Bearer ${t}` };
+      wsOpts.protocols.push(t);
       lastSentToken = t;
     }
   }
@@ -115,16 +115,12 @@ export default async function initProse({
         }
         return;
       }
-      wsProvider.params = { Authorization: `Bearer ${fresh}` };
+      wsProvider.protocols = ['yjs', fresh];
       lastSentToken = fresh;
       return;
     }
     const fresh = await getAuthToken();
-    if (fresh) {
-      wsProvider.params = { Authorization: `Bearer ${fresh}` };
-    } else {
-      wsProvider.params = {};
-    }
+    wsProvider.protocols = fresh ? ['yjs', fresh] : ['yjs'];
     lastSentToken = fresh;
   });
 


### PR DESCRIPTION
## Summary

- The canvas editor (`ew-editor-doc/prose.js`) was sending the Bearer token as an `Authorization` URL query parameter on WebSocket connections, causing it to appear verbatim in server/CDN logs
- `edit/prose/index.js` already used the correct approach: passing the token as a WebSocket sub-protocol value (in `sec-websocket-protocol` headers), which da-collab already supports
- This PR aligns the canvas editor to the same pattern, eliminating the token from all URLs

## Test plan

Test page: https://wsproto--da-live--adobe.aem.live/

- [ ] Open a document in the canvas editor while authenticated — confirm collab connects and syncs normally
- [ ] Verify no `Authorization=Bearer%20...` appears in da-collab request logs after deploy
- [ ] Let token expire mid-session — confirm 4401 reconnect flow still works with the new `protocols` assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)