### PR TITLE
fix: surface image upload failures instead of failing silently

### DIFF
--- a/blocks/edit/prose/plugins/imageDrop.js
+++ b/blocks/edit/prose/plugins/imageDrop.js
@@ -24,7 +24,26 @@ export async function uploadImageFile(view, file) {
 
   const { source } = await getNx2Api();
   const resp = await source.save(path, { body: file });
-  if (!resp.ok) return;
+  if (!resp.ok) {
+    // eslint-disable-next-line no-console
+    console.error(`Failed to upload image "${file.name}": ${resp.status} ${resp.statusText}`);
+    view.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'image' && node.attrs.src === fpoSrc) {
+        view.dispatch(view.state.tr.delete(pos, pos + node.nodeSize));
+        return false;
+      }
+      return true;
+    });
+    const daTitle = document.querySelector('da-title');
+    if (daTitle) {
+      // eslint-disable-next-line no-underscore-dangle
+      daTitle._status = {
+        message: `Couldn't upload "${file.name}"`,
+        details: `Server responded ${resp.status} ${resp.statusText}`.trim(),
+      };
+    }
+    return;
+  }
   const json = await resp.json();
 
   // Create a doc image to pre-download the image before showing it.

--- a/test/unit/blocks/edit/prose/plugins/imageDrop.test.js
+++ b/test/unit/blocks/edit/prose/plugins/imageDrop.test.js
@@ -60,15 +60,31 @@ describe('imageDrop plugin', () => {
     }
   });
 
-  it('uploadImageFile bails when daFetch is not ok', async () => {
+  it('uploadImageFile removes the FPO, logs, and shows an error banner when the upload fails', async () => {
     const savedFetch = window.fetch;
-    window.fetch = () => Promise.resolve(new Response('boom', { status: 500 }));
+    const savedConsoleError = console.error;
+    let loggedArgs = null;
+    console.error = (...args) => { loggedArgs = args; };
+    window.fetch = () => Promise.resolve(new Response('boom', { status: 403, statusText: 'Forbidden' }));
+    const daTitle = document.createElement('da-title');
+    document.body.append(daTitle);
     try {
       const file = new File(['x'], 'pic.png', { type: 'image/png' });
       await uploadImageFile(editor.view, file);
-      // FPO is still inserted; we just verify no throw.
+      let foundImg = false;
+      editor.view.state.doc.descendants((node) => {
+        if (node.type.name === 'image') foundImg = true;
+      });
+      expect(foundImg).to.be.false;
+      expect(loggedArgs).to.not.be.null;
+      expect(loggedArgs[0]).to.include('pic.png');
+      expect(daTitle._status).to.not.be.undefined;
+      expect(daTitle._status.message).to.include('pic.png');
+      expect(daTitle._status.details).to.include('403');
     } finally {
       window.fetch = savedFetch;
+      console.error = savedConsoleError;
+      daTitle.remove();
     }
   });
 


### PR DESCRIPTION
## Summary
- A failed image upload (`imageDrop.js`) silently returned, leaving the FPO placeholder stuck in the doc forever with zero feedback.
- Now: the placeholder is removed, the failure is logged, and the existing `da-title` error banner (same UI used for save/publish failures) shows the filename and server status.

## Test plan
- [x] Added a failing-first test asserting the placeholder is removed, the error is logged, and `da-title._status` is set — confirmed red before the fix
- [x] Full prose plugin suite: 299/299 passing
- [x] `npm run lint` — clean