### PR TITLE
feat(ew): add support for blocks search in slash menu

### DIFF
--- a/blocks/canvas/editor-utils/block-slash.js
+++ b/blocks/canvas/editor-utils/block-slash.js
@@ -1,0 +1,127 @@
+const BLOCK_ICON = 'tableadd';
+
+export function buildBlockEntries(resolvedBlocks) {
+  const entries = [];
+  (resolvedBlocks || []).forEach((block) => {
+    (block.variants || []).forEach((variant) => {
+      entries.push({
+        id: `block:${entries.length}`,
+        blockName: block.name,
+        variantName: variant.name,
+        variants: variant.variants,
+        tags: variant.tags,
+        description: variant.description,
+        dom: variant.dom,
+      });
+    });
+  });
+  return entries;
+}
+
+// Split an entry into a display label + variant subtitle so rows look consistent
+// regardless of how the library expresses variants:
+// - class-modifier variants carry an explicit `variants` string (e.g. "small, blue")
+// - heading-named variants encode the variant in a trailing parenthetical
+//   (e.g. "Banner (blue)" -> label "Banner", subtitle "blue")
+function deriveDisplay(entry) {
+  const name = entry.variantName || entry.blockName || '';
+  if (entry.variants) return { label: name, subtitle: entry.variants };
+  const match = name.match(/^(.*\S)\s*\(([^)]+)\)\s*$/);
+  if (match) return { label: match[1].trim(), subtitle: match[2].trim() };
+  return { label: name, subtitle: undefined };
+}
+
+export function matchBlockEntries(entries, query) {
+  const terms = (query || '').toLowerCase().split(/\s+/).filter(Boolean);
+  if (!terms.length) return [];
+
+  return (entries || [])
+    .map((entry, index) => {
+      const { label, subtitle } = deriveDisplay(entry);
+      const haystack = [entry.blockName, entry.variantName, entry.variants, entry.tags]
+        .filter(Boolean).join(' ').toLowerCase();
+      if (!terms.every((term) => haystack.includes(term))) return null;
+      const rank = label.toLowerCase().startsWith(terms[0]) ? 0 : 1;
+      return { entry, label, subtitle, index, rank };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(({ entry, label, subtitle }) => ({
+      id: entry.id,
+      label,
+      subtitle: subtitle || undefined,
+      icon: BLOCK_ICON,
+    }));
+}
+
+const store = {
+  entries: [],
+  state: 'idle', // 'idle' | 'loading' | 'ready' | 'empty'
+  hasLibrary: false,
+  key: null,
+};
+
+export function getState() {
+  return store.state;
+}
+
+export function hasLibrary() {
+  return store.hasLibrary;
+}
+
+export function blockItemsForQuery(query) {
+  return matchBlockEntries(store.entries, query);
+}
+
+export function resetBlockLibrary() {
+  store.entries = [];
+  store.state = 'idle';
+  store.hasLibrary = false;
+  store.key = null;
+}
+
+export async function ingestBlocks(blocks) {
+  const resolved = await Promise.all(
+    (blocks || []).map(async (block) => ({
+      name: block.name,
+      variants: (await block.loadVariants) || [],
+    })),
+  );
+  store.entries = buildBlockEntries(resolved);
+  store.state = store.entries.length ? 'ready' : 'empty';
+  store.hasLibrary = true;
+  return store.entries;
+}
+
+export async function insertBlockItem(view, id) {
+  const entry = store.entries.find((e) => e.id === id);
+  if (!entry) return;
+  const { insertBlock } = await import('../ew-panel-extensions/helpers.js');
+  insertBlock(view, entry.dom);
+}
+
+export async function prefetchBlockLibrary({ org, site } = {}) {
+  if (!org || !site) return;
+  const key = `${org}/${site}`;
+  if (store.key === key && store.state !== 'idle') return;
+  store.key = key;
+  store.state = 'loading';
+  try {
+    const { fetchExtensions, fetchBlocks } = await import('../ew-panel-extensions/helpers.js');
+    const extensions = await fetchExtensions(org, site);
+    const ext = extensions?.find((e) => e.name === 'blocks');
+    if (!ext) {
+      store.entries = [];
+      store.hasLibrary = false;
+      store.state = 'empty';
+      return;
+    }
+    // hasLibrary reflects a configured blocks extension; the library modal fetches independently,
+    // so keep it true even if prefetch of block data fails.
+    store.hasLibrary = true;
+    const blocks = await fetchBlocks(ext.sources);
+    await ingestBlocks(blocks);
+  } catch {
+    store.state = 'empty';
+  }
+}

--- a/blocks/canvas/editor-utils/command-defs.js
+++ b/blocks/canvas/editor-utils/command-defs.js
@@ -30,6 +30,7 @@ import {
   removeLink,
 } from './command-helpers.js';
 import { openLinkDialog, openAltDialog, triggerAddImage } from './selection-toolbar.js';
+import { blockItemsForQuery, hasLibrary, insertBlockItem } from './block-slash.js';
 
 const notImageSelected = (state) => !isImageNodeSelected(state);
 
@@ -408,18 +409,36 @@ export function commandsFor(showIn) {
 
 export const COMMAND_BY_ID = new Map(COMMANDS.map((c) => [c.id, c]));
 
-const SLASH_GROUPS = [
-  { section: 'Blocks', showIn: 'slash-blocks' },
-  { section: 'Text', showIn: 'slash-text' },
-];
-
 export function slashMenuItemsForQuery(query) {
-  const q = (query || '').toLowerCase();
-  const groups = SLASH_GROUPS
-    .map(({ section, showIn }) => ({
-      section,
-      items: commandsFor(showIn).filter((i) => !q || i.label.toLowerCase().startsWith(q)),
-    }))
-    .filter((g) => g.items.length > 0);
-  return groups.flatMap(({ section, items }) => [{ section }, ...items]);
+  const raw = query || '';
+  const q = raw.toLowerCase();
+
+  const blockRows = raw.trim() ? blockItemsForQuery(raw) : [];
+  const blockCmds = commandsFor('slash-blocks')
+    .filter((c) => (c.id !== 'open-library' || hasLibrary()))
+    .filter((c) => !q || c.label.toLowerCase().startsWith(q));
+  const blockItems = [...blockRows, ...blockCmds];
+
+  const textItems = commandsFor('slash-text')
+    .filter((c) => !q || c.label.toLowerCase().startsWith(q));
+
+  // On the bare "/" menu (no query yet), surface a hint so users discover that
+  // typing filters the configured block library.
+  const showBlockHint = !raw.trim() && hasLibrary();
+
+  const out = [];
+  if (blockItems.length) {
+    out.push({ section: 'Blocks' });
+    if (showBlockHint) out.push({ hint: 'Type a block name to search the library' });
+    out.push(...blockItems);
+  }
+  if (textItems.length) out.push({ section: 'Text' }, ...textItems);
+  return out;
+}
+
+export function applySlashSelection(view, id) {
+  const command = COMMAND_BY_ID.get(id);
+  if (command) return command.apply(view);
+  if (id?.startsWith('block:')) return insertBlockItem(view, id);
+  return undefined;
 }

--- a/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js
+++ b/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js
@@ -1,9 +1,11 @@
 /* eslint-disable import/no-unresolved -- importmap */
 import { Plugin } from 'da-y-wrapper';
 import { getNx } from '../../../../scripts/utils.js';
-import { slashMenuItemsForQuery, COMMAND_BY_ID } from '../../editor-utils/command-defs.js';
+import { slashMenuItemsForQuery, applySlashSelection } from '../../editor-utils/command-defs.js';
+import { prefetchBlockLibrary } from '../../editor-utils/block-slash.js';
 
 await import(`${getNx()}/blocks/shared/menu/menu.js`);
+const { hashChange } = await import(`${getNx()}/utils/utils.js`);
 
 function inTopLevelParagraph($from) {
   if ($from.parent.type.name !== 'paragraph') return false;
@@ -11,7 +13,7 @@ function inTopLevelParagraph($from) {
   return $from.node($from.depth - 1).type.name === 'doc';
 }
 
-function getSlashContext(state) {
+export function getSlashContext(state) {
   const { $from } = state.selection;
   if (!inTopLevelParagraph($from)) return null;
 
@@ -23,7 +25,7 @@ function getSlashContext(state) {
   if (!prefix.startsWith('/')) return null;
 
   const query = prefix.slice(1);
-  if (/\s/.test(query)) return null;
+  if (query.length > 50) return null;
 
   return { query, anchorPos: paraStart };
 }
@@ -50,15 +52,13 @@ function setup(container, view) {
   container.append(menu);
 
   menu.addEventListener('select', (e) => {
-    const run = COMMAND_BY_ID.get(e.detail.id)?.apply;
     const { state } = view;
     const slash = getSlashContext(state);
-    if (slash && run) {
+    if (slash) {
       const { anchorPos } = slash;
       const head = state.selection.from;
-      const tr = state.tr.delete(anchorPos, head);
-      view.dispatch(tr);
-      run(view);
+      view.dispatch(state.tr.delete(anchorPos, head));
+      applySlashSelection(view, e.detail.id);
     }
     view.focus();
   });
@@ -149,6 +149,13 @@ export function createSlashMenuPlugin() {
 
   return new Plugin({
     view(editorView) {
+      let hashState;
+      const unsub = hashChange.subscribe((s) => { hashState = s; });
+      unsub();
+      if (hashState?.org && hashState?.site) {
+        prefetchBlockLibrary({ org: hashState.org, site: hashState.site });
+      }
+
       const onKeyDown = () => {
         syncSlashUi(editorView, ctxRef);
       };

--- a/test/fixtures/nx/utils/utils.js
+++ b/test/fixtures/nx/utils/utils.js
@@ -5,3 +5,17 @@ export const loadStyle = async () => {
 };
 
 export const DA_ADMIN = 'https://admin.da.live';
+
+let _hashState = {};
+const _hashSubscribers = new Set();
+export const hashChange = {
+  subscribe(fn) {
+    _hashSubscribers.add(fn);
+    fn(_hashState);
+    return () => _hashSubscribers.delete(fn);
+  },
+  _set(state) {
+    _hashState = state;
+    _hashSubscribers.forEach((fn) => fn(state));
+  },
+};

--- a/test/unit/blocks/canvas/editor-utils/block-slash.test.js
+++ b/test/unit/blocks/canvas/editor-utils/block-slash.test.js
@@ -1,0 +1,245 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+let buildBlockEntries;
+let matchBlockEntries;
+
+before(async () => {
+  const mod = await import('../../../../../blocks/canvas/editor-utils/block-slash.js');
+  buildBlockEntries = mod.buildBlockEntries;
+  matchBlockEntries = mod.matchBlockEntries;
+});
+
+function sampleEntries() {
+  return buildBlockEntries([
+    {
+      name: 'banner',
+      variants: [
+        { name: 'banner', variants: undefined, dom: document.createElement('table') },
+        { name: 'banner', variants: 'small, blue', tags: 'promo', dom: document.createElement('table') },
+      ],
+    },
+    {
+      name: 'cards',
+      variants: [
+        { name: 'cards', variants: undefined, dom: document.createElement('table') },
+      ],
+    },
+  ]);
+}
+
+describe('buildBlockEntries', () => {
+  it('flattens blocks and variants into namespaced entries', () => {
+    const entries = sampleEntries();
+    expect(entries).to.have.lengthOf(3);
+    expect(entries[0].id).to.equal('block:0');
+    expect(entries[1].id).to.equal('block:1');
+    expect(entries[2].id).to.equal('block:2');
+    expect(entries[1].blockName).to.equal('banner');
+    expect(entries[1].variants).to.equal('small, blue');
+    expect(entries[2].blockName).to.equal('cards');
+  });
+
+  it('tolerates blocks with no variants', () => {
+    const entries = buildBlockEntries([{ name: 'empty' }]);
+    expect(entries).to.deep.equal([]);
+  });
+});
+
+describe('matchBlockEntries', () => {
+  it('returns [] for an empty query', () => {
+    expect(matchBlockEntries(sampleEntries(), '')).to.deep.equal([]);
+    expect(matchBlockEntries(sampleEntries(), '   ')).to.deep.equal([]);
+  });
+
+  it('matches by block name prefix', () => {
+    const items = matchBlockEntries(sampleEntries(), 'ban');
+    expect(items).to.have.lengthOf(2);
+    expect(items.every((i) => i.id.startsWith('block:'))).to.be.true;
+    expect(items[0].icon).to.equal('tableadd');
+  });
+
+  it('carries the variants string as the subtitle', () => {
+    const items = matchBlockEntries(sampleEntries(), 'blue');
+    expect(items).to.have.lengthOf(1);
+    expect(items[0].label).to.equal('banner');
+    expect(items[0].subtitle).to.equal('small, blue');
+  });
+
+  it('matches all whitespace-separated terms (contains-all)', () => {
+    const items = matchBlockEntries(sampleEntries(), 'banner promo');
+    expect(items).to.have.lengthOf(1);
+    expect(items[0].subtitle).to.equal('small, blue');
+  });
+
+  it('matches against tags', () => {
+    const items = matchBlockEntries(sampleEntries(), 'promo');
+    expect(items).to.have.lengthOf(1);
+  });
+
+  it('ranks name-prefix matches above contains-only matches', () => {
+    const entries = buildBlockEntries([
+      { name: 'hero', variants: [{ name: 'hero', variants: 'card', dom: document.createElement('table') }] },
+      { name: 'card', variants: [{ name: 'card', variants: undefined, dom: document.createElement('table') }] },
+    ]);
+    const items = matchBlockEntries(entries, 'card');
+    // "card" (name prefix) ranks before "hero" (matched only via its "card" variant)
+    expect(items[0].label).to.equal('card');
+    expect(items[1].label).to.equal('hero');
+  });
+
+  it('splits a heading-named variant "Name (variant)" into label + subtitle', () => {
+    const entries = buildBlockEntries([
+      { name: 'banner', variants: [{ name: 'Banner (blue)', dom: document.createElement('table') }] },
+    ]);
+    const items = matchBlockEntries(entries, 'banner');
+    expect(items).to.have.lengthOf(1);
+    expect(items[0].label).to.equal('Banner');
+    expect(items[0].subtitle).to.equal('blue');
+  });
+
+  it('still matches on the parenthetical variant text after the split', () => {
+    const entries = buildBlockEntries([
+      { name: 'cards', variants: [{ name: 'Cards (no images)', dom: document.createElement('table') }] },
+    ]);
+    const items = matchBlockEntries(entries, 'no images');
+    expect(items).to.have.lengthOf(1);
+    expect(items[0].label).to.equal('Cards');
+    expect(items[0].subtitle).to.equal('no images');
+  });
+
+  it('leaves a plain variant name without a subtitle', () => {
+    const entries = buildBlockEntries([
+      { name: 'hero', variants: [{ name: 'Hero', dom: document.createElement('table') }] },
+    ]);
+    const items = matchBlockEntries(entries, 'hero');
+    expect(items[0].label).to.equal('Hero');
+    expect(items[0].subtitle).to.be.undefined;
+  });
+
+  it('prefers an explicit variants string over parsing the name', () => {
+    const entries = buildBlockEntries([
+      { name: 'banner', variants: [{ name: 'banner', variants: 'small, blue', dom: document.createElement('table') }] },
+    ]);
+    const items = matchBlockEntries(entries, 'banner');
+    expect(items[0].label).to.equal('banner');
+    expect(items[0].subtitle).to.equal('small, blue');
+  });
+});
+
+describe('block-slash store', () => {
+  let ingestBlocks;
+  let blockItemsForQuery;
+  let insertBlockItem;
+  let hasLibrary;
+  let getState;
+  let resetBlockLibrary;
+
+  let prefetchBlockLibrary;
+
+  before(async () => {
+    const mod = await import('../../../../../blocks/canvas/editor-utils/block-slash.js');
+    ingestBlocks = mod.ingestBlocks;
+    blockItemsForQuery = mod.blockItemsForQuery;
+    insertBlockItem = mod.insertBlockItem;
+    hasLibrary = mod.hasLibrary;
+    getState = mod.getState;
+    resetBlockLibrary = mod.resetBlockLibrary;
+    prefetchBlockLibrary = mod.prefetchBlockLibrary;
+  });
+
+  afterEach(() => resetBlockLibrary());
+
+  function mockBlocks() {
+    return [
+      {
+        name: 'banner',
+        path: '/banner',
+        loadVariants: Promise.resolve([
+          { name: 'banner', variants: 'small, blue', dom: document.createElement('table') },
+        ]),
+      },
+    ];
+  }
+
+  it('starts idle with no library', () => {
+    expect(getState()).to.equal('idle');
+    expect(hasLibrary()).to.be.false;
+    expect(blockItemsForQuery('banner')).to.deep.equal([]);
+  });
+
+  it('ingests blocks into a queryable ready store', async () => {
+    await ingestBlocks(mockBlocks());
+    expect(getState()).to.equal('ready');
+    expect(hasLibrary()).to.be.true;
+    const items = blockItemsForQuery('ban');
+    expect(items).to.have.lengthOf(1);
+    expect(items[0].subtitle).to.equal('small, blue');
+  });
+
+  it('sets state empty when there are no variants', async () => {
+    await ingestBlocks([{ name: 'x', path: '/x', loadVariants: Promise.resolve([]) }]);
+    expect(getState()).to.equal('empty');
+  });
+
+  it('insertBlockItem inserts the entry block into the editor at the cursor', async () => {
+    const { EditorState } = await import('da-y-wrapper');
+    const { getSchema } = await import('da-parser');
+    const schema = getSchema();
+
+    const table = document.createElement('table');
+    table.innerHTML = '<tr><td>hero</td></tr><tr><td>content</td></tr>';
+    await ingestBlocks([
+      {
+        name: 'hero',
+        path: '/hero',
+        loadVariants: Promise.resolve([
+          { name: 'hero', variants: undefined, dom: table },
+        ]),
+      },
+    ]);
+
+    const doc = schema.nodes.doc.create(null, schema.nodes.paragraph.create());
+    let state = EditorState.create({ schema, doc });
+    const view = {
+      get state() { return state; },
+      dispatch(tr) { state = state.apply(tr); },
+      focus() {},
+    };
+
+    const before = state.doc.content.size;
+    await insertBlockItem(view, 'block:0');
+    // Real insertion through helpers.insertBlock grows the document.
+    expect(state.doc.content.size).to.be.greaterThan(before);
+  });
+
+  it('insertBlockItem is a no-op for an unknown id (never dispatches)', async () => {
+    await ingestBlocks(mockBlocks());
+    const view = { state: {}, dispatch() { throw new Error('should not dispatch'); } };
+    let threw = false;
+    try {
+      await insertBlockItem(view, 'block:nope');
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.be.false;
+  });
+
+  it('resetBlockLibrary clears the store', async () => {
+    await ingestBlocks(mockBlocks());
+    resetBlockLibrary();
+    expect(getState()).to.equal('idle');
+    expect(hasLibrary()).to.be.false;
+    expect(blockItemsForQuery('ban')).to.deep.equal([]);
+  });
+
+  it('prefetchBlockLibrary leaves hasLibrary false and state empty when no blocks extension is configured', async () => {
+    // The test fixture's fetchDaConfigs returns {}, so fetchExtensions yields no 'blocks'
+    // extension — this exercises the no-library branch.
+    await prefetchBlockLibrary({ org: 'testorg', site: 'testsite' });
+    expect(hasLibrary()).to.be.false;
+    expect(getState()).to.equal('empty');
+  });
+});

--- a/test/unit/blocks/canvas/editor-utils/command-defs.test.js
+++ b/test/unit/blocks/canvas/editor-utils/command-defs.test.js
@@ -1,0 +1,138 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+let slashMenuItemsForQuery;
+let applySlashSelection;
+let COMMAND_BY_ID;
+let ingestBlocks;
+let resetBlockLibrary;
+
+before(async () => {
+  const cmd = await import('../../../../../blocks/canvas/editor-utils/command-defs.js');
+  slashMenuItemsForQuery = cmd.slashMenuItemsForQuery;
+  applySlashSelection = cmd.applySlashSelection;
+  COMMAND_BY_ID = cmd.COMMAND_BY_ID;
+  const bs = await import('../../../../../blocks/canvas/editor-utils/block-slash.js');
+  ingestBlocks = bs.ingestBlocks;
+  resetBlockLibrary = bs.resetBlockLibrary;
+});
+
+afterEach(() => resetBlockLibrary());
+
+async function seed() {
+  await ingestBlocks([
+    {
+      name: 'banner',
+      path: '/banner',
+      loadVariants: Promise.resolve([
+        { name: 'banner', variants: 'small, blue', dom: document.createElement('table') },
+      ]),
+    },
+  ]);
+}
+
+const sections = (items) => items.filter((i) => i.section).map((i) => i.section);
+
+describe('slashMenuItemsForQuery', () => {
+  it('shows only commands for an empty query (no inline block rows)', () => {
+    const items = slashMenuItemsForQuery('');
+    expect(items.some((i) => i.id && i.id.startsWith('block:'))).to.be.false;
+    expect(items.some((i) => i.id === 'insert-block')).to.be.true;
+  });
+
+  it('hides "Open block library" when no library is configured', () => {
+    const items = slashMenuItemsForQuery('');
+    expect(items.some((i) => i.id === 'open-library')).to.be.false;
+  });
+
+  it('shows "Open block library" for the empty menu once a library is ingested', async () => {
+    await seed();
+    const items = slashMenuItemsForQuery('');
+    expect(items.some((i) => i.id === 'open-library')).to.be.true;
+    expect(items.some((i) => i.id === 'insert-block')).to.be.true;
+  });
+
+  it('adds a type-to-search hint on the empty menu when a library exists', async () => {
+    await seed();
+    const items = slashMenuItemsForQuery('');
+    expect(items.some((i) => i.hint)).to.be.true;
+  });
+
+  it('omits the hint when no library is configured', () => {
+    const items = slashMenuItemsForQuery('');
+    expect(items.some((i) => i.hint)).to.be.false;
+  });
+
+  it('omits the hint once the user starts typing', async () => {
+    await seed();
+    const items = slashMenuItemsForQuery('ban');
+    expect(items.some((i) => i.hint)).to.be.false;
+  });
+
+  it('shows inline block rows for a matching query and prefix-filters block commands out', async () => {
+    await seed();
+    const items = slashMenuItemsForQuery('ban');
+    expect(sections(items)).to.include('Blocks');
+    expect(items.some((i) => i.id && i.id.startsWith('block:'))).to.be.true;
+    expect(items.some((i) => i.id === 'open-library')).to.be.false;
+    expect(items.some((i) => i.id === 'insert-block')).to.be.false;
+  });
+
+  it('matches text commands too', () => {
+    const items = slashMenuItemsForQuery('head');
+    expect(sections(items)).to.include('Text');
+    expect(items.some((i) => i.id === 'heading-1')).to.be.true;
+  });
+
+  it('returns nothing for a non-matching non-empty query so the menu can auto-close', () => {
+    expect(slashMenuItemsForQuery('zzzznomatch')).to.deep.equal([]);
+  });
+});
+
+describe('applySlashSelection', () => {
+  it('runs the matching static command with the view', () => {
+    const target = COMMAND_BY_ID.get('heading-2');
+    const stub = sinon.stub(target, 'apply');
+    const fakeView = { id: 'view' };
+    applySlashSelection(fakeView, 'heading-2');
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.firstCall.args[0]).to.equal(fakeView);
+    stub.restore();
+  });
+
+  it('routes block: ids to real block insertion', async () => {
+    const { EditorState } = await import('da-y-wrapper');
+    const { getSchema } = await import('da-parser');
+    const schema = getSchema();
+
+    const table = document.createElement('table');
+    table.innerHTML = '<tr><td>banner</td></tr><tr><td>content</td></tr>';
+    await ingestBlocks([
+      {
+        name: 'banner',
+        path: '/banner',
+        loadVariants: Promise.resolve([
+          { name: 'banner', variants: 'small, blue', dom: table },
+        ]),
+      },
+    ]);
+
+    const doc = schema.nodes.doc.create(null, schema.nodes.paragraph.create());
+    let state = EditorState.create({ schema, doc });
+    const view = {
+      get state() { return state; },
+      dispatch(tr) { state = state.apply(tr); },
+      focus() {},
+    };
+    const before = state.doc.content.size;
+    await applySlashSelection(view, 'block:0');
+    expect(state.doc.content.size).to.be.greaterThan(before);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(applySlashSelection({}, 'totally-unknown-id')).to.be.undefined;
+  });
+});

--- a/test/unit/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import { EditorState, TextSelection } from 'da-y-wrapper';
+import { getSchema } from 'da-parser';
+import { setNx } from '../../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const schema = getSchema();
+
+let getSlashContext;
+
+before(async () => {
+  const mod = await import('../../../../../../blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js');
+  getSlashContext = mod.getSlashContext;
+});
+
+function stateWithParagraph(text) {
+  const para = schema.nodes.paragraph.create(null, text ? schema.text(text) : null);
+  const doc = schema.nodes.doc.create(null, para);
+  // doc.content.size is after the paragraph's close bracket; -1 puts cursor inside it
+  const sel = TextSelection.create(doc, doc.content.size - 1);
+  return EditorState.create({ schema, doc, selection: sel });
+}
+
+describe('getSlashContext', () => {
+  it('returns the query for a single-word slash command', () => {
+    const ctx = getSlashContext(stateWithParagraph('/banner'));
+    expect(ctx).to.not.be.null;
+    expect(ctx.query).to.equal('banner');
+  });
+
+  it('allows spaces for multi-term queries', () => {
+    const ctx = getSlashContext(stateWithParagraph('/banner blue'));
+    expect(ctx).to.not.be.null;
+    expect(ctx.query).to.equal('banner blue');
+  });
+
+  it('returns null when the paragraph does not start with a slash', () => {
+    expect(getSlashContext(stateWithParagraph('banner'))).to.be.null;
+  });
+
+  it('returns null for an over-long query (cap)', () => {
+    expect(getSlashContext(stateWithParagraph(`/${'x'.repeat(60)}`))).to.be.null;
+  });
+});


### PR DESCRIPTION
Adds support to slash menu to pick blocks from the library if configured.

<img width="3454" height="1910" alt="2026-07-08 12 34 10" src="https://github.com/user-attachments/assets/2e6545f0-bf7c-4896-8702-d6335ec329f3" />


Should be merged with: https://github.com/adobe/da-nx/pull/585