### PR TITLE
test: make the collab test more stable

### DIFF
--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -62,6 +62,9 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   await page2.mouse.click(editBox.x + 10, editBox.y + 10);
   await page2.keyboard.type('From user 2');
 
+  // Give the collab cursors some cycles to appear
+  await page.waitForTimeout(3000);
+
   // Wait for page2's edit to reach page1 — confirms YJS sync before checking collab state
   await expect(page.locator('div.ProseMirror')).toContainText('From user 2');
 
@@ -111,7 +114,7 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
     sourceUrl = `https://api.aem.live/${org}/sites/${site}/source/${rest.join('/')}.html`;
   }
 
-  console.log('Checking backend at ', sourceUrl);
+  console.log('Checking backend at', sourceUrl);
   const resp = await page.request.get(sourceUrl, { headers: { Authorization: authHeader } });
   const body = await resp.text();
 


### PR DESCRIPTION
## Description

Added an extra wait to give the collab indicators some time to appear. 

Because the Github Action runners use a low-spec machine to run the tests, this is sometimes needed to get async elements to surface. Other tests use a similar approach for this.

## How Has This Been Tested?

This is a test.

## Types of changes

These are just test changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
