### PR TITLE
fix(test): update ACL browse e2e for ancestor-listing fallback

### DIFF
--- a/test/e2e/tests/auth.setup.js
+++ b/test/e2e/tests/auth.setup.js
@@ -33,6 +33,12 @@ The configuration in https://da.live/config#/da-testautomation/ should be as fol
   /acltest/testdocs/subdir/subdir2/subdir3 907136ED5D35CBF50A495CD4 read
   /acltest/testdocs/dir-readwrite/+** 907136ED5D35CBF50A495CD4/DA-Test write
   /acltest/testdocs/dir-readonly/+** 907136ED5D35CBF50A495CD4/DA-Test read
+
+`/acltest/otherdir` must NOT have any rule on it or any descendant (no row
+above should match it or anything below it). It is used to verify that a
+folder with no permitted descendant anywhere is still blocked with 403,
+now that adobe/da-admin#299 lets ancestors of a permitted path (like
+`testdocs` above) list successfully.
 */
 
 // This is executed once to authenticate the user used during the tests.

--- a/test/e2e/tests/authenticated/acl_browse.spec.js
+++ b/test/e2e/tests/authenticated/acl_browse.spec.js
@@ -109,15 +109,39 @@ test('Readonly directory with writeable document', async ({ page }) => {
   await expect(editor).toHaveAttribute('contenteditable', 'true');
 });
 
-test('No access directory should not show anything', async ({ page }) => {
+test('Ancestor directory shows only permitted descendants', async ({ page }) => {
   test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   await page.goto(`${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir`);
 
   // In this directory we should be able to see files
   await expect(page.getByRole('button', { name: 'Name' })).toBeVisible();
 
-  // In this directory we should be able to see nothing
+  // `testdocs` itself has no direct grant, but the user has permission on
+  // several descendants (readwrite-doc, readonly-doc, subdir/**, dir-readwrite/**,
+  // dir-readonly/**), so listing it should now succeed and be filtered to just
+  // those, per adobe/da-admin#299.
   await page.goto(`${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs`);
+  // We need to reload the page explicitly because the only thing we changed
+  // was the anchor and that doesn't normally trigger a change
+  await page.reload();
+
+  await expect(page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/readwrite-doc"]')).toBeVisible();
+  await expect(page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/readonly-doc"]')).toBeVisible();
+  await expect(page.locator('a[href="#/da-testautomation/acltest/testdocs/subdir"]')).toBeVisible();
+  await expect(page.locator('a[href="#/da-testautomation/acltest/testdocs/dir-readwrite"]')).toBeVisible();
+  await expect(page.locator('a[href="#/da-testautomation/acltest/testdocs/dir-readonly"]')).toBeVisible();
+
+  // noaccess-doc requires DA-Nonexist, which the test user is not a member of
+  await expect(page.locator('a[href="/edit#/da-testautomation/acltest/testdocs/noaccess-doc"]')).not.toBeVisible();
+});
+
+test('No access directory should not show anything', async ({ page }) => {
+  test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
+
+  // `otherdir` sits outside the `testdocs` tree and has no ACL grant on it or
+  // any descendant, so unlike `testdocs` above it has no permitted descendant
+  // to fall back on and listing it must still be blocked (see auth.setup.js).
+  await page.goto(`${ENV}/${getQuery()}#/da-testautomation/acltest/otherdir`);
   // We need to reload the page explicitly because the only thing we changed
   // was the anchor and that doesn't normally trigger a change
   await page.reload();


### PR DESCRIPTION
## Summary
- adobe/da-admin#299 changed list-permission semantics: a folder with no direct grant but a permitted descendant now lists successfully (filtered), instead of returning 403.
- Updated `acl_browse.spec.js` test formerly named "No access directory should not show anything" to assert the new filtered listing on `testdocs` (visible: readwrite-doc, readonly-doc, subdir, dir-readwrite, dir-readonly; hidden: noaccess-doc).
- Added a new test using a sibling path (`otherdir`) with zero ACL grants anywhere in its subtree, to keep coverage of the true 403 "no permission at all" case.
- Documented the `otherdir` fixture assumption in `auth.setup.js`. Verified against the live da-testautomation ACL config — no rule matches it, no config change needed.

## Test plan
- [ ] CI Playwright run against da-status passes `acl_browse.spec.js`
- [ ] Confirm `Ancestor directory shows only permitted descendants` shows filtered items on `testdocs`
- [ ] Confirm `No access directory should not show anything` still 403s on `otherdir`