### PR TITLE
feat(ew): add image overlay for alt text and replace in content mode

### DIFF
--- a/blocks/canvas/editor-utils/image-ops.js
+++ b/blocks/canvas/editor-utils/image-ops.js
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-unresolved -- importmap */
+import { NodeSelection } from 'da-y-wrapper';
+import { daFetch } from '../../shared/utils.js';
+import { getSourceUploadContext } from '../ew-editor-doc/prose-plugins/sourceUploadContext.js';
+
+/** MIME types accepted by the DA upload endpoint for image replace/insert. */
+export const SUPPORTED_IMAGE_TYPES = [
+  'image/svg+xml',
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+];
+
+/**
+ * Returns `{ node, pos }` when an `image` NodeSelection is active, else `null`.
+ * @param {import('prosemirror-state').EditorState} state
+ */
+export function getSelectedImage(state) {
+  const { selection } = state;
+  if (!(selection instanceof NodeSelection)) return null;
+  if (selection.node?.type?.name !== 'image') return null;
+  return { node: selection.node, pos: selection.from };
+}
+
+/**
+ * Replace the `src` (and optionally other attrs) of the image at `pos`,
+ * preserving every attribute the caller does not override (alt, title, href,
+ * focal point, sizing style, …).
+ * @returns {boolean} true if a node was updated.
+ */
+export function updateImageAttrs(view, pos, attrs) {
+  if (!view) return false;
+  const node = view.state.doc.nodeAt(pos);
+  if (!node || node.type.name !== 'image') return false;
+  const tr = view.state.tr.setNodeMarkup(pos, null, { ...node.attrs, ...attrs });
+  view.dispatch(tr);
+  return true;
+}
+
+/**
+ * Derive a human-readable fallback alt from an uploaded filename.
+ * "my-cool-photo.png" → "My cool photo".
+ */
+export function altFromFilename(filename) {
+  if (!filename) return '';
+  const stem = filename.replace(/\.[^.]+$/, '').replace(/[-_]+/g, ' ').trim();
+  if (!stem) return '';
+  return stem.charAt(0).toUpperCase() + stem.slice(1);
+}
+
+/**
+ * Upload an image file to the DA admin source endpoint and return the public
+ * delivery URL. Mirrors the upload pipeline used by `imageDrop` so that all
+ * "replace from local file" flows share one code path.
+ *
+ * @param {{ file: File, sourceUrl: string }} args
+ * @returns {Promise<{ src: string } | null>} returns `null` when the upload
+ *   target cannot be derived (non-DA source) or the request fails.
+ */
+export async function uploadImageToDa({ file, sourceUrl }) {
+  if (!file) return null;
+  if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) return null;
+  const details = getSourceUploadContext(sourceUrl ?? '');
+  if (!details) return null;
+
+  const safeName = encodeURIComponent(file.name);
+  const url = `${details.origin}/source${details.parent}/.${details.name}/${safeName}`;
+  const formData = new FormData();
+  formData.append('data', file);
+  const resp = await daFetch(url, { method: 'PUT', body: formData });
+  if (!resp.ok) return null;
+  const json = await resp.json().catch(() => null);
+  const src = json?.source?.contentUrl;
+  if (!src) return null;
+  return { src };
+}

--- a/blocks/canvas/editor-utils/selection-toolbar.js
+++ b/blocks/canvas/editor-utils/selection-toolbar.js
@@ -1,8 +1,6 @@
 /* eslint-disable import/no-unresolved -- importmap */
 import { Plugin, PluginKey, NodeSelection } from 'da-y-wrapper';
 
-const NON_TEXT_NODES = new Set(['table', 'image']);
-
 /** Set on transactions that mirror WYSIWYG iframe text selection into ProseMirror. */
 export const NX_QUICK_EDIT_IFRAME_SELECTION_META = 'nxQuickEditIframeSelection';
 
@@ -15,37 +13,152 @@ function getSelectionOriginFromIframe(state) {
   return selectionToolbarOriginKey.getState(state)?.fromIframe ?? false;
 }
 
-let toolbar;
-let componentLoaded;
+let textToolbar;
+let imageOverlay;
+let textToolbarReady;
+let imageOverlayReady;
 
+/**
+ * Returns a fully-upgraded custom element, lazily importing its module and
+ * waiting for `customElements.whenDefined` before resolving. This is critical
+ * because plugin `update` can run as soon as y-sync hydrates the doc — before
+ * any dynamic `import(...)` of the component module has resolved — and calling
+ * methods on a not-yet-upgraded element throws `<method> is not a function`.
+ */
+async function ensureUpgradedElement(tagName, importer) {
+  await importer();
+  await customElements.whenDefined(tagName);
+  const el = document.createElement(tagName);
+  document.body.append(el);
+  return el;
+}
+
+function ensureSelectionToolbar() {
+  if (textToolbar) return textToolbar;
+  textToolbarReady ??= ensureUpgradedElement(
+    'ew-selection-toolbar',
+    () => import('../ew-selection-toolbar/ew-selection-toolbar.js'),
+  ).then((el) => {
+    // If a sync fallback element was created in the meantime, prefer it
+    // (its custom element class will have been upgraded automatically).
+    textToolbar = textToolbar ?? el;
+    return textToolbar;
+  });
+  return textToolbarReady;
+}
+
+/**
+ * Backwards-compatible sync accessor for callers that tolerate the "may not be
+ * upgraded yet" property-set pattern (the legacy text toolbar uses this from
+ * `handlers.js`). Returns the cached element if available; otherwise kicks off
+ * the upgrade and returns a synchronously-created element as a best-effort
+ * fallback — the browser will retroactively upgrade it once
+ * `customElements.define` runs.
+ */
 export function getSelectionToolbar() {
-  if (toolbar) return toolbar;
-  componentLoaded ??= import('../ew-selection-toolbar/ew-selection-toolbar.js');
-  toolbar = document.createElement('ew-selection-toolbar');
-  document.body.append(toolbar);
-  return toolbar;
+  if (textToolbar) return textToolbar;
+  ensureSelectionToolbar();
+  if (!textToolbar) {
+    textToolbar = document.createElement('ew-selection-toolbar');
+    document.body.append(textToolbar);
+  }
+  return textToolbar;
+}
+
+async function ensureImageOverlay() {
+  if (imageOverlay) return imageOverlay;
+  imageOverlayReady ??= ensureUpgradedElement(
+    'ew-image-overlay',
+    () => import('../ew-image-overlay/ew-image-overlay.js'),
+  ).then((el) => {
+    imageOverlay = imageOverlay ?? el;
+    return imageOverlay;
+  });
+  return imageOverlayReady;
 }
 
 export function hideSelectionToolbar() {
-  toolbar?.hide?.();
+  textToolbar?.hide?.();
+  imageOverlay?.hide?.();
 }
 
