### PR TITLE
feat: restrict explorer new item menu to folders-only at org level

### DIFF
--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -141,7 +141,8 @@ export default class DaBrowse extends LitElement {
       <da-new
         @newitem=${this.handleNewItem}
         fullpath="${this.details.fullpath}"
-        editor="${this.editor}">
+        editor="${this.editor}"
+        ?folderOnly=${this.isRootFolder(this.details.fullpath)}>
       </da-new>`;
   }
 

--- a/blocks/browse/da-new/da-new.js
+++ b/blocks/browse/da-new/da-new.js
@@ -14,6 +14,7 @@ export default class DaNew extends LitElement {
   static properties = {
     fullpath: { type: String },
     editor: { type: String },
+    folderOnly: { type: Boolean },
     permissions: { attribute: false },
     _createShow: { state: true },
     _createType: { state: true },
@@ -36,6 +37,17 @@ export default class DaNew extends LitElement {
   }
 
   handleCreateMenu() {
+    if (this.folderOnly) {
+      this._createShow = this._createShow === 'input' ? '' : 'input';
+      this._createType = 'folder';
+      if (this._createShow === 'input') {
+        setTimeout(() => {
+          const input = this.shadowRoot.querySelector('.da-actions-input');
+          input?.focus();
+        }, 500);
+      }
+      return;
+    }
     this._createShow = this._createShow === 'menu' ? '' : 'menu';
   }
 
@@ -170,23 +182,25 @@ export default class DaNew extends LitElement {
     return html`
       <div class="da-actions-create ${this._createShow}">
         <button class="da-actions-new-button" @click=${this.handleCreateMenu} ?disabled=${this._disabled}>New</button>
-        <ul class="da-actions-menu">
-          <li class=da-actions-menu-item>
-            <button data-type=folder @click=${this.handleNewType}>Folder</button>
-          </li>
-          <li class=da-actions-menu-item>
-            <button data-type=document @click=${this.handleNewType}>Document</button>
-          </li>
-          <li class=da-actions-menu-item>
-            <button data-type=sheet @click=${this.handleNewType}>Sheet</button>
-          </li>
-          <li class=da-actions-menu-item>
-            <button data-type=media @click=${this.handleNewType}>Media</button>
-          </li>
-          <li class=da-actions-menu-item>
-            <button data-type=link @click=${this.handleNewType}>Link</button>
-          </li>
-        </ul>
+        ${this.folderOnly ? '' : html`
+          <ul class="da-actions-menu">
+            <li class=da-actions-menu-item>
+              <button data-type=folder @click=${this.handleNewType}>Folder</button>
+            </li>
+            <li class=da-actions-menu-item>
+              <button data-type=document @click=${this.handleNewType}>Document</button>
+            </li>
+            <li class=da-actions-menu-item>
+              <button data-type=sheet @click=${this.handleNewType}>Sheet</button>
+            </li>
+            <li class=da-actions-menu-item>
+              <button data-type=media @click=${this.handleNewType}>Media</button>
+            </li>
+            <li class=da-actions-menu-item>
+              <button data-type=link @click=${this.handleNewType}>Link</button>
+            </li>
+          </ul>
+        `}
         <div class="da-actions-input-container">
           <input type="text" class="da-actions-input" placeholder="name" @input=${this.handleNameChange} .value=${this._createName || ''} @keydown=${this.handleKeyCommands}/>
           ${this._createType === 'link' ? html`<input type="text" class="da-actions-input" placeholder="url" @input=${this.handleUrlChange} .value=${this._externalUrl || ''} />` : ''}

--- a/test/unit/blocks/browse/da-new/da-new.test.js
+++ b/test/unit/blocks/browse/da-new/da-new.test.js
@@ -313,6 +313,30 @@ describe('DaNew', () => {
       el.handleCreateMenu();
       expect(el._createShow).to.equal('');
     });
+
+    it('Goes directly to folder input when folderOnly is set', () => {
+      const el = new DaNew();
+      Object.defineProperty(el, 'shadowRoot', {
+        configurable: true,
+        value: { querySelector: () => null },
+      });
+      el.folderOnly = true;
+      el.handleCreateMenu();
+      expect(el._createShow).to.equal('input');
+      expect(el._createType).to.equal('folder');
+    });
+
+    it('Toggles folder input closed when folderOnly is set and already open', () => {
+      const el = new DaNew();
+      Object.defineProperty(el, 'shadowRoot', {
+        configurable: true,
+        value: { querySelector: () => null },
+      });
+      el.folderOnly = true;
+      el.handleCreateMenu();
+      el.handleCreateMenu();
+      expect(el._createShow).to.equal('');
+    });
   });
 
   describe('handleNewType', () => {


### PR DESCRIPTION
## Summary

Customer reported they cannot edit a sheet created at the org level (da-admin cannot read the sheet). 2 solutions: fix da-admin or simply restrict the UI to only allow folder creation at the org level. This is implementing the latter.

- At the org level (path depth 1 — e.g. `#/org`), clicking **New** skips the type-picker dropdown and jumps straight to the folder name input, since the only valid thing to create there is a site/folder
- At site level and deeper (`#/org/site/...`) the full menu (Folder, Document, Sheet, Media, Link) is preserved unchanged
- Implemented via a new `folderOnly` boolean prop on `da-new`; `da-browse` derives the value from the existing `isRootFolder()` helper

## Test plan

- [ ] Navigate to an org (`#/org`) — click **New**, verify it goes directly to the name input with no dropdown
- [ ] Navigate to a site (`#/org/site`) — click **New**, verify the full Folder/Document/Sheet/Media/Link menu appears
- [ ] Create a folder from the org level and confirm it appears in the list
- [ ] `npm test` passes (1454 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)