### PR TITLE
feat(ew): move chat's AI disclaimer outside its bordered body

### DIFF
--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -154,7 +154,9 @@ const CANVAS_PANELS = {
     width: '400px',
     getContent: async () => {
       await import(`${getNx()}/blocks/chat/chat.js`);
-      return document.createElement('nx-chat');
+      const chat = document.createElement('nx-chat');
+      chat.styled = true;
+      return chat;
     },
   },
   after: {


### PR DESCRIPTION
## Description

Sets `chat.styled = true` on the nx-chat element created for the canvas chat panel, opting into nx-chat's self-styled mode. No other change is needed here — the surrounding panel automatically drops its own background/border once it contains a self-styled element.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
