### PR TITLE
fix(e2e): reduce flakiness in Update Document and collab cursor tests

### DIFF
--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -17,7 +17,7 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator
 
-  test.setTimeout(60000);
+  test.setTimeout(120000);
 
   const pageURL = getTestPageURL('collab', workerInfo);
 
@@ -70,11 +70,13 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
 
   // Check the little cloud icon for collaborators
   // as we use the same user for both pages, the cloud icon should be visible on both pages
-  await expect(page.locator('div.collab-icon.collab-icon-user[data-popup-content="DA Testuser"]')).toBeVisible();
-  await expect(page2.locator('div.collab-icon.collab-icon-user[data-popup-content="DA Testuser"]')).toBeVisible();
+  // These rely on the Y.js awareness broadcast reaching the other tab, which is a real
+  // network round trip - give it more room than the global default under slow CI runners.
+  await expect(page.locator('div.collab-icon.collab-icon-user[data-popup-content="DA Testuser"]')).toBeVisible({ timeout: 30000 });
+  await expect(page2.locator('div.collab-icon.collab-icon-user[data-popup-content="DA Testuser"]')).toBeVisible({ timeout: 30000 });
 
   // Check the cursor for collaborator
-  await expect(page2.locator('span.ProseMirror-yjs-cursor')).toBeVisible();
+  await expect(page2.locator('span.ProseMirror-yjs-cursor')).toBeVisible({ timeout: 30000 });
   await expect(page2.locator('span.ProseMirror-yjs-cursor')).toContainText('DA Testuser');
   // Wait for user 1's cursor awareness to settle at the end of text so the two
   // text pieces are adjacent in innerText (cursor span between them breaks indexOf)
@@ -86,7 +88,7 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   expect(cursor2Idx).toBeGreaterThanOrEqual(0);
   expect(cursor2Idx).toBeGreaterThan(text2Idx);
   // Check the cursor for collaborator, should be in a different location here
-  await expect(page.locator('span.ProseMirror-yjs-cursor')).toBeVisible();
+  await expect(page.locator('span.ProseMirror-yjs-cursor')).toBeVisible({ timeout: 30000 });
   await expect(page.locator('span.ProseMirror-yjs-cursor')).toContainText('DA Testuser');
   await expect(page.locator('div.ProseMirror')).toContainText('From user 2');
   await expect(page.locator('div.ProseMirror')).toContainText('Entered by user 1');

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -28,8 +28,12 @@ test('Update Document', async ({ browser, page }, workerInfo) => {
   const enteredText = `[${workerInfo.project.name}] Edited by test ${new Date()}`;
   await fill(page, enteredText);
 
-  // Wait for content to save before closing
-  await page.waitForTimeout(3000);
+  // Confirm the collab save actually flushed to the backend before closing -
+  // a fixed wait here raced against Y.js persistence and was occasionally too
+  // short under CI load, leaving the reopened page empty. da-content.forceSave()
+  // is the same flush-and-wait-for-ack protocol the app uses before preview/publish.
+  const flushResult = await page.evaluate(() => document.querySelector('da-content').forceSave());
+  expect(flushResult.ok).toBe(true);
   await page.close();
 
   const newPage = await browser.newPage();


### PR DESCRIPTION
## What changed
Two pre-existing e2e tests showed up as flaky in CI while working on #1074 (unrelated PR) - "Update Document" and "Collab cursors in multiple editors". Root-caused and fixed both.

### Update Document
Raced a fixed `waitForTimeout(3000)` against Y.js persistence before closing the page and reopening it in a new one. Occasionally too short under CI load, so the reopened page loaded an empty document. Replaced with `da-content.forceSave()` - the same flush-and-wait-for-server-ack protocol the app already uses before preview/publish - so the test deterministically confirms the save landed instead of guessing at a timeout.

### Collab cursors in multiple editors
`span.ProseMirror-yjs-cursor` visibility depends on a real Y.js awareness broadcast round trip between two browser tabs/websocket connections. That occasionally exceeded the global 15s `expect` timeout under slower CI runners (seen failing on firefox/webkit, not chromium). Gave those specific assertions (cloud icon + cursor visibility) an explicit 30s timeout and bumped the test-level timeout from 60s to 120s to match - no code path bug found, this is inherent network/CI timing variance.

## Why
Found while debugging unrelated CI failures on #1074 and wanted to fix separately rather than bundle into that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)