### PR TITLE
test(playwright): run playwright tests with Helix 6

### DIFF
--- a/.github/workflows/playwright-hlx.yml
+++ b/.github/workflows/playwright-hlx.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Playwright Tests (Helix)
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/playwright-hlx.yml
+++ b/.github/workflows/playwright-hlx.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run Playwright tests
       env:
         TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-      run: cd test/e2e && TEST_SITE=da-e2e-tests npm run test:all
+      run: cd test/e2e && TEST_ORG=da-testautomation TEST_SITE=da-e2e-tests npm run test:all
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/.github/workflows/playwright-hlx.yml
+++ b/.github/workflows/playwright-hlx.yml
@@ -1,0 +1,41 @@
+name: Playwright Tests
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: cd test/e2e && npm ci
+    - name: Install Playwright Browsers
+      run: cd test/e2e && npx playwright install --with-deps
+    - name: Run Playwright tests
+      env:
+        TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      run: cd test/e2e && TEST_SITE=da-e2e-tests npm run test:all
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: test/e2e/playwright-report/
+        retention-days: 30
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: screenshots
+        path: test/e2e/.playwright/shots/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Playwright Tests (Da-Admin)
 on:
   workflow_dispatch:
   push:

--- a/test/e2e/tests/authenticated/acl_browse.spec.js
+++ b/test/e2e/tests/authenticated/acl_browse.spec.js
@@ -11,9 +11,10 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../../utils/env.js';
-import { getTestPageURL, getQuery, tabBackward, fill } from '../../utils/page.js';
+import { getTestPageURL, getQuery, tabBackward, fill, TEST_SITE } from '../../utils/page.js';
 
 test('Read-only directory', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir`;
 
   await page.goto(url);
@@ -35,6 +36,7 @@ test('Read-only directory', async ({ page }) => {
 });
 
 test('Read-write directory', async ({ browser, page }, workerInfo) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   test.setTimeout(60000);
   const pageURL = getTestPageURL('acl-browse-edt', workerInfo, '/da-testautomation/acltest/testdocs/subdir/subdir1');
   const pageName = pageURL.split('/').pop();
@@ -90,6 +92,7 @@ test('Read-write directory', async ({ browser, page }, workerInfo) => {
 });
 
 test('Readonly directory with writeable document', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const browseURL = `${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir/subdir2`;
   await page.goto(browseURL);
 
@@ -110,6 +113,7 @@ test('Readonly directory with writeable document', async ({ page }) => {
 });
 
 test('No access directory should not show anything', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   await page.goto(`${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir`);
 
   // In this directory we should be able to see files

--- a/test/e2e/tests/authenticated/acl_doc.spec.js
+++ b/test/e2e/tests/authenticated/acl_doc.spec.js
@@ -11,9 +11,10 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../../utils/env.js';
-import { getQuery } from '../../utils/page.js';
+import { getQuery, TEST_SITE } from '../../utils/page.js';
 
 test('Read-only document directly configured', async ({ page }, workerInfo) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/readonly-doc`;
 
   await page.goto(url);
@@ -38,6 +39,7 @@ test('Read-only document directly configured', async ({ page }, workerInfo) => {
 });
 
 test('Read-only document indirectly configured', async ({ page }, workerInfo) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/subdir/onlyread-doc`;
 
   await page.goto(url);
@@ -62,6 +64,7 @@ test('Read-only document indirectly configured', async ({ page }, workerInfo) =>
 });
 
 test('Read-write document', async ({ page }, workerInfo) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/readwrite-doc`;
 
   await page.goto(url);
@@ -82,6 +85,7 @@ test('Read-write document', async ({ page }, workerInfo) => {
 });
 
 test('No access at all', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/noaccess-doc`;
 
   await page.goto(url);

--- a/test/e2e/tests/authenticated/acl_versions.spec.js
+++ b/test/e2e/tests/authenticated/acl_versions.spec.js
@@ -11,9 +11,10 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../../utils/env.js';
-import { getQuery } from '../../utils/page.js';
+import { getQuery, TEST_SITE } from '../../utils/page.js';
 
 test('Can read versions of read-write document', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/dir-readwrite/doc-rw`;
 
   await page.goto(url);
@@ -39,6 +40,7 @@ test('Can read versions of read-write document', async ({ page }) => {
 });
 
 test('Cannot read versions of read-only document', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/dir-readonly/doc-r`;
 
   await page.goto(url);
@@ -64,6 +66,7 @@ test('Cannot read versions of read-only document', async ({ page }) => {
 });
 
 test('Cannot access versions of no-access document', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   const url = `${ENV}/edit${getQuery()}#/da-testautomation/acltest/testdocs/dir-noaccess/doc-nope`;
 
   await page.goto(url);

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -100,8 +100,8 @@ test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo)
   // Convert the editor URL (…#/<org>/<site>/<path>) into the da-admin/Helix source URL.
   const [, org, site, ...rest] = pageURL.split('#')[1].split('/');
   let sourceUrl;
-  if (TEST_SITE == 'da-status') {
-    sourceUrl = 'https://admin.da.live/source/${otg}/${site}/${rest.join('/')}.html';
+  if (TEST_SITE === 'da-status') {
+    sourceUrl = `https://admin.da.live/source/${org}/${site}/${rest.join('/')}.html`;
   } else {
     sourceUrl = `https://api.aem.live/${org}/sites/${site}/source/${rest.join('/')}.html`;
   }

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -12,7 +12,8 @@
 import { test, expect } from '@playwright/test';
 import { getTestPageURL, fill, TEST_SITE } from '../../utils/page.js';
 
-test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo) => {
+test('Collab cursors in multiple editors', async ({ browser, page, browserName }, workerInfo) => {
+  test.skip(browserName !== 'chromium', 'Collab test only runs on Chrome');
   // Open 2 editors on the same page and edit in both of them.
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -13,7 +13,6 @@ import { test, expect } from '@playwright/test';
 import { getTestPageURL, fill, TEST_SITE } from '../../utils/page.js';
 
 test('Collab cursors in multiple editors', async ({ browser, page, browserName }, workerInfo) => {
-  test.skip(browserName !== 'chromium', 'Collab test only runs on Chrome');
   // Open 2 editors on the same page and edit in both of them.
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator
@@ -97,6 +96,9 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   expect(cursorIdx).toBeLessThan(textIdx);
   expect(textIdx2).toBeLessThan(cursorIdx);
 
+  // Wait for debounce to happen and changes to be saved
+  await page.waitForTimeout(4000);
+
   // Check with the backend that the edits came through and are stored there.
   // Convert the editor URL (…#/<org>/<site>/<path>) into the da-admin/Helix source URL.
   const [, org, site, ...rest] = pageURL.split('#')[1].split('/');
@@ -107,7 +109,7 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
     sourceUrl = `https://api.aem.live/${org}/sites/${site}/source/${rest.join('/')}.html`;
   }
 
-  console.log('*** Checking ', sourceUrl, ' with auth header ', authHeader?.substring(0, 30));
+  console.log('Checking backend at ', sourceUrl);
   const resp = await page.request.get(sourceUrl, { headers: { Authorization: authHeader } });
   const body = await resp.text();
 

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -37,7 +37,7 @@ test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo)
 
   await expect(page.locator('div.ProseMirror')).toBeVisible();
   await expect(page.locator('div.ProseMirror')).toHaveAttribute('contenteditable', 'true');
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(3000);
   await fill(page, 'Entered by user 1');
 
   // Right now there should not be any collab indicators yet

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -106,6 +106,8 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   } else {
     sourceUrl = `https://api.aem.live/${org}/sites/${site}/source/${rest.join('/')}.html`;
   }
+
+  console.log('*** Checking ', sourceUrl, ' with auth header ', authHeader?.substring(0, 30));
   const resp = await page.request.get(sourceUrl, { headers: { Authorization: authHeader } });
   const body = await resp.text();
 

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -17,6 +17,8 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator
 
+  test.setTimeout(60000);
+
   const pageURL = getTestPageURL('collab', workerInfo);
 
   // Capture the Bearer token that da-live's daFetch attaches to its backend

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -10,15 +10,23 @@
  * governing permissions and limitations under the License.
  */
 import { test, expect } from '@playwright/test';
-import { getTestPageURL, fill } from '../../utils/page.js';
+import { getTestPageURL, fill, TEST_SITE } from '../../utils/page.js';
 
 test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo) => {
-  // Open 2 editors on the same page and edit in both of them. One editor is logged in,
-  // the other isn't.
+  // Open 2 editors on the same page and edit in both of them.
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator
 
   const pageURL = getTestPageURL('collab', workerInfo);
+
+  // Capture the Bearer token that da-live's daFetch attaches to its backend
+  // requests, so we can reuse the exact same Authorization header below.
+  let authHeader;
+  page.on('request', (request) => {
+    const auth = request.headers().authorization;
+    if (auth?.startsWith('Bearer ') && !authHeader) authHeader = auth;
+  });
+
   await page.goto(pageURL);
   await page.waitForTimeout(2000);
   await page.getByText('Create document', { exact: true }).click();
@@ -87,4 +95,19 @@ test('Collab cursors in multiple editors', async ({ browser, page }, workerInfo)
   expect(cursorIdx).toBeGreaterThanOrEqual(0);
   expect(cursorIdx).toBeLessThan(textIdx);
   expect(textIdx2).toBeLessThan(cursorIdx);
+
+  // Check with the backend that the edits came through and are stored there.
+  // Convert the editor URL (…#/<org>/<site>/<path>) into the da-admin/Helix source URL.
+  const [, org, site, ...rest] = pageURL.split('#')[1].split('/');
+  let sourceUrl;
+  if (TEST_SITE == 'da-status') {
+    sourceUrl = 'https://admin.da.live/source/${otg}/${site}/${rest.join('/')}.html';
+  } else {
+    sourceUrl = `https://api.aem.live/${org}/sites/${site}/source/${rest.join('/')}.html`;
+  }
+  const resp = await page.request.get(sourceUrl, { headers: { Authorization: authHeader } });
+  const body = await resp.text();
+
+  const expected = '<main><div><p>From user 2Entered by user 1</p></div></main>';
+  expect(body).toContain(expected);
 });

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -11,15 +11,17 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
-import { getQuery, getTestFolderURL, getTestPageURL, fill, TEST_SITE } from '../utils/page.js';
+import {
+  getQuery, getTestFolderURL, getTestPageURL, fill, TEST_ORG, TEST_SITE,
+} from '../utils/page.js';
 
 test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => {
   test.skip(
-    TEST_SITE !== 'da-status', 
+    TEST_SITE !== 'da-status',
     `
 On Helix 6 the copy and paste from one folder to another doesn't work yet, it fails on this line: 
 const link = await page.getByRole('link', { name: orgPageName });
-    `
+    `,
   );
 
   // This test has a fairly high timeout because it waits for the document to be saved
@@ -58,7 +60,7 @@ const link = await page.getByRole('link', { name: orgPageName });
   await page.waitForTimeout(5000);
 
   // Go back to the directory view
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
 
   const copyFolderURL = getTestFolderURL('copy', workerInfo);
   const copyFolderName = copyFolderURL.split('/').pop();
@@ -74,18 +76,18 @@ const link = await page.getByRole('link', { name: orgPageName });
   await page.getByRole('button', { name: 'Copy' }).click();
 
   await page.getByRole('link', { name: copyFolderName }).click();
-  await page.waitForURL(`**/da-sites/${TEST_SITE}/tests/${copyFolderName}`);
+  await page.waitForURL(`**/${TEST_ORG}/${TEST_SITE}/tests/${copyFolderName}`);
 
   await page.getByRole('button', { name: 'Paste' }).click();
   await page.waitForTimeout(3000);
   /* TODO REMOVE once #233 is fixed */ await page.reload();
   const link = await page.getByRole('link', { name: orgPageName });
   const href = await link.getAttribute('href');
-  await expect(href).toEqual(`/edit#/da-sites/${TEST_SITE}/tests/${copyFolderName}/${orgPageName}`);
+  await expect(href).toEqual(`/edit#/${TEST_ORG}/${TEST_SITE}/tests/${copyFolderName}/${orgPageName}`);
 
   // go back to the original to rename it
   // Go to the directory view
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
   await page.reload(); // Clears any leftover selection, if any
 
   const checkbox = page.locator('div.da-item-list-item-inner').filter({ hasText: orgPageName })
@@ -119,7 +121,7 @@ const link = await page.getByRole('link', { name: orgPageName });
   await expect(page.locator('div.ProseMirror')).toContainText('Versioned text');
 
   // now go to the copy
-  await page.goto(`${ENV}/edit${getQuery()}#/da-sites/${TEST_SITE}/tests/${copyFolderName}/${orgPageName}`);
+  await page.goto(`${ENV}/edit${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests/${copyFolderName}/${orgPageName}`);
   await page.reload(); // Resets the versions view, shouldn't be needed TODO
   await expect(page.locator('div.ProseMirror')).toContainText('After versioned');
   await page.getByRole('button', { name: 'Versions' }).click();

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -11,9 +11,17 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
-import { getQuery, getTestFolderURL, getTestPageURL, fill } from '../utils/page.js';
+import { getQuery, getTestFolderURL, getTestPageURL, fill, TEST_SITE } from '../utils/page.js';
 
 test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => {
+  test.skip(
+    TEST_SITE !== 'da-status', 
+    `
+On Helix 6 the copy and paste from one folder to another doesn't work yet, it fails on this line: 
+const link = await page.getByRole('link', { name: orgPageName });
+    `
+  );
+
   // This test has a fairly high timeout because it waits for the document to be saved
   // a number of times
   test.setTimeout(60000);
@@ -50,7 +58,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await page.waitForTimeout(5000);
 
   // Go back to the directory view
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
 
   const copyFolderURL = getTestFolderURL('copy', workerInfo);
   const copyFolderName = copyFolderURL.split('/').pop();
@@ -66,18 +74,18 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await page.getByRole('button', { name: 'Copy' }).click();
 
   await page.getByRole('link', { name: copyFolderName }).click();
-  await page.waitForURL(`**/da-sites/da-status/tests/${copyFolderName}`);
+  await page.waitForURL(`**/da-sites/${TEST_SITE}/tests/${copyFolderName}`);
 
   await page.getByRole('button', { name: 'Paste' }).click();
   await page.waitForTimeout(3000);
   /* TODO REMOVE once #233 is fixed */ await page.reload();
   const link = await page.getByRole('link', { name: orgPageName });
   const href = await link.getAttribute('href');
-  await expect(href).toEqual(`/edit#/da-sites/da-status/tests/${copyFolderName}/${orgPageName}`);
+  await expect(href).toEqual(`/edit#/da-sites/${TEST_SITE}/tests/${copyFolderName}/${orgPageName}`);
 
   // go back to the original to rename it
   // Go to the directory view
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
   await page.reload(); // Clears any leftover selection, if any
 
   const checkbox = page.locator('div.da-item-list-item-inner').filter({ hasText: orgPageName })
@@ -111,7 +119,7 @@ test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => 
   await expect(page.locator('div.ProseMirror')).toContainText('Versioned text');
 
   // now go to the copy
-  await page.goto(`${ENV}/edit${getQuery()}#/da-sites/da-status/tests/${copyFolderName}/${orgPageName}`);
+  await page.goto(`${ENV}/edit${getQuery()}#/da-sites/${TEST_SITE}/tests/${copyFolderName}/${orgPageName}`);
   await page.reload(); // Resets the versions view, shouldn't be needed TODO
   await expect(page.locator('div.ProseMirror')).toContainText('After versioned');
   await page.getByRole('button', { name: 'Versions' }).click();

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -12,7 +12,7 @@
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
 import {
-  getQuery, getTestPageURL, getTestResourceAge, tabBackward, fill, TEST_SITE,
+  getQuery, getTestPageURL, getTestResourceAge, tabBackward, fill, TEST_ORG, TEST_SITE,
 } from '../utils/page.js';
 
 // Files are deleted after 2 hours by default
@@ -31,7 +31,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   test.setTimeout(600000);
 
   // Open the directory listing
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
 
   // This page will always be there as its used by a test
   await expect(page.getByText('pingtest'), 'Precondition').toBeVisible();
@@ -115,14 +115,14 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await page.close();
 
   const list = await browser.newPage();
-  await list.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await list.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
 
   await list.waitForTimeout(3000);
   await list.reload();
 
   // Now delete the document
-  await expect(list.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`)).toBeVisible();
-  await list.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`).focus();
+  await expect(list.locator(`a[href="/edit#/${TEST_ORG}/${TEST_SITE}/tests/${pageName}"]`)).toBeVisible();
+  await list.locator(`a[href="/edit#/${TEST_ORG}/${TEST_SITE}/tests/${pageName}"]`).focus();
   await tabBackward(list);
   await list.keyboard.press(' ');
   await list.waitForTimeout(500);

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -11,7 +11,9 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
-import { getQuery, getTestPageURL, getTestResourceAge, tabBackward, fill } from '../utils/page.js';
+import {
+  getQuery, getTestPageURL, getTestResourceAge, tabBackward, fill, TEST_SITE,
+} from '../utils/page.js';
 
 // Files are deleted after 2 hours by default
 const MIN_HOURS = process.env.PW_DELETE_HOURS ? Number(process.env.PW_DELETE_HOURS) : 2;
@@ -29,7 +31,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   test.setTimeout(600000);
 
   // Open the directory listing
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
 
   // This page will always be there as its used by a test
   await expect(page.getByText('pingtest'), 'Precondition').toBeVisible();
@@ -86,6 +88,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
 });
 
 test('Empty out open editors on deleted documents', async ({ browser, page }, workerInfo) => {
+  test.skip(TEST_SITE !== 'da-status', 'Empty out open editors on deleted documents doesn\'t work yet in Helix 6');
   test.setTimeout(60000);
 
   const url = getTestPageURL('delete', workerInfo);
@@ -110,14 +113,14 @@ test('Empty out open editors on deleted documents', async ({ browser, page }, wo
   await page.close();
 
   const list = await browser.newPage();
-  await list.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
+  await list.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
 
   await list.waitForTimeout(3000);
   await list.reload();
 
   // Now delete the document
-  await expect(list.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).toBeVisible();
-  await list.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`).focus();
+  await expect(list.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`)).toBeVisible();
+  await list.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`).focus();
   await tabBackward(list);
   await list.keyboard.press(' ');
   await list.waitForTimeout(500);

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -11,7 +11,7 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
-import { getQuery, getTestPageURL, tabBackward, fill } from '../utils/page.js';
+import { getQuery, getTestPageURL, tabBackward, fill, TEST_SITE } from '../utils/page.js';
 
 test('Update Document', async ({ browser, page }, workerInfo) => {
   test.setTimeout(30000);
@@ -42,7 +42,7 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   const url = getTestPageURL('edit2', workerInfo);
   const pageName = url.split('/').pop();
 
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
   await page.locator('button.da-actions-new-button').click();
   await page.locator('button:text("Document")').click();
   await page.locator('input.da-actions-input').fill(pageName);
@@ -56,13 +56,13 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   await page.waitForTimeout(1000);
 
   const newPage = await browser.newPage();
-  await newPage.goto(`${ENV}/${getQuery()}#/da-sites/da-status/tests`);
+  await newPage.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
 
   await newPage.waitForTimeout(3000);
   await newPage.reload();
 
-  await expect(newPage.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).toBeVisible();
-  await newPage.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`).focus();
+  await expect(newPage.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`)).toBeVisible();
+  await newPage.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`).focus();
   await tabBackward(newPage);
   await newPage.keyboard.press(' ');
   await newPage.waitForTimeout(500);
@@ -74,7 +74,7 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
 
   await newPage.waitForTimeout(1000);
   /* TODO REMOVE once #233 is fixed */ await newPage.reload();
-  await expect(newPage.locator(`a[href="/edit#/da-sites/da-status/tests/${pageName}"]`)).not.toBeVisible();
+  await expect(newPage.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`)).not.toBeVisible();
 });
 
 test('Change document by switching anchors', async ({ page }, workerInfo) => {

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -11,7 +11,9 @@
  */
 import { test, expect } from '@playwright/test';
 import ENV from '../utils/env.js';
-import { getQuery, getTestPageURL, tabBackward, fill, TEST_SITE } from '../utils/page.js';
+import {
+  getQuery, getTestPageURL, tabBackward, fill, TEST_ORG, TEST_SITE,
+} from '../utils/page.js';
 
 test('Update Document', async ({ browser, page }, workerInfo) => {
   test.setTimeout(30000);
@@ -42,7 +44,7 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   const url = getTestPageURL('edit2', workerInfo);
   const pageName = url.split('/').pop();
 
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
   await page.locator('button.da-actions-new-button').click();
   await page.locator('button:text("Document")').click();
   await page.locator('input.da-actions-input').fill(pageName);
@@ -56,13 +58,13 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   await page.waitForTimeout(1000);
 
   const newPage = await browser.newPage();
-  await newPage.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await newPage.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
 
   await newPage.waitForTimeout(3000);
   await newPage.reload();
 
-  await expect(newPage.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`)).toBeVisible();
-  await newPage.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`).focus();
+  await expect(newPage.locator(`a[href="/edit#/${TEST_ORG}/${TEST_SITE}/tests/${pageName}"]`)).toBeVisible();
+  await newPage.locator(`a[href="/edit#/${TEST_ORG}/${TEST_SITE}/tests/${pageName}"]`).focus();
   await tabBackward(newPage);
   await newPage.keyboard.press(' ');
   await newPage.waitForTimeout(500);
@@ -74,7 +76,7 @@ test('Create Delete Document', async ({ browser, page }, workerInfo) => {
 
   await newPage.waitForTimeout(1000);
   /* TODO REMOVE once #233 is fixed */ await newPage.reload();
-  await expect(newPage.locator(`a[href="/edit#/da-sites/${TEST_SITE}/tests/${pageName}"]`)).not.toBeVisible();
+  await expect(newPage.locator(`a[href="/edit#/${TEST_ORG}/${TEST_SITE}/tests/${pageName}"]`)).not.toBeVisible();
 });
 
 test('Change document by switching anchors', async ({ page }, workerInfo) => {

--- a/test/e2e/tests/regionaledits.spec.js
+++ b/test/e2e/tests/regionaledits.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
-import ENV from '../utils/env.js';
 import path from 'path';
-import { getQuery, getTestFolderURL, TEST_SITE } from '../utils/page.js';
+import ENV from '../utils/env.js';
+import { getQuery, getTestFolderURL, TEST_ORG, TEST_SITE } from '../utils/page.js';
 
 async function findPageTab(title, page, context) {
   let attemptsLeft = 5;
@@ -35,7 +35,7 @@ test('Regional Edit Document', async ({ page, context }, workerInfo) => {
   const folderURL = getTestFolderURL('regionaledit', workerInfo);
 
   /* */ // Added this to make it work in Helix 6
-  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
   const folderName = folderURL.split('/').pop();
   await page.getByRole('button', { name: 'New' }).click();
   await page.getByRole('button', { name: 'Folder' }).click();

--- a/test/e2e/tests/regionaledits.spec.js
+++ b/test/e2e/tests/regionaledits.spec.js
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import ENV from '../utils/env.js';
 import path from 'path';
-import { getTestFolderURL } from '../utils/page.js';
+import { getQuery, getTestFolderURL, TEST_SITE } from '../utils/page.js';
 
 async function findPageTab(title, page, context) {
   let attemptsLeft = 5;
@@ -28,9 +29,19 @@ const sendUndo = async (page) => {
 };
 
 test('Regional Edit Document', async ({ page, context }, workerInfo) => {
+  /// Why does this fail?
   test.setTimeout(30000);
 
   const folderURL = getTestFolderURL('regionaledit', workerInfo);
+
+  /* */ // Added this to make it work in Helix 6
+  await page.goto(`${ENV}/${getQuery()}#/da-sites/${TEST_SITE}/tests`);
+  const folderName = folderURL.split('/').pop();
+  await page.getByRole('button', { name: 'New' }).click();
+  await page.getByRole('button', { name: 'Folder' }).click();
+  await page.locator('input.da-actions-input').fill(folderName);
+  await page.locator('input.da-actions-input').press('Enter');
+  /* */ // End addition
 
   await page.goto(folderURL);
   await page.getByRole('button', { name: 'New' }).click();

--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -10,9 +10,18 @@
  * governing permissions and limitations under the License.
  */
 import { test, expect } from '@playwright/test';
-import { getTestPageURL, fill } from '../utils/page.js';
+import { getTestPageURL, fill, TEST_SITE } from '../utils/page.js';
 
 test('Create Version and Restore from it', async ({ page }, workerInfo) => {
+  test.skip(
+    TEST_SITE !== 'da-status', 
+    `
+    Restoring versions doesn't work yet with Helix 6 and automatic 'audit' versions are not supported.
+    This test fails here: 
+      const audit = await page.locator('.da-version-entry.is-audit').first();
+      await audit.click();
+    `
+  );
   // This test has a fairly high timeout because it waits for the document to be saved
   // a number of times
   test.setTimeout(60000);

--- a/test/e2e/utils/env.js
+++ b/test/e2e/utils/env.js
@@ -21,3 +21,5 @@ function getEnv() {
 
 const ENV = (() => getEnv())();
 export default ENV;
+
+export const TEST_SITE = process.env.TEST_SITE || 'da-status';

--- a/test/e2e/utils/env.js
+++ b/test/e2e/utils/env.js
@@ -22,4 +22,5 @@ function getEnv() {
 const ENV = (() => getEnv())();
 export default ENV;
 
+export const TEST_ORG = process.env.TEST_ORG || 'da-sites';
 export const TEST_SITE = process.env.TEST_SITE || 'da-status';

--- a/test/e2e/utils/page.js
+++ b/test/e2e/utils/page.js
@@ -9,9 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import ENV, { TEST_SITE } from './env.js';
+import ENV, { TEST_ORG, TEST_SITE } from './env.js';
 
-export { TEST_SITE };
+export { TEST_ORG, TEST_SITE };
 
 export function getQuery() {
   const { GITHUB_HEAD_REF: branch } = process.env;
@@ -23,7 +23,7 @@ export function getQuery() {
 
 const QUERY = getQuery();
 
-function getTestURL(type, testIdentifier, workerInfo, dir = `/da-sites/${TEST_SITE}/tests`) {
+function getTestURL(type, testIdentifier, workerInfo, dir = `/${TEST_ORG}/${TEST_SITE}/tests`) {
   const dateStamp = Date.now().toString(36);
   const pageName = `pw-${testIdentifier}-${dateStamp}-${workerInfo.project.name}`;
   return `${ENV}/${type}${QUERY}#${dir}/${pageName}`;

--- a/test/e2e/utils/page.js
+++ b/test/e2e/utils/page.js
@@ -9,7 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import ENV from './env.js';
+import ENV, { TEST_SITE } from './env.js';
+
+export { TEST_SITE };
 
 export function getQuery() {
   const { GITHUB_HEAD_REF: branch } = process.env;
@@ -21,7 +23,7 @@ export function getQuery() {
 
 const QUERY = getQuery();
 
-function getTestURL(type, testIdentifier, workerInfo, dir = '/da-sites/da-status/tests') {
+function getTestURL(type, testIdentifier, workerInfo, dir = `/da-sites/${TEST_SITE}/tests`) {
   const dateStamp = Date.now().toString(36);
   const pageName = `pw-${testIdentifier}-${dateStamp}-${workerInfo.project.name}`;
   return `${ENV}/${type}${QUERY}#${dir}/${pageName}`;


### PR DESCRIPTION
## Description

Add support for an environment variables `TEST_ORG` and `TEST_SITE` to select the test to use with the playwright tests. org defaults to `da-sites` and sites defaults to `da-status` which runs the tests against da-admin as before.
Setting `TEST_SITE=da-e2e-tests` will switch to a site backed by Helix 6 and runs the tests there.

Some tests are skipped for sites other than `da-sites` because if missing functionality or different behaviour in Helix 6. See the 'Skipped' tests in the test report for details.

## How Has This Been Tested?

These are tests. 

## Types of changes

Test changes only.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
