### PR TITLE
fix(ew): Add superscript and subscript to selection toolbar

### DIFF
--- a/blocks/canvas/editor-utils/command-defs.js
+++ b/blocks/canvas/editor-utils/command-defs.js
@@ -77,6 +77,24 @@ export const COMMANDS = [
     active: (state) => markIsActive(state, 's'),
     apply: inlineMark('s'),
   },
+  {
+    id: 'sup',
+    label: 'Superscript',
+    schema: 'sup',
+    icon: iconName('TextSuperscript'),
+    showIn: ['toolbar-marks'],
+    active: (state) => markIsActive(state, 'sup'),
+    apply: inlineMark('sup'),
+  },
+  {
+    id: 'sub',
+    label: 'Subscript',
+    schema: 'sub',
+    icon: iconName('TextSubscript'),
+    showIn: ['toolbar-marks'],
+    active: (state) => markIsActive(state, 'sub'),
+    apply: inlineMark('sub'),
+  },
 
   // Toolbar: block-type picker
   {

--- a/test/fixtures/nx/blocks/shared/picker/picker.js
+++ b/test/fixtures/nx/blocks/shared/picker/picker.js
@@ -1,0 +1,5 @@
+class NxPicker extends HTMLElement {}
+
+if (!customElements.get('nx-picker')) {
+  customElements.define('nx-picker', NxPicker);
+}

--- a/test/fixtures/nx/blocks/shared/popover/popover.js
+++ b/test/fixtures/nx/blocks/shared/popover/popover.js
@@ -1,0 +1,5 @@
+class NxPopover extends HTMLElement {}
+
+if (!customElements.get('nx-popover')) {
+  customElements.define('nx-popover', NxPopover);
+}

--- a/test/unit/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.test.js
+++ b/test/unit/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.test.js
@@ -1,0 +1,66 @@
+import { expect } from '@esm-bundle/chai';
+import { TextSelection } from 'da-y-wrapper';
+import { setNx } from '../../../../../scripts/utils.js';
+import { createTestEditor, destroyEditor } from '../../edit/prose/test-helpers.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+describe('ew-selection-toolbar buttons', () => {
+  let editor;
+  let toolbar;
+
+  before(async () => {
+    await import('../../../../../blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js');
+  });
+
+  beforeEach(async () => {
+    editor = await createTestEditor();
+    toolbar = document.createElement('ew-selection-toolbar');
+    document.body.append(toolbar);
+    toolbar.view = editor.view;
+  });
+
+  after(() => {
+    toolbar?.remove();
+    destroyEditor(editor);
+  });
+
+  function setText(text) {
+    editor.view.dispatch(editor.view.state.tr.insertText(text));
+  }
+
+  function selectText(from, to) {
+    const selection = TextSelection.create(editor.view.state.doc, from, to);
+    editor.view.dispatch(editor.view.state.tr.setSelection(selection));
+  }
+
+  async function clickToolbarButton(id) {
+    const btn = toolbar.shadowRoot.querySelector(`button[data-id="${id}"]`);
+    expect(btn, `${id} button`).to.exist;
+    btn.click();
+    await toolbar.updateComplete;
+  }
+
+  function selectionHasMark(name) {
+    const { from, to } = editor.view.state.selection;
+    return editor.view.state.doc.rangeHasMark(from, to, editor.view.state.schema.marks[name]);
+  }
+
+  it('applies superscript to the selected range', async () => {
+    setText('hello');
+    selectText(1, 6);
+
+    await clickToolbarButton('sup');
+
+    expect(selectionHasMark('sup')).to.be.true;
+  });
+
+  it('applies subscript to the selected range', async () => {
+    setText('world');
+    selectText(1, 6);
+
+    await clickToolbarButton('sub');
+
+    expect(selectionHasMark('sub')).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description

fix: added `sup` and `sub` to `command-defs.js` so they appear in the selection toolbar marks group

+ unit tests for `ew-selection-toolbar` verifying that the superscript and subscript buttons apply the correct marks
+ minimal `nx-picker` and `nx-popover` test fixtures required to load the toolbar component in unit tests

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Open `/canvas#/{org}/{site}/{page}`.
2. Select some text.
3. Use sub & sup toolbar actions

<!--- Provide a general summary of your changes in the Title above -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
