### PR TITLE
test(playwright): only confirm YES when deleting more than 10 pages

### DIFF
--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -38,7 +38,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   // created by the getTestPageURL() function in page.js
   const items = page.locator('.da-item-list-item-name');
 
-  let itemsToDelete;
+  let itemsToDelete = 0;
   for (let i = 0; i < await items.count(); i += 1) {
     const item = items.nth(i);
     const fileName = await item.innerText();
@@ -52,7 +52,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
     }
     const day = 1000 * 60 * 60 * MIN_HOURS;
     if (Date.now() - day < age) {
-      // console.log('Too new:', fileName);
+      // console.log('Too new:', fileName, ' age is ', new Date(age));
       // eslint-disable-next-line no-continue
       continue;
     }
@@ -64,7 +64,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
     // console.log('To be deleted, checked box:', await checkbox.count());
     await checkbox.focus();
     await page.keyboard.press(' ');
-    itemsToDelete = true;
+    itemsToDelete += 1;
   }
 
   if (!itemsToDelete) {
@@ -76,7 +76,9 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   await page.locator('button.delete-button').locator('visible=true').click();
 
   // Type in YES to delete > 10 items
-  await page.locator('sl-input[placeholder="YES"]').locator('input').fill('YES');
+  if (itemsToDelete > 10) {
+    await page.locator('sl-input[placeholder="YES"]').locator('input').fill('YES');
+  }
 
   // Hit the delete confirmation button
   await page.locator('sl-button.negative').locator('visible=true').click();


### PR DESCRIPTION
## Description

Track the count of pages to delete and only fill the YES confirmation input when more than 10 items are selected.

This fixes a playwright failure in the case the number of items to delete is >0 but <10.

## How Has This Been Tested?

This is a Playwright test-only change.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
