### PR TITLE
fix(ew): exclude section-metadata from block indexing to fix outline panel offset

### DIFF
--- a/blocks/canvas/editor-utils/blocks.js
+++ b/blocks/canvas/editor-utils/blocks.js
@@ -1,5 +1,7 @@
 import { DOMParser as PMDOMParser } from 'da-y-wrapper';
 
+const NON_BLOCK_TABLE_NAMES = new Set(['metadata', 'section metadata', 'section-metadata']);
+
 function getTableBlockName(tableNode) {
   const firstRow = tableNode.firstChild;
   if (!firstRow) return '';
@@ -22,7 +24,7 @@ export function getBlockPositions(view) {
   doc.descendants((node, pos) => {
     if (node.type.name === 'table') {
       const blockName = getTableBlockName(node);
-      if (blockName === 'metadata') return;
+      if (NON_BLOCK_TABLE_NAMES.has(blockName)) return;
       positions.push(pos);
     }
   });


### PR DESCRIPTION
Fixes a bug in the EW page outline where blocks after section-metadata were selected incorrectly, because `getBlockPositions` counted section-metadata tables while the outline strips them.

Fix is to skip section-metadata (and page metadata) in `getBlockPositions` so editor indices match the outline

BEFORE:
<img width="3454" height="1910" alt="2026-07-09 21 22 12" src="https://github.com/user-attachments/assets/59f1518d-f7fa-4238-be74-3e28762fa38b" />


AFTER:
<img width="3454" height="1910" alt="2026-07-09 21 22 33" src="https://github.com/user-attachments/assets/295ef058-2a69-4bd1-ad25-3fde937f72e8" />