-function isNonTextSelection({ selection }) {
-  return selection instanceof NodeSelection
-    && NON_TEXT_NODES.has(selection.node.type.name);
+/**
+ * Returns the toolbar mode for the current selection:
+ *   - `'image'` when a single image node is selected
+ *   - `'text'`  for ranges, cursors, and any other node selection we should
+ *               still show the text toolbar for
+ *   - `null`    when the toolbar should be hidden entirely (e.g. table NodeSelection)
+ *
+ * Exported for unit-testing; consumers should not call this directly.
+ */
+export function toolbarModeForSelection({ selection }) {
+  if (!(selection instanceof NodeSelection)) return 'text';
+  const nodeType = selection.node?.type?.name;
+  if (nodeType === 'image') return 'image';
+  // Other NodeSelections (table, hr, …) → keep the legacy "hide" behavior.
+  return null;
 }
 
-function syncToolbar(view) {
-  if (!view) return;
-  const tb = getSelectionToolbar();
+/**
+ * Find the DOM element backing the currently selected image node. Returns
+ * `null` if the editor view does not have a DOM mapping for the selection
+ * (e.g. the doc editor is unmounted in layout-only mode).
+ */
+function getImageElementAt(view, pos) {
+  try {
+    const dom = view.nodeDOM(pos);
+    if (!dom) return null;
+    if (dom.tagName === 'IMG') return dom;
+    return dom.querySelector?.('img') ?? dom;
+  } catch {
+    return null;
+  }
+}
+
+async function showImageOverlayFor(view) {
+  const pos = view.state.selection.from;
+  const getAnchor = () => getImageElementAt(view, pos);
+  // If the anchor isn't ready yet (image still hydrating), bail rather than
+  // showing the overlay at (0,0); the next view update will retry.
+  if (!getAnchor()) return;
+  const overlay = await ensureImageOverlay();
+  // Selection may have moved on by the time the upgrade finished.
+  if (!view.state || view.state.selection.from !== pos) return;
+  if (toolbarModeForSelection(view.state) !== 'image') return;
+  textToolbar?.hide?.();
+  overlay.showFor({ view, placement: 'content', getAnchor });
+}
+
+async function showTextToolbarFor(view) {
+  const tb = await ensureSelectionToolbar();
   if (tb.linkDialogOpen || tb.isInteracting) return;
-  if (isNonTextSelection(view.state)) {
+  if (!view.hasFocus()) return;
+  imageOverlay?.hide?.();
+  tb.view = view;
+  tb.show();
+}
+
+function syncForActiveView(view) {
+  if (!view) return;
+  const mode = toolbarModeForSelection(view.state);
+  if (mode === null) {
     hideSelectionToolbar();
     return;
   }
-  if (!view.hasFocus()) return;
-  tb.view = view;
-  tb.show();
+  if (mode === 'image') {
+    // Fire-and-forget: plugin `update` is sync. Errors are surfaced via the
+    // ensure*() promise rejection handlers below.
+    showImageOverlayFor(view).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('[selection-toolbar] failed to show image overlay', err);
+    });
+    return;
+  }
+  if (imageOverlay?.isInteracting) return;
+  showTextToolbarFor(view).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('[selection-toolbar] failed to show text toolbar', err);
+  });
 }
 
 export function createSelectionToolbarPlugin() {
@@ -67,9 +180,12 @@ export function createSelectionToolbarPlugin() {
         update(view) {
           const header = document.querySelector('ew-canvas-header');
           const ev = header?.editorView;
+          // Image overlay + text toolbar only render over the doc editor
+          // surface (content/split). Layout-mode image editing is handled
+          // separately and is not part of this surface.
           if (ev !== 'content' && ev !== 'split') return;
           if (getSelectionOriginFromIframe(view.state)) return;
-          syncToolbar(view);
+          syncForActiveView(view);
         },
         destroy() {
           hideSelectionToolbar();

--- a/blocks/canvas/ew-editor-doc/prose-plugins/imageDrop.js
+++ b/blocks/canvas/ew-editor-doc/prose-plugins/imageDrop.js
@@ -1,9 +1,28 @@
 import { Plugin, TextSelection } from 'da-y-wrapper';
 import { daFetch } from '../../../shared/utils.js';
 import { getSourceUploadContext } from './sourceUploadContext.js';
+import { altFromFilename, SUPPORTED_IMAGE_TYPES } from '../../editor-utils/image-ops.js';
 
 const FPO_IMG_URL = '/blocks/edit/img/fpo.svg';
-const SUPPORTED_FILES = ['image/svg+xml', 'image/png', 'image/jpeg', 'image/gif'];
+
+/**
+ * If `event.clientX/Y` falls inside an existing `image` node, return its
+ * document position. Used to decide whether a drop should *replace* that
+ * image instead of inserting a new one.
+ */
+function imageNodePosAtPoint(view, event) {
+  const coords = { left: event.clientX, top: event.clientY };
+  const hit = view.posAtCoords(coords);
+  if (!hit) return null;
+  const $pos = view.state.doc.resolve(hit.pos);
+  // `nodeAfter` covers the click-on-image case in inline content; fall back
+  // to the parent walk for clicks on padding around the image element.
+  const candidate = $pos.nodeAfter ?? view.state.doc.nodeAt(Math.max(0, hit.pos - 1));
+  if (candidate?.type?.name === 'image') {
+    return $pos.nodeAfter ? hit.pos : Math.max(0, hit.pos - 1);
+  }
+  return null;
+}
 
 /**
  * @param {import('prosemirror-model').Schema} schema
@@ -14,23 +33,59 @@ export default function imageDrop(schema, getSourceUrl) {
     props: {
       handleDOMEvents: {
         drop: (view, event) => {
-          event.preventDefault();
-
           const { files } = event.dataTransfer;
           if (files.length === 0) return false;
 
           const details = getSourceUploadContext(getSourceUrl() ?? '');
           if (!details) return false;
 
-          ([...files]).forEach(async (file) => {
-            if (!SUPPORTED_FILES.some((type) => type === file.type)) return;
+          event.preventDefault();
 
+          const replacePos = imageNodePosAtPoint(view, event);
+
+          ([...files]).forEach(async (file) => {
+            if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) return;
+
+            // Use encoded filename to defang special chars and prevent simple
+            // path-traversal attempts via OS filenames.
+            const safeName = encodeURIComponent(file.name);
+            const url = `${details.origin}/source${details.parent}/.${details.name}/${safeName}`;
+
+            // Replace-in-place: keep the existing image's alt/title/href/focal/
+            // sizing, swap only `src`. Don't insert an FPO placeholder — the
+            // existing image stays put until the upload completes.
+            if (replacePos !== null) {
+              const existing = view.state.doc.nodeAt(replacePos);
+              if (!existing || existing.type.name !== 'image') return;
+
+              const formData = new FormData();
+              formData.append('data', file);
+              const resp = await daFetch(url, { method: 'PUT', body: formData });
+              if (!resp.ok) return;
+              const json = await resp.json().catch(() => null);
+              const newSrc = json?.source?.contentUrl;
+              if (!newSrc) return;
+
+              const current = view.state.doc.nodeAt(replacePos);
+              if (!current || current.type.name !== 'image') return;
+              const altOverride = current.attrs.alt
+                ? {}
+                : { alt: altFromFilename(file.name) };
+              view.dispatch(
+                view.state.tr.setNodeMarkup(replacePos, null, {
+                  ...current.attrs,
+                  src: newSrc,
+                  ...altOverride,
+                }),
+              );
+              return;
+            }
+
+            // Insert path (no existing image at the drop point).
             const fpo = schema.nodes.image.create({ src: FPO_IMG_URL, style: 'width: 180px' });
             view.dispatch(view.state.tr.replaceSelectionWith(fpo).scrollIntoView());
 
             const { $from } = view.state.selection;
-
-            const url = `${details.origin}/source${details.parent}/.${details.name}/${file.name}`;
 
             const formData = new FormData();
             formData.append('data', file);

--- a/blocks/canvas/ew-image-overlay/ew-image-overlay-assets.css
+++ b/blocks/canvas/ew-image-overlay/ew-image-overlay-assets.css
@@ -1,0 +1,64 @@
+/* Styles for the AEM Assets selector dialog launched from <ew-image-overlay>.
+   Loaded into document head (light DOM) because the third-party asset
+   selector library renders inside `.ovl-assets-host` and relies on the host
+   element living in the same DOM tree as document-scoped styles. */
+
+dialog.ew-image-overlay-assets-dialog {
+  position: fixed;
+  top: 24px;
+  left: 24px;
+  right: 24px;
+  bottom: 24px;
+  width: auto;
+  height: auto;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 48px);
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 12px 48px rgb(0 0 0 / 30%);
+  overflow: hidden;
+}
+
+dialog.ew-image-overlay-assets-dialog::backdrop {
+  background: rgb(0 0 0 / 50%);
+}
+
+.ew-image-overlay-assets-frame {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.ew-image-overlay-assets-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: #eee;
+  color: #000;
+  font: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.ew-image-overlay-assets-close:hover {
+  background: #ccc;
+}
+
+.ew-image-overlay-assets-frame .ovl-assets-host {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+}

--- a/blocks/canvas/ew-image-overlay/ew-image-overlay.css
+++ b/blocks/canvas/ew-image-overlay/ew-image-overlay.css
@@ -1,0 +1,224 @@
+:host {
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 120;
+}
+
+.ovl-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background: var(--s2-gray-25);
+  border: 1px solid var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-300);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 18%);
+  pointer-events: auto;
+  position: relative;
+}
+
+.ovl-btn {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 8px;
+  border: none;
+  border-radius: var(--s2-corner-radius-100);
+  background: none;
+  color: var(--s2-gray-800);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ovl-btn:hover {
+  background: var(--s2-gray-200);
+}
+
+.ovl-btn[aria-expanded="true"] {
+  background: var(--s2-blue-200);
+  color: var(--s2-blue-900);
+}
+
+.ovl-btn-warn {
+  background: var(--s2-orange-200, #ffdcb9);
+  color: var(--s2-orange-900, #6b3500);
+}
+
+.ovl-btn-warn:hover {
+  background: var(--s2-orange-300, #ffc890);
+}
+
+.ovl-btn-close {
+  padding: 0;
+  width: 24px;
+  min-width: 24px;
+  justify-content: center;
+}
+
+.ovl-btn-label {
+  display: inline-block;
+  line-height: 1;
+}
+
+.ovl-icon {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+/* Replace popover (anchored to .ovl-bar) */
+
+.ovl-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
+  padding: 4px;
+  background: var(--s2-gray-25);
+  border: 1px solid var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-300);
+  box-shadow: 0 6px 24px rgb(0 0 0 / 18%);
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.ovl-popover-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 10px;
+  border: none;
+  border-radius: var(--s2-corner-radius-100);
+  background: none;
+  color: var(--s2-gray-800);
+  font: inherit;
+  font-size: 0.875rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ovl-popover-item:hover,
+.ovl-popover-item:focus-within {
+  background: var(--s2-gray-200);
+}
+
+.ovl-popover-item[disabled],
+.ovl-popover-item[disabled]:hover {
+  background: none;
+  color: var(--s2-gray-500);
+  cursor: not-allowed;
+}
+
+.ovl-popover-item .ovl-icon {
+  flex: 0 0 auto;
+}
+
+/* Modal dialogs (alt text, URL) */
+
+.ovl-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 40%);
+  pointer-events: auto;
+}
+
+.ovl-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-100);
+  padding: var(--s2-spacing-200);
+  min-width: 340px;
+  max-width: min(90vw, 480px);
+  background: var(--s2-gray-25);
+  border: 1px solid var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-500);
+  box-shadow: 0 8px 32px rgb(0 0 0 / 18%);
+}
+
+.ovl-form-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--s2-gray-900);
+}
+
+.ovl-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.75rem;
+  color: var(--s2-gray-700);
+}
+
+.ovl-form-field input {
+  box-sizing: border-box;
+  height: 32px;
+  padding: 0 var(--s2-spacing-100);
+  border: 1px solid var(--s2-gray-300);
+  border-radius: var(--s2-corner-radius-100);
+  background: var(--s2-gray-50);
+  color: var(--s2-gray-900);
+  font: inherit;
+  font-size: 0.875rem;
+}
+
+.ovl-form-field input:focus {
+  outline: 2px solid var(--s2-blue-600);
+  outline-offset: -1px;
+  border-color: transparent;
+}
+
+.ovl-form-actions {
+  display: flex;
+  gap: var(--s2-spacing-75);
+  justify-content: flex-end;
+  margin-top: var(--s2-spacing-50);
+}
+
+.ovl-btn-primary,
+.ovl-btn-secondary {
+  height: 32px;
+  padding: 0 16px;
+  border: none;
+  border-radius: var(--s2-corner-radius-800);
+  font: inherit;
+  font-size: var(--s2-body-size-s, 0.875rem);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ovl-btn-secondary {
+  background: var(--s2-gray-200);
+  color: var(--s2-gray-800);
+}
+
+.ovl-btn-secondary:hover {
+  background: var(--s2-gray-300);
+}
+
+.ovl-btn-primary {
+  background: var(--s2-blue-900);
+  color: light-dark(var(--s2-gray-25), #fff);
+}
+
+.ovl-btn-primary:hover {
+  background: var(--s2-blue-1000);
+}
+
+/* The AEM Assets selector modal lives in the document's light DOM (so the
+   third-party selector library's stylesheets apply correctly) — see
+   ew-image-overlay-assets.css for its styles. */

--- a/blocks/canvas/ew-image-overlay/ew-image-overlay.js
+++ b/blocks/canvas/ew-image-overlay/ew-image-overlay.js
@@ -1,0 +1,583 @@
+import { LitElement, html, nothing } from 'da-lit';
+import { getNx } from '../../../scripts/utils.js';
+import {
+  uploadImageToDa,
+  updateImageAttrs,
+  altFromFilename,
+  SUPPORTED_IMAGE_TYPES,
+} from '../editor-utils/image-ops.js';
+import { sourceUrlFromEditorCtx } from '../ew-editor-doc/utils/ctx.js';
+
+const { loadStyle, hashChange } = await import(`${getNx()}/utils/utils.js`);
+
+const styles = await loadStyle(import.meta.url);
+
+// Document-scoped stylesheet for the AEM Assets modal — see the file header.
+let assetsStyleLinked = false;
+function ensureAssetsStylesLoaded() {
+  if (assetsStyleLinked) return;
+  assetsStyleLinked = true;
+  const { href } = new URL('./ew-image-overlay-assets.css', import.meta.url);
+  if (document.querySelector(`link[data-ew-image-overlay-assets][href="${href}"]`)) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.dataset.ewImageOverlayAssets = '1';
+  document.head.append(link);
+}
+
+const ICON_ALT = 'tag';
+const ICON_REPLACE = 'imageadd';
+const ICON_LIBRARY = 'cclibrary';
+const ICON_UPLOAD = 'uploadtocloud';
+const ICON_URL = 'link';
+// Use a unicode glyph for close — no Spectrum stem is referenced elsewhere
+// in the canvas for this affordance.
+const CLOSE_GLYPH = '\u2715';
+
+const ALT_MAX_LENGTH = 250;
+
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:']);
+
+/**
+ * `ew-image-overlay` is the per-image action surface for Experience Workspace.
+ *
+ * It positions itself ABSOLUTELY against an anchor rect provided by the
+ * selection-toolbar plugin:
+ *   - Content/Split: the anchor is the image's own `<img>` element rect.
+ *   - Layout: the anchor is the iframe's bounding rect (we cannot read the
+ *     image's coordinates from the cross-origin preview iframe).
+ *
+ * It always uses `position: fixed` so it stays glued to the anchor as the
+ * page scrolls — we recompute the rect on every scroll/resize while visible.
+ */
+class EwImageOverlay extends LitElement {
+  static properties = {
+    view: { attribute: false },
+    /** 'content' | 'layout' — drives Replace-popover placement and corner. */
+    placement: { type: String },
+    /** Function returning the anchor element (image or iframe) — re-invoked each frame. */
+    getAnchor: { attribute: false },
+    _open: { state: true },
+    _replaceOpen: { state: true },
+    _altOpen: { state: true },
+    _urlOpen: { state: true },
+    _aemState: { state: true },
+    _assetsOpen: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.placement = 'content';
+    this._open = false;
+    this._replaceOpen = false;
+    this._altOpen = false;
+    this._urlOpen = false;
+    this._assetsOpen = false;
+    // Tri-state so the popover can show "Browse AEM Assets…" as a disabled
+    // item while we're still checking, instead of vanishing entirely.
+    //   'unknown'      → check in flight (or hash not yet set)
+    //   'available'    → site has aem.repositoryId configured
+    //   'unavailable'  → check completed, site has no AEM Assets config
+    this._aemState = 'unknown';
+    this._aemOrg = undefined;
+    this._aemSite = undefined;
+    this._rafId = 0;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [styles];
+    this._onOutside = (e) => this._handleOutsidePointer(e);
+    this._onKey = (e) => this._handleKey(e);
+    this._onScroll = () => this._scheduleReposition();
+    this._onResize = () => this._scheduleReposition();
+    document.addEventListener('pointerdown', this._onOutside, true);
+    document.addEventListener('keydown', this._onKey, true);
+    window.addEventListener('scroll', this._onScroll, true);
+    window.addEventListener('resize', this._onResize);
+    this._unsubHash = hashChange.subscribe((s) => this._refreshAemCapability(s));
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('pointerdown', this._onOutside, true);
+    document.removeEventListener('keydown', this._onKey, true);
+    window.removeEventListener('scroll', this._onScroll, true);
+    window.removeEventListener('resize', this._onResize);
+    this._unsubHash?.();
+    this._closeAssetsModal();
+    this._cancelRaf();
+  }
+
+  /* ---- Public API used by the selection-toolbar plugin ---- */
+
+  showFor({ view, placement, getAnchor }) {
+    this.view = view;
+    this.placement = placement ?? 'content';
+    this.getAnchor = getAnchor;
+    this._open = true;
+    this._scheduleReposition(true);
+  }
+
+  hide() {
+    this._open = false;
+    this._replaceOpen = false;
+    this._altOpen = false;
+    this._urlOpen = false;
+    this._closeAssetsModal();
+    this._cancelRaf();
+    this.style.visibility = 'hidden';
+  }
+
+  get isOpen() { return this._open; }
+
+  get isInteracting() {
+    return this._replaceOpen || this._altOpen || this._urlOpen || this._assetsOpen;
+  }
+
+  /* ---- Capability detection ---- */
+
+  async _refreshAemCapability(hashState) {
+    const { org, site } = hashState ?? {};
+    const key = org && site ? `${org}/${site}` : '';
+    if (key === this._aemCapKey) return;
+    this._aemCapKey = key;
+    this._aemOrg = org;
+    this._aemSite = site;
+    if (!key) {
+      this._aemState = 'unknown';
+      return;
+    }
+    this._aemState = 'unknown';
+    try {
+      const { hasAemAssetsConfig } = await import('../ew-panel-extensions/aem-assets.js');
+      const ok = await hasAemAssetsConfig({ org, site });
+      if (this._aemCapKey === key) this._aemState = ok ? 'available' : 'unavailable';
+    } catch {
+      if (this._aemCapKey === key) this._aemState = 'unavailable';
+    }
+  }
+
+  /* ---- Positioning ---- */
+
+  _cancelRaf() {
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = 0;
+    }
+  }
+
+  _scheduleReposition(immediate = false) {
+    if (!this._open) return;
+    if (immediate) {
+      this._reposition();
+      return;
+    }
+    if (this._rafId) return;
+    this._rafId = requestAnimationFrame(() => {
+      this._rafId = 0;
+      this._reposition();
+    });
+  }
+
+  _reposition() {
+    if (!this._open) return;
+    const anchor = this.getAnchor?.();
+    if (!anchor) {
+      this.style.visibility = 'hidden';
+      return;
+    }
+    const rect = anchor.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      // Anchor present but not laid out yet (e.g. detached image during a
+      // collab sync). Hide rather than render at (0,0).
+      this.style.visibility = 'hidden';
+      return;
+    }
+
+    this.style.position = 'fixed';
+    this.style.visibility = 'visible';
+    this.style.zIndex = '120';
+
+    // Place the toolbar at the TOP-RIGHT corner of the anchor, just inside it.
+    // For Layout (iframe anchor) we pin under the top edge so it's not
+    // obscured by the canvas header.
+    const top = Math.max(rect.top + 8, 8);
+    const right = Math.max(window.innerWidth - rect.right + 8, 8);
+    this.style.top = `${top}px`;
+    this.style.right = `${right}px`;
+    this.style.left = 'auto';
+    this.style.bottom = 'auto';
+  }
+
+  /* ---- Outside dismissal ---- */
+
+  _handleOutsidePointer(e) {
+    if (!this._open) return;
+    // When the AEM Assets selector is open, the underlying library frequently
+    // mounts secondary surfaces (file pickers, focus traps, etc.) outside our
+    // shadow root. Treat all pointer activity as belonging to that flow and
+    // never auto-dismiss while it's up — the user closes it via the X.
+    if (this._assetsOpen) return;
+    const path = e.composedPath();
+    if (path.includes(this)) return;
+    // A click on the anchor itself should not dismiss — the plugin will
+    // re-show on the next selection update anyway.
+    const anchor = this.getAnchor?.();
+    if (anchor && path.includes(anchor)) return;
+    // Outside the toolbar AND outside the anchor — close any popover/dialog.
+    if (this._replaceOpen || this._altOpen || this._urlOpen) {
+      this._replaceOpen = false;
+      this._altOpen = false;
+      this._urlOpen = false;
+    } else {
+      this.hide();
+    }
+  }
+
+  _handleKey(e) {
+    if (!this._open) return;
+    if (e.key !== 'Escape') return;
+    if (this._assetsOpen) {
+      this._assetsOpen = false;
+      e.stopPropagation();
+    } else if (this._altOpen || this._urlOpen) {
+      this._altOpen = false;
+      this._urlOpen = false;
+      e.stopPropagation();
+    } else if (this._replaceOpen) {
+      this._replaceOpen = false;
+      e.stopPropagation();
+    }
+  }
+
+  /* ---- Editor helpers ---- */
+
+  _getSourceUrl() {
+    const editorDoc = this.view?.dom?.closest?.('ew-editor-doc');
+    return sourceUrlFromEditorCtx(editorDoc?.ctx);
+  }
+
+  /** Resolve the selected `image` node and its position from the active view. */
+  _selectedImage() {
+    const sel = this.view?.state?.selection;
+    if (!sel) return null;
+    const node = sel.node ?? null;
+    if (node?.type?.name !== 'image') return null;
+    return { node, pos: sel.from };
+  }
+
+  /* ---- Actions ---- */
+
+  _onAltClick() {
+    this._replaceOpen = false;
+    this._altOpen = true;
+  }
+
+  _onReplaceClick() {
+    this._altOpen = false;
+    this._urlOpen = false;
+    this._replaceOpen = !this._replaceOpen;
+  }
+
+  _closeReplace() { this._replaceOpen = false; }
+
+  _onAltSubmit(e) {
+    e.preventDefault();
+    const image = this._selectedImage();
+    if (!image) {
+      this._altOpen = false;
+      return;
+    }
+    const raw = (e.target.elements['alt-text'].value || '').replace(/\s+/g, ' ').trim();
+    const next = raw.slice(0, ALT_MAX_LENGTH) || null;
+    this._altOpen = false;
+    updateImageAttrs(this.view, image.pos, { alt: next });
+  }
+
+  _resolveOrgSite() {
+    if (this._aemOrg && this._aemSite) {
+      return { org: this._aemOrg, site: this._aemSite };
+    }
+    // Fallback: hash listener hasn't populated us yet (custom-element upgrade
+    // and `hashChange.subscribe` haven't reconciled by the first user click).
+    // Parse `#/<org>/<site>/…` directly so the click still works.
+    const [org, site] = window.location.hash.replace(/^#\//, '').split('/');
+    return { org: org || undefined, site: site || undefined };
+  }
+
+  async _onReplaceAem() {
+    // Open the AEM Assets selector inside our own modal rather than routing
+    // through the tool-panel. This sidesteps two pitfalls:
+    //   1. The tool-panel's <dialog>.showModal() needs transient user
+    //      activation that can be lost across the await chain that opens the
+    //      side panel, syncs extension views, and mounts the dialog.
+    //   2. The tool-panel may not be open at all (Layout-only mode), in which
+    //      case the panel-open event also has to spin up the aside.
+    // The selector library mounts its own CSS and DOM into the host element
+    // and expects the host to live in light DOM (its stylesheets are scoped
+    // at the document level). We append the modal to document.body so the
+    // selector renders correctly.
+    this._closeReplace();
+    if (this._assetsOpen) return;
+    const { org, site } = this._resolveOrgSite();
+    if (!org || !site) {
+      // eslint-disable-next-line no-console
+      console.warn('[ew-image-overlay] Cannot open AEM Assets — missing org/site in hash');
+      return;
+    }
+    this._assetsOpen = true;
+    ensureAssetsStylesLoaded();
+    const modal = this._createAemModal();
+    document.body.append(modal);
+    this._assetsModal = modal;
+    try {
+      modal.showModal();
+    } catch (err) {
+      // Fall back to non-modal display if showModal() rejects (rare — happens
+      // when transient user activation has been consumed).
+      // eslint-disable-next-line no-console
+      console.warn('[ew-image-overlay] showModal failed, using open()', err);
+      modal.show();
+    }
+
+    // Surface progress in the modal so a slow / failed selector script load
+    // doesn't look like nothing happened.
+    const host = modal.querySelector('.ovl-assets-host');
+    host.textContent = 'Loading AEM Assets…';
+
+    try {
+      const { renderAssets, hasAemAssetsConfig } = await import('../ew-panel-extensions/aem-assets.js');
+      const configured = await hasAemAssetsConfig({ org, site });
+      if (!configured) {
+        host.textContent = 'AEM Assets is not configured for this site.';
+        return;
+      }
+      host.textContent = '';
+      await renderAssets({
+        container: host,
+        org,
+        site,
+        onClose: () => this._closeAssetsModal(),
+      });
+      // `renderAssets` resolves whether or not the selector actually rendered
+      // (it bails silently when there is no IMS token or repo config). If the
+      // host is still empty, surface that to the user.
+      if (!host.firstElementChild && !host.firstChild) {
+        host.textContent = 'Could not load AEM Assets — you may need to sign in to Adobe IMS.';
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[ew-image-overlay] AEM Assets selector failed to load', err);
+      host.textContent = `AEM Assets failed to load: ${err?.message || err}`;
+    }
+  }
+
+  _createAemModal() {
+    // Use a native <dialog>+showModal() — this is what the canvas tool-panel
+    // uses for its AEM Assets surface and is known to work with the third-
+    // party selector library. It also puts us in the top layer so we don't
+    // have to fight z-index against other canvas chrome.
+    const dialog = document.createElement('dialog');
+    dialog.className = 'ew-image-overlay-assets-dialog';
+    dialog.innerHTML = `
+      <div class="ew-image-overlay-assets-frame">
+        <button type="button" class="ew-image-overlay-assets-close" aria-label="Close" title="Close">${CLOSE_GLYPH}</button>
+        <div class="ovl-assets-host"></div>
+      </div>
+    `;
+    dialog.addEventListener('close', () => this._closeAssetsModal());
+    dialog.querySelector('.ew-image-overlay-assets-close')
+      .addEventListener('click', () => dialog.close());
+    return dialog;
+  }
+
+  _closeAssetsModal() {
+    this._assetsOpen = false;
+    if (this._assetsModal) {
+      try { if (this._assetsModal.open) this._assetsModal.close(); } catch { /* noop */ }
+      this._assetsModal.remove();
+      this._assetsModal = null;
+    }
+  }
+
+  async _onReplaceUpload(e) {
+    const input = e.target;
+    const file = input.files?.[0];
+    input.value = '';
+    this._closeReplace();
+    const image = this._selectedImage();
+    if (!file || !image) return;
+    if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) {
+      // eslint-disable-next-line no-console
+      console.warn('[ew-image-overlay] Unsupported image type:', file.type);
+      return;
+    }
+    const result = await uploadImageToDa({ file, sourceUrl: this._getSourceUrl() });
+    if (!result) return;
+    const altOverride = image.node.attrs.alt ? {} : { alt: altFromFilename(file.name) };
+    updateImageAttrs(this.view, image.pos, { src: result.src, ...altOverride });
+  }
+
+  _showUrlDialog() {
+    this._replaceOpen = false;
+    this._urlOpen = true;
+  }
+
+  _onUrlSubmit(e) {
+    e.preventDefault();
+    const image = this._selectedImage();
+    if (!image) {
+      this._urlOpen = false;
+      return;
+    }
+    const raw = (e.target.elements['image-src'].value || '').trim();
+    if (!raw) return;
+    try {
+      const u = new URL(raw, window.location.href);
+      if (!SAFE_URL_SCHEMES.has(u.protocol)) {
+        // eslint-disable-next-line no-console
+        console.warn('[ew-image-overlay] Unsafe URL scheme:', u.protocol);
+        return;
+      }
+    } catch { return; }
+    this._urlOpen = false;
+    updateImageAttrs(this.view, image.pos, { src: raw });
+  }
+
+  /* ---- Rendering ---- */
+
+  updated() {
+    if (this._open) this._reposition();
+  }
+
+  _icon(name) {
+    return html`<svg aria-hidden="true" class="ovl-icon" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-${name}-20-n.svg#icon"></use></svg>`;
+  }
+
+  _renderReplacePopover() {
+    if (!this._replaceOpen) return nothing;
+    const accept = SUPPORTED_IMAGE_TYPES.join(',');
+    // Always render the AEM Assets entry so its presence isn't gated on an
+    // in-flight capability check (which races the user opening the popover).
+    // Disable + tooltip when the site has no `aem.repositoryId` configured.
+    const aemUnavailable = this._aemState === 'unavailable';
+    const aemPending = this._aemState === 'unknown';
+    let aemTitle = 'Browse AEM Assets…';
+    if (aemUnavailable) aemTitle = 'AEM Assets is not configured for this site';
+    else if (aemPending) aemTitle = 'Checking AEM Assets availability…';
+    return html`
+      <div class="ovl-popover" role="menu"
+        @mousedown=${(e) => e.stopPropagation()}>
+        <button type="button" class="ovl-popover-item" role="menuitem"
+          ?disabled=${aemUnavailable}
+          title=${aemTitle}
+          @click=${() => this._onReplaceAem()}>
+          ${this._icon(ICON_LIBRARY)}<span>Browse AEM Assets…</span>
+        </button>
+        <label class="ovl-popover-item" role="menuitem">
+          ${this._icon(ICON_UPLOAD)}<span>Upload from computer…</span>
+          <input type="file" accept=${accept} hidden
+            @change=${(e) => this._onReplaceUpload(e)} />
+        </label>
+        <button type="button" class="ovl-popover-item" role="menuitem"
+          @click=${() => this._showUrlDialog()}>
+          ${this._icon(ICON_URL)}<span>Replace from URL…</span>
+        </button>
+      </div>
+    `;
+  }
+
+  _renderAltDialog() {
+    if (!this._altOpen) return nothing;
+    const image = this._selectedImage();
+    const existing = image?.node.attrs.alt ?? '';
+    return html`
+      <div class="ovl-modal"
+        @mousedown=${(e) => { if (e.target === e.currentTarget) { this._altOpen = false; } }}>
+        <form class="ovl-form" @submit=${(e) => this._onAltSubmit(e)}>
+          <div class="ovl-form-title">Alt text</div>
+          <label class="ovl-form-field">
+            <span>Describe the image for screen readers</span>
+            <input name="alt-text" type="text" maxlength=${ALT_MAX_LENGTH}
+                   autocomplete="off" autofocus
+                   placeholder="e.g. A red sports car on a mountain road"
+                   .value=${existing} />
+          </label>
+          <div class="ovl-form-actions">
+            <button type="button" class="ovl-btn-secondary"
+              @click=${() => { this._altOpen = false; }}>Cancel</button>
+            <button type="submit" class="ovl-btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    `;
+  }
+
+  _renderUrlDialog() {
+    if (!this._urlOpen) return nothing;
+    return html`
+      <div class="ovl-modal"
+        @mousedown=${(e) => { if (e.target === e.currentTarget) { this._urlOpen = false; } }}>
+        <form class="ovl-form" @submit=${(e) => this._onUrlSubmit(e)}>
+          <div class="ovl-form-title">Replace from URL</div>
+          <label class="ovl-form-field">
+            <span>Image URL</span>
+            <input name="image-src" type="url" placeholder="https://…"
+                   required autocomplete="off" autofocus />
+          </label>
+          <div class="ovl-form-actions">
+            <button type="button" class="ovl-btn-secondary"
+              @click=${() => { this._urlOpen = false; }}>Cancel</button>
+            <button type="submit" class="ovl-btn-primary">Replace</button>
+          </div>
+        </form>
+      </div>
+    `;
+  }
+
+  render() {
+    if (!this._open) return nothing;
+    const image = this._selectedImage();
+    const altMissing = image && !(image.node.attrs.alt ?? '').trim();
+    return html`
+      <div class="ovl-bar"
+        @mousedown=${(e) => e.preventDefault()}>
+        <button
+          type="button"
+          class="ovl-btn ${altMissing ? 'ovl-btn-warn' : ''}"
+          aria-label=${altMissing ? 'Add alt text (missing)' : 'Edit alt text'}
+          title=${altMissing ? 'Add alt text (missing)' : 'Edit alt text'}
+          @click=${() => this._onAltClick()}>
+          ${this._icon(ICON_ALT)}
+          <span class="ovl-btn-label">Alt</span>
+        </button>
+        <button
+          type="button"
+          class="ovl-btn"
+          aria-label="Replace image"
+          title="Replace image"
+          aria-haspopup="menu"
+          aria-expanded=${this._replaceOpen ? 'true' : 'false'}
+          @click=${() => this._onReplaceClick()}>
+          ${this._icon(ICON_REPLACE)}
+          <span class="ovl-btn-label">Replace</span>
+        </button>
+        <button
+          type="button"
+          class="ovl-btn ovl-btn-close"
+          aria-label="Close"
+          title="Close"
+          @click=${() => this.hide()}>${CLOSE_GLYPH}</button>
+        ${this._renderReplacePopover()}
+      </div>
+      ${this._renderAltDialog()}
+      ${this._renderUrlDialog()}
+    `;
+  }
+}
+
+customElements.define('ew-image-overlay', EwImageOverlay);
+
+export default EwImageOverlay;

--- a/blocks/canvas/ew-panel-extensions/aem-assets.js
+++ b/blocks/canvas/ew-panel-extensions/aem-assets.js
@@ -2,11 +2,16 @@
 import { DOMParser as PMDOMParser } from 'da-y-wrapper';
 import { getNx } from '../../../scripts/utils.js';
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
+import { getSelectedImage, updateImageAttrs } from '../editor-utils/image-ops.js';
 
 const { fetchDaConfigs, getFirstSheet } = await import(`${getNx()}/utils/daConfig.js`);
 
 const ASSET_SELECTOR_URL = 'https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/assets-selectors.js';
 const DEFAULT_BASE_PATH = '/adobe/assets';
+
+// Cache repository config per `org/site` so capability checks and the actual
+// selector load do not refetch every panel open.
+const repoConfigCache = new Map();
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -38,6 +43,25 @@ async function getRepositoryConfig(org, site) {
   const assetBasePath = getValue('aem.assets.prod.basepath') || DEFAULT_BASE_PATH;
 
   return { repositoryId, tierType, assetOrigin, assetBasePath, isDmEnabled };
+}
+
+async function getCachedRepositoryConfig(org, site) {
+  if (!org || !site) return null;
+  const key = `${org}/${site}`;
+  if (!repoConfigCache.has(key)) {
+    repoConfigCache.set(key, getRepositoryConfig(org, site).catch(() => null));
+  }
+  return repoConfigCache.get(key);
+}
+
+/**
+ * Capability check for the active site. Returns `true` when the site has an
+ * `aem.repositoryId` configured (any tier). Used to gate AEM-only UI such as
+ * the "Browse AEM Assets…" option in the image replace popover.
+ */
+export async function hasAemAssetsConfig({ org, site }) {
+  const cfg = await getCachedRepositoryConfig(org, site);
+  return !!cfg;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +172,14 @@ export async function renderAssets({ container, org, site, onClose }) {
       const src = resolveAssetUrl(asset, repoConfig);
       const mimetype = (asset.mimetype || asset['dc:format'] || '').toLowerCase();
       const alt = getAssetAlt(asset);
+      // Replace-in-place when an image is already selected: keep its existing
+      // alt/title/href/focal/sizing instead of wiping them via insertImage.
+      const existing = getSelectedImage(view.state);
+      if (existing && mimetype.startsWith('image/')) {
+        const altOverride = existing.node.attrs.alt ? {} : { alt: alt || null };
+        updateImageAttrs(view, existing.pos, { src, ...altOverride });
+        return;
+      }
       if (mimetype.startsWith('image/')) {
         insertImage(view, src, alt);
       } else {

--- a/test/unit/blocks/canvas/editor-utils/image-ops.test.js
+++ b/test/unit/blocks/canvas/editor-utils/image-ops.test.js
@@ -1,0 +1,147 @@
+import { expect } from '@esm-bundle/chai';
+import { NodeSelection, TextSelection } from 'da-y-wrapper';
+import { setNx } from '../../../../../scripts/utils.js';
+import { createTestEditor, destroyEditor } from '../../edit/prose/test-helpers.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const {
+  getSelectedImage,
+  updateImageAttrs,
+  altFromFilename,
+  uploadImageToDa,
+  SUPPORTED_IMAGE_TYPES,
+} = await import('../../../../../blocks/canvas/editor-utils/image-ops.js');
+
+function paragraphWithImage(view, attrs) {
+  const { schema } = view.state;
+  const img = schema.nodes.image.create(attrs);
+  const para = schema.nodes.paragraph.create(null, img);
+  const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, para);
+  view.dispatch(tr);
+}
+
+function selectImage(view) {
+  // Image is at position 1 (inside the paragraph at position 0).
+  const tr = view.state.tr.setSelection(NodeSelection.create(view.state.doc, 1));
+  view.dispatch(tr);
+}
+
+describe('image-ops · pure helpers', () => {
+  it('SUPPORTED_IMAGE_TYPES covers common web image MIME types', () => {
+    expect(SUPPORTED_IMAGE_TYPES).to.include.members([
+      'image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif',
+    ]);
+  });
+
+  it('altFromFilename handles common shapes', () => {
+    expect(altFromFilename('my-cool-photo.png')).to.equal('My cool photo');
+    expect(altFromFilename('hero_image.JPG')).to.equal('Hero image');
+    expect(altFromFilename('no-extension')).to.equal('No extension');
+    expect(altFromFilename('')).to.equal('');
+    expect(altFromFilename(undefined)).to.equal('');
+  });
+});
+
+describe('image-ops · getSelectedImage / updateImageAttrs', () => {
+  let editor;
+
+  beforeEach(async () => { editor = await createTestEditor(); });
+  afterEach(() => destroyEditor(editor));
+
+  it('returns null when no image is selected', () => {
+    expect(getSelectedImage(editor.view.state)).to.equal(null);
+  });
+
+  it('returns {node, pos} when an image NodeSelection is active', () => {
+    paragraphWithImage(editor.view, { src: '/a.png', alt: 'A' });
+    selectImage(editor.view);
+    const sel = getSelectedImage(editor.view.state);
+    expect(sel).to.not.equal(null);
+    expect(sel.node.type.name).to.equal('image');
+    expect(sel.node.attrs.src).to.equal('/a.png');
+    expect(sel.pos).to.equal(1);
+  });
+
+  it('returns null for a text selection even if cursor is next to an image', () => {
+    paragraphWithImage(editor.view, { src: '/a.png' });
+    const tr = editor.view.state.tr.setSelection(TextSelection.create(editor.view.state.doc, 0));
+    editor.view.dispatch(tr);
+    expect(getSelectedImage(editor.view.state)).to.equal(null);
+  });
+
+  it('updateImageAttrs swaps src while preserving other attrs', () => {
+    paragraphWithImage(editor.view, {
+      src: '/old.png',
+      alt: 'Caption',
+      title: 'Hover text',
+    });
+    selectImage(editor.view);
+    const ok = updateImageAttrs(editor.view, 1, { src: '/new.png' });
+    expect(ok).to.equal(true);
+    const node = editor.view.state.doc.nodeAt(1);
+    expect(node.attrs.src).to.equal('/new.png');
+    expect(node.attrs.alt).to.equal('Caption');
+    expect(node.attrs.title).to.equal('Hover text');
+  });
+
+  it('updateImageAttrs returns false when pos is not an image', () => {
+    paragraphWithImage(editor.view, { src: '/a.png' });
+    const ok = updateImageAttrs(editor.view, 0, { src: '/b.png' });
+    expect(ok).to.equal(false);
+  });
+});
+
+describe('image-ops · uploadImageToDa', () => {
+  let savedFetch;
+
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  function mockResp(body, status = 200) {
+    window.fetch = () => Promise.resolve(new Response(JSON.stringify(body), { status }));
+  }
+
+  const validSource = 'https://admin.da.live/source/org/repo/path/doc.html';
+
+  it('no-ops on unsupported MIME types', async () => {
+    const file = new File(['x'], 'evil.exe', { type: 'application/x-msdownload' });
+    const result = await uploadImageToDa({ file, sourceUrl: validSource });
+    expect(result).to.equal(null);
+  });
+
+  it('no-ops when sourceUrl is not a DA source URL', async () => {
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    const result = await uploadImageToDa({ file, sourceUrl: 'not-a-url' });
+    expect(result).to.equal(null);
+  });
+
+  it('returns {src} on successful upload', async () => {
+    mockResp({ source: { contentUrl: 'https://content.da.live/x.png' } });
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    const result = await uploadImageToDa({ file, sourceUrl: validSource });
+    expect(result).to.deep.equal({ src: 'https://content.da.live/x.png' });
+  });
+
+  it('returns null when the upload fails', async () => {
+    mockResp({}, 500);
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    const result = await uploadImageToDa({ file, sourceUrl: validSource });
+    expect(result).to.equal(null);
+  });
+
+  it('encodes the filename so path traversal characters are defanged', async () => {
+    let calledUrl = '';
+    window.fetch = (url) => {
+      calledUrl = String(url);
+      return Promise.resolve(new Response(
+        JSON.stringify({ source: { contentUrl: '/x.png' } }),
+        { status: 200 },
+      ));
+    };
+    const file = new File(['x'], '../etc/passwd.png', { type: 'image/png' });
+    await uploadImageToDa({ file, sourceUrl: validSource });
+    expect(calledUrl).to.not.include('../');
+    expect(calledUrl).to.include('..%2Fetc%2Fpasswd.png');
+  });
+});

--- a/test/unit/blocks/canvas/editor-utils/selection-toolbar.test.js
+++ b/test/unit/blocks/canvas/editor-utils/selection-toolbar.test.js
@@ -1,0 +1,60 @@
+import { expect } from '@esm-bundle/chai';
+import { NodeSelection, TextSelection } from 'da-y-wrapper';
+import { setNx } from '../../../../../scripts/utils.js';
+import { createTestEditor, destroyEditor } from '../../edit/prose/test-helpers.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { toolbarModeForSelection } = await import(
+  '../../../../../blocks/canvas/editor-utils/selection-toolbar.js'
+);
+
+function paragraphWithImage(view) {
+  const { schema } = view.state;
+  const img = schema.nodes.image.create({ src: '/a.png' });
+  const para = schema.nodes.paragraph.create(null, img);
+  view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, para));
+}
+
+describe('toolbarModeForSelection', () => {
+  let editor;
+  beforeEach(async () => { editor = await createTestEditor(); });
+  afterEach(() => destroyEditor(editor));
+
+  it('returns "image" for an image NodeSelection', () => {
+    paragraphWithImage(editor.view);
+    editor.view.dispatch(editor.view.state.tr.setSelection(
+      NodeSelection.create(editor.view.state.doc, 1),
+    ));
+    expect(toolbarModeForSelection(editor.view.state)).to.equal('image');
+  });
+
+  it('returns "text" for a caret/text selection', () => {
+    paragraphWithImage(editor.view);
+    editor.view.dispatch(editor.view.state.tr.setSelection(
+      TextSelection.create(editor.view.state.doc, 0),
+    ));
+    expect(toolbarModeForSelection(editor.view.state)).to.equal('text');
+  });
+
+  it('returns null for non-image NodeSelections (e.g. table)', () => {
+    // Build a table NodeSelection.
+    const { schema } = editor.view.state;
+    const tableSchema = schema.nodes.table;
+    if (!tableSchema) return; // schema may not include tables in some configs.
+    // Build a minimal table: 1 row × 1 cell × empty paragraph.
+    const para = schema.nodes.paragraph.create();
+    const cell = schema.nodes.table_cell.create(null, para);
+    const row = schema.nodes.table_row.create(null, cell);
+    const table = tableSchema.create(null, row);
+    editor.view.dispatch(editor.view.state.tr.replaceWith(
+      0,
+      editor.view.state.doc.content.size,
+      table,
+    ));
+    editor.view.dispatch(editor.view.state.tr.setSelection(
+      NodeSelection.create(editor.view.state.doc, 0),
+    ));
+    expect(toolbarModeForSelection(editor.view.state)).to.equal(null);
+  });
+});

