### PR TITLE
fix: strip .html extension when unpublishing from browse

### DIFF
--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -445,10 +445,12 @@ export default class DaList extends LitElement {
 
       if (this._unpublish && this._confirmText === 'YES') {
         const { aem } = await getNx2Api();
-        const previewResp = await aem.unPreview(item.path);
+        // AEM resolves HTML pages by their extensionless path
+        const aemPath = item.path.endsWith('.html') ? item.path.slice(0, -5) : item.path;
+        const previewResp = await aem.unPreview(aemPath);
         if (!previewResp.ok) this._itemErrors.push({ ...item, message: 'Couldn\'t unpublish preview' });
 
-        const liveResp = await aem.unPublish(item.path);
+        const liveResp = await aem.unPublish(aemPath);
         if (!liveResp.ok) this._itemErrors.push({ ...item, message: 'Couldn\'t unpublish production' });
       }
       this._itemsRemaining -= 1;

--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -446,7 +446,7 @@ export default class DaList extends LitElement {
       if (this._unpublish && this._confirmText === 'YES') {
         const { aem } = await getNx2Api();
         // AEM resolves HTML pages by their extensionless path
-        const aemPath = item.path.endsWith('.html') ? item.path.slice(0, -5) : item.path;
+        const aemPath = item.ext === 'html' ? item.path.slice(0, -5) : item.path;
         const previewResp = await aem.unPreview(aemPath);
         if (!previewResp.ok) this._itemErrors.push({ ...item, message: 'Couldn\'t unpublish preview' });
 

--- a/test/fixtures/nx/public/utils/tree.js
+++ b/test/fixtures/nx/public/utils/tree.js
@@ -1,7 +1,13 @@
 export class Queue {
-  constructor() { this.items = []; }
+  constructor(callback) {
+    this.callback = callback;
+    this.items = [];
+  }
 
-  push(item) { this.items.push(item); }
+  push(item) {
+    this.items.push(item);
+    return this.callback ? this.callback(item) : undefined;
+  }
 
   shift() { return this.items.shift(); }
 }

--- a/test/unit/blocks/browse/da-list/da-list.test.js
+++ b/test/unit/blocks/browse/da-list/da-list.test.js
@@ -552,6 +552,42 @@ describe('DaList helpers', () => {
         source.move = origMove;
       }
     });
+
+    it('Unpublishes non-HTML items with their extension intact', async () => {
+      const { aem, source } = await getNx2Api();
+      const origUnPreview = aem.unPreview;
+      const origUnPublish = aem.unPublish;
+      const origMove = source.move;
+      const unpublished = [];
+      aem.unPreview = (path) => {
+        unpublished.push(path);
+        return { ok: true };
+      };
+      aem.unPublish = (path) => {
+        unpublished.push(path);
+        return { ok: true };
+      };
+      source.move = () => ({ ok: true });
+
+      try {
+        const el = makeList();
+        el._itemErrors = [];
+        el._listItems = [];
+        el._listItemPaths = new Set();
+        el._unpublish = true;
+        el._confirmText = 'YES';
+        el._selectedItems = [{ name: 'data', ext: 'json', path: '/org/site/data.json' }];
+
+        await el.handleConfirmDelete();
+
+        expect(unpublished).to.deep.equal(['/org/site/data.json', '/org/site/data.json']);
+        expect(el._itemErrors).to.deep.equal([]);
+      } finally {
+        aem.unPreview = origUnPreview;
+        aem.unPublish = origUnPublish;
+        source.move = origMove;
+      }
+    });
   });
 
   describe('drop flow', () => {

--- a/test/unit/blocks/browse/da-list/da-list.test.js
+++ b/test/unit/blocks/browse/da-list/da-list.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
-import { setNx } from '../../../../../scripts/utils.js';
+import { setNx, getNx2Api } from '../../../../../scripts/utils.js';
 
 setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
@@ -515,6 +515,42 @@ describe('DaList helpers', () => {
       // handleConfirmDelete uses queue.push but with empty list nothing happens.
       await el.handleConfirmDelete();
       expect(el._itemsRemaining).to.equal(0);
+    });
+
+    it('Unpublishes HTML items by their extensionless path', async () => {
+      const { aem, source } = await getNx2Api();
+      const origUnPreview = aem.unPreview;
+      const origUnPublish = aem.unPublish;
+      const origMove = source.move;
+      const unpublished = [];
+      aem.unPreview = (path) => {
+        unpublished.push(path);
+        return { ok: true };
+      };
+      aem.unPublish = (path) => {
+        unpublished.push(path);
+        return { ok: true };
+      };
+      source.move = () => ({ ok: true });
+
+      try {
+        const el = makeList();
+        el._itemErrors = [];
+        el._listItems = [];
+        el._listItemPaths = new Set();
+        el._unpublish = true;
+        el._confirmText = 'YES';
+        el._selectedItems = [{ name: 'doc', ext: 'html', path: '/org/site/doc.html' }];
+
+        await el.handleConfirmDelete();
+
+        expect(unpublished).to.deep.equal(['/org/site/doc', '/org/site/doc']);
+        expect(el._itemErrors).to.deep.equal([]);
+      } finally {
+        aem.unPreview = origUnPreview;
+        aem.unPublish = origUnPublish;
+        source.move = origMove;
+      }
     });
   });
 


### PR DESCRIPTION
Fix #1007

Test URL: https://unpubext--da-live--adobe.aem.live/

🤖 Generated with [Claude Code](https://claude.com/claude-code)