### PR TITLE
fix(ew): don't highlight a folder sharing a name with a file in the files panel

### DIFF
--- a/blocks/canvas/ew-file-explorer/ew-file-explorer.js
+++ b/blocks/canvas/ew-file-explorer/ew-file-explorer.js
@@ -231,7 +231,7 @@ class EwFileExplorer extends LitElement {
     const isDir = type === 'directory';
     const expanded = isDir && this._expanded?.has(pathKey);
     const hashPath = itemHashPath(item);
-    const selected = this._selectedPath === hashPath;
+    const selected = !isDir && this._selectedPath === hashPath;
 
     return html`
       <li role="none">


### PR DESCRIPTION
Before:
<img width="397" height="550" alt="image" src="https://github.com/user-attachments/assets/89403e7d-3dfe-4284-af4d-e8fa403d529d" />

After:
<img width="400" height="659" alt="image" src="https://github.com/user-attachments/assets/749d35a9-8aeb-4df2-98af-a5bffb8bbc05" />