--- a/test/unit/blocks/canvas/ew-editor-doc/imageDrop.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/imageDrop.test.js
@@ -1,0 +1,141 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+import { createTestEditor, destroyEditor } from '../../edit/prose/test-helpers.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const imageDropFactory = (await import(
+  '../../../../../blocks/canvas/ew-editor-doc/prose-plugins/imageDrop.js'
+)).default;
+
+const SOURCE_URL = 'https://admin.da.live/source/org/repo/path/page.html';
+
+let testSchema;
+
+before(async () => {
+  const { getSchema } = await import('da-parser');
+  testSchema = getSchema();
+});
+
+function makePlugin() {
+  return imageDropFactory(testSchema, () => SOURCE_URL);
+}
+
+const tick = (ms = 20) => new Promise((r) => { setTimeout(r, ms); });
+
+function paragraphWithImage(view, attrs) {
+  const { schema } = view.state;
+  const img = schema.nodes.image.create(attrs);
+  const para = schema.nodes.paragraph.create(null, img);
+  view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, para));
+}
+
+describe('canvas imageDrop · replace-in-place', () => {
+  let editor;
+  let savedFetch;
+
+  beforeEach(async () => {
+    editor = await createTestEditor({ additionalPlugins: [makePlugin()] });
+    savedFetch = window.fetch;
+  });
+
+  afterEach(() => {
+    destroyEditor(editor);
+    window.fetch = savedFetch;
+  });
+
+  it('preserves alt/title when a drop lands on an existing image', async () => {
+    paragraphWithImage(editor.view, {
+      src: '/old.png',
+      alt: 'Original alt',
+      title: 'Original title',
+    });
+
+    let uploadCalled = false;
+    window.fetch = () => {
+      uploadCalled = true;
+      return Promise.resolve(new Response(
+        JSON.stringify({ source: { contentUrl: 'https://content.da.live/new.png' } }),
+        { status: 200 },
+      ));
+    };
+
+    // Fake `posAtCoords` returning the image's position (pos 1 inside the paragraph).
+    editor.view.posAtCoords = () => ({ pos: 1, inside: 0 });
+
+    const file = new File(['x'], 'replacement.png', { type: 'image/png' });
+    const plugin = makePlugin();
+    const { drop } = plugin.props.handleDOMEvents;
+
+    let prevented = false;
+    await drop(editor.view, {
+      preventDefault: () => { prevented = true; },
+      clientX: 10,
+      clientY: 10,
+      dataTransfer: { files: [file] },
+    });
+    expect(prevented).to.equal(true);
+
+    // Wait for the upload promise + .json() + dispatch to settle.
+    await tick();
+
+    expect(uploadCalled).to.equal(true);
+    const node = editor.view.state.doc.nodeAt(1);
+    expect(node.attrs.src).to.equal('https://content.da.live/new.png');
+    expect(node.attrs.alt).to.equal('Original alt');
+    expect(node.attrs.title).to.equal('Original title');
+  });
+
+  it('derives alt from filename when the existing image had no alt', async () => {
+    paragraphWithImage(editor.view, { src: '/old.png' });
+
+    window.fetch = () => Promise.resolve(new Response(
+      JSON.stringify({ source: { contentUrl: 'https://content.da.live/new.png' } }),
+      { status: 200 },
+    ));
+
+    editor.view.posAtCoords = () => ({ pos: 1, inside: 0 });
+
+    const file = new File(['x'], 'mountain-view.png', { type: 'image/png' });
+    const plugin = makePlugin();
+    await plugin.props.handleDOMEvents.drop(editor.view, {
+      preventDefault: () => {},
+      clientX: 10,
+      clientY: 10,
+      dataTransfer: { files: [file] },
+    });
+    await tick();
+
+    const node = editor.view.state.doc.nodeAt(1);
+    expect(node.attrs.alt).to.equal('Mountain view');
+  });
+
+  it('falls through to the insert path when the drop is not on an image', async () => {
+    paragraphWithImage(editor.view, { src: '/keep.png', alt: 'Keep me' });
+
+    window.fetch = () => Promise.resolve(new Response(
+      JSON.stringify({ source: { contentUrl: 'https://content.da.live/inserted.png' } }),
+      { status: 200 },
+    ));
+
+    // Drop is not on any image position.
+    editor.view.posAtCoords = () => null;
+
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    const plugin = makePlugin();
+    await plugin.props.handleDOMEvents.drop(editor.view, {
+      preventDefault: () => {},
+      clientX: 10,
+      clientY: 10,
+      dataTransfer: { files: [file] },
+    });
+    await tick();
+
+    // The original image's src should still be present (untouched).
+    let foundOld = false;
+    editor.view.state.doc.descendants((node) => {
+      if (node.type.name === 'image' && node.attrs.src === '/keep.png') foundOld = true;
+    });
+    expect(foundOld).to.equal(true);
+  });
+});


### PR DESCRIPTION

## Description

Add an image-anchored overlay in Experience Workspace content/split mode that lets authors edit alt text and replace an image without opening the siderail. Replace offers Browse AEM Assets (capability-gated), upload from computer, and replace-from-URL, and preserves existing image attributes.

Layout-mode image editing is out of scope and will follow in a separate change.

## Related Issue

https://jira.corp.adobe.com/browse/SITES-45673

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Override scripts from Chrome dev tools and validated

## Screenshots (if appropriate):
<img width="1252" height="755" alt="Screenshot 2026-06-12 at 3 04 41 PM" src="https://github.com/user-attachments/assets/586d703e-2f55-4c9d-9c87-c774fc2beb35" />
<img width="1252" height="755" alt="Screenshot 2026-06-12 at 3 02 46 PM" src="https://github.com/user-attachments/assets/05f8626b-6eb8-4117-b0f8-2935659062cf" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
