### PR TITLE
fix: select-all and share respect active filter in browse list

### DIFF
--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -613,7 +613,7 @@ export default class DaList extends LitElement {
       }
     }
 
-    this._listItems.forEach((item) => { item.isChecked = check; });
+    this.filteredItems.forEach((item) => { item.isChecked = check; });
     this.handleSelectionState();
   }
 
@@ -697,9 +697,16 @@ export default class DaList extends LitElement {
     this._filter = e.target.value;
   }
 
+  get filteredItems() {
+    return this._filter
+      ? this._listItems.filter((item) => item.name.includes(this._filter))
+      : this._listItems;
+  }
+
   get isSelectAll() {
-    const selectCount = this._listItems.filter((item) => item.isChecked).length;
-    return selectCount === this._listItems.length && this._listItems.length !== 0;
+    const items = this.filteredItems;
+    const selectCount = items.filter((item) => item.isChecked).length;
+    return selectCount === items.length && items.length !== 0;
   }
 
   get actionBar() {
@@ -942,9 +949,7 @@ export default class DaList extends LitElement {
 
   render() {
     const hasMorePages = this._continuationToken && !this._allPagesLoaded;
-    const filteredItems = this._filter
-      ? this._listItems.filter((item) => item.name.includes(this._filter))
-      : this._listItems;
+    const { filteredItems } = this;
     const showList = filteredItems?.length > 0 || hasMorePages;
 
     return html`

--- a/test/unit/blocks/browse/da-list/da-list.test.js
+++ b/test/unit/blocks/browse/da-list/da-list.test.js
@@ -180,6 +180,29 @@ describe('DaList helpers', () => {
     });
   });
 
+  describe('filteredItems getter', () => {
+    it('Returns full list when no filter is active', () => {
+      const el = makeList();
+      el._listItems = [{ name: 'alpha' }, { name: 'beta' }];
+      el._filter = '';
+      expect(el.filteredItems).to.deep.equal(el._listItems);
+    });
+
+    it('Returns only items whose name includes the filter string', () => {
+      const el = makeList();
+      el._listItems = [{ name: 'alpha' }, { name: 'beta' }, { name: 'alphabet' }];
+      el._filter = 'alpha';
+      expect(el.filteredItems.map((i) => i.name)).to.deep.equal(['alpha', 'alphabet']);
+    });
+
+    it('Returns empty array when no items match the filter', () => {
+      const el = makeList();
+      el._listItems = [{ name: 'alpha' }, { name: 'beta' }];
+      el._filter = 'zzz';
+      expect(el.filteredItems).to.deep.equal([]);
+    });
+  });
+
   describe('isSelectAll getter', () => {
     it('Is true when every list item is selected', () => {
       const el = makeList();
@@ -196,6 +219,27 @@ describe('DaList helpers', () => {
     it('Is false when there are no items', () => {
       const el = makeList();
       el._listItems = [];
+      expect(el.isSelectAll).to.be.false;
+    });
+
+    it('Is true when all filtered items are checked, even if unfiltered items are not', () => {
+      const el = makeList();
+      el._listItems = [
+        { name: 'alpha', isChecked: true },
+        { name: 'beta', isChecked: false },
+      ];
+      el._filter = 'alpha';
+      expect(el.isSelectAll).to.be.true;
+    });
+
+    it('Is false when some filtered items are unchecked', () => {
+      const el = makeList();
+      el._listItems = [
+        { name: 'alpha', isChecked: true },
+        { name: 'alphabet', isChecked: false },
+        { name: 'beta', isChecked: true },
+      ];
+      el._filter = 'alpha';
       expect(el.isSelectAll).to.be.false;
     });
   });
@@ -752,6 +796,32 @@ describe('DaList helpers', () => {
       el.handleSelectionState = () => {};
       await el.handleCheckAll();
       expect(el._listItems.every((i) => i.isChecked === false)).to.be.true;
+    });
+
+    it('With filter active, only checks matching items and leaves others unchecked', async () => {
+      const el = makeList();
+      const alpha = { name: 'alpha', isChecked: false };
+      const beta = { name: 'beta', isChecked: false };
+      el._listItems = [alpha, beta];
+      el._filter = 'alpha';
+      el._continuationToken = null;
+      el.handleSelectionState = () => {};
+      await el.handleCheckAll();
+      expect(alpha.isChecked).to.be.true;
+      expect(beta.isChecked).to.be.false;
+    });
+
+    it('With filter active, unchecks only matching items when all filtered are already checked', async () => {
+      const el = makeList();
+      const alpha = { name: 'alpha', isChecked: true };
+      const beta = { name: 'beta', isChecked: true };
+      el._listItems = [alpha, beta];
+      el._filter = 'alpha';
+      el._continuationToken = null;
+      el.handleSelectionState = () => {};
+      await el.handleCheckAll();
+      expect(alpha.isChecked).to.be.false;
+      expect(beta.isChecked).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Summary

- When a filter was active, clicking \"select all\" checked items in the full list (including hidden ones), so sharing copied URLs for non-visible items too
- Added a `filteredItems` getter as a single source of truth for the filter computation
- `handleCheckAll` and `isSelectAll` now operate on `filteredItems` instead of `_listItems` when a filter is active
- 7 new unit tests covering `filteredItems`, filter-aware `isSelectAll`, and filter-aware `handleCheckAll`

## Test plan

- [ ] Open a folder with many items
- [ ] Filter the list (e.g. type a partial name)
- [ ] Click \"select all\" — only filtered/visible items should be checked
- [ ] Click share — clipboard should contain only filtered item URLs
- [ ] Clear the filter — previously unchecked items remain unchecked
- [ ] `npm test` passes (1481 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)