### PR TITLE
test: disable delete outdated docs in Helix 6 until its supported

### DIFF
--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -20,6 +20,7 @@ const MIN_HOURS = process.env.PW_DELETE_HOURS ? Number(process.env.PW_DELETE_HOU
 
 // This test deletes old testing pages that are older than 2 hours
 test('Delete multiple old pages', async ({ page }, workerInfo) => {
+  test.skip(TEST_SITE !== 'da-status', 'Deleting documents doesn\'t work yet in Helix 6');
   if (workerInfo.project.name !== 'chromium') {
     // only execute this test on chromium
     return;


### PR DESCRIPTION
## Description

The playwright test that deletes documents older than 2 hours needs to be disabled for the Helix 6 runs until the UI can delete folders. 
This is tracked by this issue: https://github.com/adobe/da-live/issues/1034

## How Has This Been Tested?

These are changes to the test only.

## Types of changes

Test changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
