### PR TITLE
test: increase retries by 1 for Playwright CI runs

### DIFF
--- a/test/e2e/playwright.config.js
+++ b/test/e2e/playwright.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 3 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
## Description

I noticed that some Playwright tests are still a little flaky when run through the CI/Github actions, especially ones that check async UI behaviour. We should make those more robust, but in the mean time let's increase the test retries by 1 until we have them more stable.

## Motivation and Context

To avoid having to re-run the tests by hand.

## How Has This Been Tested?

These are changes to the Playwright test runner only.

## Types of changes

Test-only

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
