### PR TITLE
fix(hlx6): correct paste destination path for hlx6 sites in browse

### DIFF
--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -363,9 +363,12 @@ export default class DaList extends LitElement {
   async handleItemAction({ item, type = 'copy' }) {
     const { source } = await getNx2Api();
 
-    const useDeleteFolder = type === 'delete' && !item.ext;
-    const deleteFn = useDeleteFolder ? source.deleteFolder : source.delete;
-    const type2fn = { copy: source.copy, delete: deleteFn, move: source.move };
+    const isFolder = !item.ext || item.contentType === 'application/folder';
+    const type2fn = {
+      copy: isFolder ? source.copyFolder : source.copy,
+      delete: isFolder ? source.deleteFolder : source.delete,
+      move: source.move,
+    };
     const fn = type2fn[type];
 
     // If source and dest are in the trash it's a proper move within the trash.
@@ -440,6 +443,10 @@ export default class DaList extends LitElement {
     const type = e.detail?.move ? 'move' : 'copy';
 
     await Promise.all(itemsToPaste.map(async (item) => {
+      if (this._isHlx6) {
+        const [, , ...rest] = sanitizePathParts(item.destination);
+        item.destination = `/${rest.join('/')}`;
+      }
       await this.handleItemAction({ item, type });
     }));
 

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -16,14 +16,6 @@ import {
 } from '../utils/page.js';
 
 test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => {
-  test.skip(
-    TEST_SITE !== 'da-status',
-    `
-On Helix 6 the copy and paste from one folder to another doesn't work yet, it fails on this line: 
-const link = await page.getByRole('link', { name: orgPageName });
-    `,
-  );
-
   // This test has a fairly high timeout because it waits for the document to be saved
   // a number of times
   test.setTimeout(60000);


### PR DESCRIPTION
fixes: #1032
fixes: #1033

merge after: https://github.com/adobe/da-nx/pull/594 + re-run playwright tests



## Problem
In `da-list.js` `handlePaste`, the destination path for pasted items on hlx6 sites was computed incorrectly:
- non-hlx6: destination should be `/org/site/path/filename`
- hlx6: destination should be `/path/filename` (no org/site segments)

## Fix
- After building the paste item's destination, if `this._isHlx6` is true, strip the `org`/`site` segments via `sanitizePathParts` so the destination is folder-relative.
- Also fixes `handleItemAction`'s folder detection to use `isFolder` (checks `item.ext` or `item.contentType === 'application/folder'`) consistently for choosing `copyFolder`/`deleteFolder` vs single-item `copy`/`delete`.

## Testing
- Ran eslint on the changed file, no issues.

Test:
- https://hlx6fc--da-live--adobe.aem.live/#/da-testautomation/da-e2e-tests/blah/mh-test