### PR TITLE
Allow setting branch for wysiwyg preview

### DIFF
--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -1,7 +1,7 @@
 import { TextSelection } from 'da-y-wrapper';
 import prose2aem from '../../shared/prose2aem.js';
 import { getNx } from '../../../scripts/utils.js';
-import { daFetch } from '../../shared/utils.js';
+import { daFetch, fetchDaConfigs } from '../../shared/utils.js';
 
 const { DA_CONTENT } = await import(`${getNx()}/utils/utils.js`);
 
@@ -308,19 +308,32 @@ export function updateCursors(ctx) {
 
 // --- preview.js ---
 
-export function getPreviewOrigin(org, repo) {
+export function getPreviewOrigin(org, repo, branch = 'main') {
   const hostname = window?.location?.hostname ?? '';
   const domain = hostname.endsWith('aem.page') || hostname.endsWith('localhost')
     ? 'stage-preview.da.live'
     : 'preview.da.live';
-  return `https://main--${repo}--${org}.${domain}`;
+  return `https://${branch}--${repo}--${org}.${domain}`;
 }
 
-export async function fetchWysiwygCookie({ org, repo, token }) {
+export async function fetchWysiwygBranch({ org, site }) {
+  if (!org || !site) return 'main';
+  try {
+    const [, siteConfig] = await Promise.all(fetchDaConfigs({ org, site }));
+    const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.wysiwygBranch');
+    const value = flag?.value?.trim();
+    return value || 'main';
+  } catch (e) {
+    if (!(e instanceof TypeError) && !(e instanceof SyntaxError)) throw e;
+  }
+  return 'main';
+}
+
+export async function fetchWysiwygCookie({ org, repo, token, branch = 'main' }) {
   if (!org || !repo || !token) {
     throw new Error('fetchWysiwygCookie: org, repo, and token required');
   }
-  const previewUrl = `${getPreviewOrigin(org, repo)}/gimme_cookie`;
+  const previewUrl = `${getPreviewOrigin(org, repo, branch)}/gimme_cookie`;
   const contentUrl = `${DA_CONTENT}/${org}/${repo}/.gimme_cookie`;
 
   const previewResp = await daFetch(previewUrl, { method: 'GET', credentials: 'include', headers: { Authorization: `Bearer ${token}` } });

--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -316,13 +316,24 @@ export function getPreviewOrigin(org, repo, branch = 'main') {
   return `https://${branch}--${repo}--${org}.${domain}`;
 }
 
-export async function fetchWysiwygBranch({ org, site }) {
+export async function fetchWysiwygBranch({ org, site, path }) {
   if (!org || !site) return 'main';
   try {
     const [, siteConfig] = await Promise.all(fetchDaConfigs({ org, site }));
-    const flag = siteConfig?.flags?.data?.find((f) => f.key === 'ew.wysiwygBranch');
-    const value = flag?.value?.trim();
-    return value || 'main';
+    const rows = siteConfig?.flags?.data?.filter((f) => f.key === 'ew.wysiwygBranch') ?? [];
+    if (!rows.length) return 'main';
+
+    const fullPath = path ? `/${path}` : `/${org}/${site}`;
+    const matched = rows
+      .map((row) => {
+        const eqIdx = row.value.indexOf('=');
+        if (eqIdx === -1) return null;
+        return { prefix: row.value.slice(0, eqIdx), branch: row.value.slice(eqIdx + 1).trim() };
+      })
+      .filter((entry) => entry?.branch && fullPath.startsWith(entry.prefix))
+      .sort((a, b) => b.prefix.length - a.prefix.length)[0];
+
+    return matched?.branch || 'main';
   } catch (e) {
     if (!(e instanceof TypeError) && !(e instanceof SyntaxError)) throw e;
   }

--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -1,7 +1,7 @@
 import { TextSelection } from 'da-y-wrapper';
 import prose2aem from '../../shared/prose2aem.js';
 import { getNx } from '../../../scripts/utils.js';
-import { daFetch, fetchDaConfigs } from '../../shared/utils.js';
+import { daFetch, fetchDaConfigs, getFirstSheet } from '../../shared/utils.js';
 
 const { DA_CONTENT } = await import(`${getNx()}/utils/utils.js`);
 
@@ -319,12 +319,13 @@ export function getPreviewOrigin(org, repo, branch = 'main') {
 export async function fetchWysiwygBranch({ org, site, path }) {
   if (!org || !site) return 'main';
   try {
-    const [, siteConfig] = await Promise.all(fetchDaConfigs({ org, site }));
-    const rows = siteConfig?.flags?.data?.filter((f) => f.key === 'ew.wysiwygBranch') ?? [];
-    if (!rows.length) return 'main';
+    const configs = await Promise.all(fetchDaConfigs({ org, site }));
+    const rows = configs.filter(Boolean).reverse().flatMap((c) => getFirstSheet(c) || []);
+    const branchRows = rows.filter((r) => r.key === 'ew.wysiwygBranch');
+    if (!branchRows.length) return 'main';
 
     const fullPath = path ? `/${path}` : `/${org}/${site}`;
-    const matched = rows
+    const matched = branchRows
       .map((row) => {
         const eqIdx = row.value.indexOf('=');
         if (eqIdx === -1) return null;

--- a/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
+++ b/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
@@ -118,7 +118,7 @@ export class EwEditorWysiwyg extends LitElement {
     const { org, repo, path } = this.ctx ?? {};
     if (!org || !repo || !path) return;
 
-    fetchWysiwygBranch({ org, site: repo }).then((branch) => {
+    fetchWysiwygBranch({ org, site: repo, path }).then((branch) => {
       this._wysiwygBranch = branch;
       return tryLoadWysiwygPreviewCookies({
         org,

--- a/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
+++ b/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
@@ -22,9 +22,7 @@ function buildQuickEditInitPayload({ org, repo, path, branch = 'main' }) {
   };
 }
 
-async function tryLoadWysiwygPreviewCookies({
-  org, repo, path, branch, getCurrentCtx,
-}) {
+async function tryLoadWysiwygPreviewCookies({ org, repo, path, branch, getCurrentCtx }) {
   try {
     const token = (await loadIms())?.accessToken?.token;
     if (!token) {

--- a/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
+++ b/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'da-lit';
 import { getNx } from '../../../scripts/utils.js';
-import { getPreviewOrigin, fetchWysiwygCookie } from '../editor-utils/editor-utils.js';
+import { getPreviewOrigin, fetchWysiwygCookie, fetchWysiwygBranch } from '../editor-utils/editor-utils.js';
 import { initIms as loadIms } from '../../shared/utils.js';
 import { hideSelectionToolbar } from '../editor-utils/selection-toolbar.js';
 
@@ -13,23 +13,25 @@ const QUICK_EDIT_INIT_MAX_ATTEMPTS = 25;
 
 const WYSIWYG_PORT_READY_ATTR = 'data-nx-wysiwyg-port-ready';
 
-function buildQuickEditInitPayload({ org, repo, path }) {
+function buildQuickEditInitPayload({ org, repo, path, branch = 'main' }) {
   const pathWithoutOrgRepo = path.split('/').slice(2).join('/');
   const pathname = pathWithoutOrgRepo ? `/${pathWithoutOrgRepo}` : '/';
   return {
-    config: { mountpoint: `${getPreviewOrigin(org, repo)}/${org}/${repo}` },
+    config: { mountpoint: `${getPreviewOrigin(org, repo, branch)}/${org}/${repo}` },
     location: { pathname },
   };
 }
 
-async function tryLoadWysiwygPreviewCookies({ org, repo, path, getCurrentCtx }) {
+async function tryLoadWysiwygPreviewCookies({
+  org, repo, path, branch, getCurrentCtx,
+}) {
   try {
     const token = (await loadIms())?.accessToken?.token;
     if (!token) {
       // eslint-disable-next-line no-console
       console.warn('[ew-editor-wysiwyg] Preview cookies: no auth token, proceeding without cookies');
     } else {
-      await fetchWysiwygCookie({ org, repo, token }).catch((e) => {
+      await fetchWysiwygCookie({ org, repo, token, branch }).catch((e) => {
         // eslint-disable-next-line no-console
         console.warn('[ew-editor-wysiwyg] Preview cookies failed, proceeding without cookies', e);
       });
@@ -72,7 +74,7 @@ export class EwEditorWysiwyg extends LitElement {
     const pathWithoutOrgRepo = segments.slice(2).join('/');
     const encodedPath = pathWithoutOrgRepo.split('/').map(encodeURIComponent).join('/');
     const quickEdit = new URLSearchParams(window.location.search).get('quick-edit') || 'on';
-    const base = `${getPreviewOrigin(org, repo)}/${encodedPath}?quick-edit=${encodeURIComponent(quickEdit)}`;
+    const base = `${getPreviewOrigin(org, repo, this._wysiwygBranch ?? 'main')}/${encodedPath}?quick-edit=${encodeURIComponent(quickEdit)}`;
     return `${base}&controller=parent`;
   }
 
@@ -116,11 +118,15 @@ export class EwEditorWysiwyg extends LitElement {
     const { org, repo, path } = this.ctx ?? {};
     if (!org || !repo || !path) return;
 
-    tryLoadWysiwygPreviewCookies({
-      org,
-      repo,
-      path,
-      getCurrentCtx: () => this.ctx,
+    fetchWysiwygBranch({ org, site: repo }).then((branch) => {
+      this._wysiwygBranch = branch;
+      return tryLoadWysiwygPreviewCookies({
+        org,
+        repo,
+        path,
+        branch,
+        getCurrentCtx: () => this.ctx,
+      });
     }).then((ok) => {
       if (!ok) return;
       this._cookieReady = true;
@@ -179,7 +185,7 @@ export class EwEditorWysiwyg extends LitElement {
     this._clearQuickEditRetry();
     this._syncCanvasVisibility();
 
-    const { config, location } = buildQuickEditInitPayload({ org, repo, path });
+    const { config, location } = buildQuickEditInitPayload({ org, repo, path, branch: this._wysiwygBranch ?? 'main' });
     const send = () => this._postQuickEditInitToIframe({
       iframe,
       config,

--- a/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
+++ b/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
@@ -46,8 +46,10 @@ describe('fetchWysiwygBranch', () => {
     return { org: `org-wbr-${testIndex}`, site: `site-wbr-${testIndex}`, ...extra };
   }
 
-  function mockConfig(flags) {
-    window.fetch = () => Promise.resolve(new Response(JSON.stringify({ flags }), { status: 200 }));
+  // Mocks the first sheet (json.data) — what getFirstSheet returns for a single-sheet config.
+  function mockConfig(rows) {
+    const body = JSON.stringify({ data: rows ?? [] });
+    window.fetch = () => Promise.resolve(new Response(body, { status: 200 }));
   }
 
   it('returns main when org is missing', async () => {
@@ -61,64 +63,58 @@ describe('fetchWysiwygBranch', () => {
   });
 
   it('returns the configured branch when path matches the prefix', async () => {
-    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '/org-wbr-3/site-wbr-3=feature' }] });
+    mockConfig([{ key: 'ew.wysiwygBranch', value: '/org-wbr-3/site-wbr-3=feature' }]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-3/site-wbr-3/some/doc' }));
     expect(branch).to.equal('feature');
   });
 
   it('picks the longest prefix when multiple entries match', async () => {
-    mockConfig({
-      data: [
-        { key: 'ew.wysiwygBranch', value: '/org-wbr-4/site-wbr-4=main' },
-        { key: 'ew.wysiwygBranch', value: '/org-wbr-4/site-wbr-4/docs=develop' },
-      ],
-    });
+    mockConfig([
+      { key: 'ew.wysiwygBranch', value: '/org-wbr-4/site-wbr-4=main' },
+      { key: 'ew.wysiwygBranch', value: '/org-wbr-4/site-wbr-4/docs=develop' },
+    ]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-4/site-wbr-4/docs/page' }));
     expect(branch).to.equal('develop');
   });
 
   it('falls back to the shorter prefix when path is outside the longer one', async () => {
-    mockConfig({
-      data: [
-        { key: 'ew.wysiwygBranch', value: '/org-wbr-5/site-wbr-5=main' },
-        { key: 'ew.wysiwygBranch', value: '/org-wbr-5/site-wbr-5/docs=develop' },
-      ],
-    });
+    mockConfig([
+      { key: 'ew.wysiwygBranch', value: '/org-wbr-5/site-wbr-5=main' },
+      { key: 'ew.wysiwygBranch', value: '/org-wbr-5/site-wbr-5/docs=develop' },
+    ]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-5/site-wbr-5/blog/post' }));
     expect(branch).to.equal('main');
   });
 
   it('trims whitespace from the branch value', async () => {
-    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '/org-wbr-6/site-wbr-6=  staging  ' }] });
+    mockConfig([{ key: 'ew.wysiwygBranch', value: '/org-wbr-6/site-wbr-6=  staging  ' }]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-6/site-wbr-6/page' }));
     expect(branch).to.equal('staging');
   });
 
   it('returns main when no prefix matches the path', async () => {
-    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '/other-org/other-site=feature' }] });
+    mockConfig([{ key: 'ew.wysiwygBranch', value: '/other-org/other-site=feature' }]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-7/site-wbr-7/page' }));
     expect(branch).to.equal('main');
   });
 
-  it('returns main when ew.wysiwygBranch flag is absent', async () => {
-    mockConfig({ data: [{ key: 'other.flag', value: 'true' }] });
+  it('returns main when ew.wysiwygBranch key is absent', async () => {
+    mockConfig([{ key: 'other.key', value: 'true' }]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-8/site-wbr-8/page' }));
     expect(branch).to.equal('main');
   });
 
-  it('returns main when flags sheet is missing', async () => {
-    mockConfig(undefined);
+  it('returns main when the sheet is empty', async () => {
+    mockConfig([]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-9/site-wbr-9/page' }));
     expect(branch).to.equal('main');
   });
 
   it('skips entries with no = separator', async () => {
-    mockConfig({
-      data: [
-        { key: 'ew.wysiwygBranch', value: 'malformed-no-equals' },
-        { key: 'ew.wysiwygBranch', value: '/org-wbr-10/site-wbr-10=valid' },
-      ],
-    });
+    mockConfig([
+      { key: 'ew.wysiwygBranch', value: 'malformed-no-equals' },
+      { key: 'ew.wysiwygBranch', value: '/org-wbr-10/site-wbr-10=valid' },
+    ]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-10/site-wbr-10/page' }));
     expect(branch).to.equal('valid');
   });

--- a/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
+++ b/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
@@ -1,0 +1,90 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+let getPreviewOrigin;
+let fetchWysiwygBranch;
+
+before(async () => {
+  const mod = await import('../../../../../blocks/canvas/editor-utils/editor-utils.js');
+  getPreviewOrigin = mod.getPreviewOrigin;
+  fetchWysiwygBranch = mod.fetchWysiwygBranch;
+});
+
+describe('getPreviewOrigin', () => {
+  it('uses main branch by default', () => {
+    const origin = getPreviewOrigin('myorg', 'myrepo');
+    expect(origin).to.include('main--myrepo--myorg');
+  });
+
+  it('uses the provided branch', () => {
+    const origin = getPreviewOrigin('myorg', 'myrepo', 'feature');
+    expect(origin).to.include('feature--myrepo--myorg');
+  });
+
+  it('uses main when branch is explicitly main', () => {
+    const origin = getPreviewOrigin('myorg', 'myrepo', 'main');
+    expect(origin).to.include('main--myrepo--myorg');
+  });
+});
+
+describe('fetchWysiwygBranch', () => {
+  let savedFetch;
+  let testIndex = 0;
+
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    testIndex += 1;
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+  });
+
+  function ctx() { return { org: `org-wbr-${testIndex}`, site: `site-wbr-${testIndex}` }; }
+
+  function mockConfig(flags) {
+    window.fetch = () => Promise.resolve(new Response(JSON.stringify({ flags }), { status: 200 }));
+  }
+
+  it('returns main when org is missing', async () => {
+    const branch = await fetchWysiwygBranch({ site: 'mysite' });
+    expect(branch).to.equal('main');
+  });
+
+  it('returns main when site is missing', async () => {
+    const branch = await fetchWysiwygBranch({ org: 'myorg' });
+    expect(branch).to.equal('main');
+  });
+
+  it('returns the configured branch from site flags', async () => {
+    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: 'feature' }] });
+    const branch = await fetchWysiwygBranch(ctx());
+    expect(branch).to.equal('feature');
+  });
+
+  it('trims whitespace from the configured branch value', async () => {
+    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '  staging  ' }] });
+    const branch = await fetchWysiwygBranch(ctx());
+    expect(branch).to.equal('staging');
+  });
+
+  it('returns main when ew.wysiwygBranch flag is absent', async () => {
+    mockConfig({ data: [{ key: 'other.flag', value: 'true' }] });
+    const branch = await fetchWysiwygBranch(ctx());
+    expect(branch).to.equal('main');
+  });
+
+  it('returns main when flags sheet is missing', async () => {
+    mockConfig(undefined);
+    const branch = await fetchWysiwygBranch(ctx());
+    expect(branch).to.equal('main');
+  });
+
+  it('returns main when flag value is empty string', async () => {
+    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '' }] });
+    const branch = await fetchWysiwygBranch(ctx());
+    expect(branch).to.equal('main');
+  });
+});

--- a/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
+++ b/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
@@ -42,7 +42,9 @@ describe('fetchWysiwygBranch', () => {
     window.fetch = savedFetch;
   });
 
-  function ctx() { return { org: `org-wbr-${testIndex}`, site: `site-wbr-${testIndex}` }; }
+  function ctx(extra = {}) {
+    return { org: `org-wbr-${testIndex}`, site: `site-wbr-${testIndex}`, ...extra };
+  }
 
   function mockConfig(flags) {
     window.fetch = () => Promise.resolve(new Response(JSON.stringify({ flags }), { status: 200 }));
@@ -58,33 +60,66 @@ describe('fetchWysiwygBranch', () => {
     expect(branch).to.equal('main');
   });
 
-  it('returns the configured branch from site flags', async () => {
-    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: 'feature' }] });
-    const branch = await fetchWysiwygBranch(ctx());
+  it('returns the configured branch when path matches the prefix', async () => {
+    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '/org-wbr-3/site-wbr-3=feature' }] });
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-3/site-wbr-3/some/doc' }));
     expect(branch).to.equal('feature');
   });
 
-  it('trims whitespace from the configured branch value', async () => {
-    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '  staging  ' }] });
-    const branch = await fetchWysiwygBranch(ctx());
+  it('picks the longest prefix when multiple entries match', async () => {
+    mockConfig({
+      data: [
+        { key: 'ew.wysiwygBranch', value: '/org-wbr-4/site-wbr-4=main' },
+        { key: 'ew.wysiwygBranch', value: '/org-wbr-4/site-wbr-4/docs=develop' },
+      ],
+    });
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-4/site-wbr-4/docs/page' }));
+    expect(branch).to.equal('develop');
+  });
+
+  it('falls back to the shorter prefix when path is outside the longer one', async () => {
+    mockConfig({
+      data: [
+        { key: 'ew.wysiwygBranch', value: '/org-wbr-5/site-wbr-5=main' },
+        { key: 'ew.wysiwygBranch', value: '/org-wbr-5/site-wbr-5/docs=develop' },
+      ],
+    });
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-5/site-wbr-5/blog/post' }));
+    expect(branch).to.equal('main');
+  });
+
+  it('trims whitespace from the branch value', async () => {
+    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '/org-wbr-6/site-wbr-6=  staging  ' }] });
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-6/site-wbr-6/page' }));
     expect(branch).to.equal('staging');
+  });
+
+  it('returns main when no prefix matches the path', async () => {
+    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '/other-org/other-site=feature' }] });
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-7/site-wbr-7/page' }));
+    expect(branch).to.equal('main');
   });
 
   it('returns main when ew.wysiwygBranch flag is absent', async () => {
     mockConfig({ data: [{ key: 'other.flag', value: 'true' }] });
-    const branch = await fetchWysiwygBranch(ctx());
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-8/site-wbr-8/page' }));
     expect(branch).to.equal('main');
   });
 
   it('returns main when flags sheet is missing', async () => {
     mockConfig(undefined);
-    const branch = await fetchWysiwygBranch(ctx());
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-9/site-wbr-9/page' }));
     expect(branch).to.equal('main');
   });
 
-  it('returns main when flag value is empty string', async () => {
-    mockConfig({ data: [{ key: 'ew.wysiwygBranch', value: '' }] });
-    const branch = await fetchWysiwygBranch(ctx());
-    expect(branch).to.equal('main');
+  it('skips entries with no = separator', async () => {
+    mockConfig({
+      data: [
+        { key: 'ew.wysiwygBranch', value: 'malformed-no-equals' },
+        { key: 'ew.wysiwygBranch', value: '/org-wbr-10/site-wbr-10=valid' },
+      ],
+    });
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-10/site-wbr-10/page' }));
+    expect(branch).to.equal('valid');
   });
 });


### PR DESCRIPTION
https://wysibr--da-live--adobe.aem.live

Format — each flags sheet row uses the same <path-prefix>=<branch-name> convention as editor.path:
  key: ew.wysiwygBranch
  value: /myorg/mysite=develop

  Multiple rows are supported:
  /myorg/mysite=develop
  /myorg/mysite/docs=feature-branch

  Matching — the path of the open document (e.g. /myorg/mysite/docs/page) is compared against all row prefixes via startsWith. The
  longest matching prefix wins. If nothing matches, it falls back to main.