### PR TITLE
fix: add checkerboard bg behind images so that transparent pixels are visible

### DIFF
--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.css
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.css
@@ -50,8 +50,20 @@
 }
 
 .ew-editor-doc .ProseMirror img {
+  --transparency-grid-size: 8px;
+  --transparency-grid-color-a: light-dark(#fff, #3a3a3a);
+  --transparency-grid-color-b: light-dark(#ccc, #505050);
+
   max-width: 100%;
   height: auto;
+
+  /* Checkerboard pattern behind the img so transparent pixels are visible */
+  background-color: var(--transparency-grid-color-a);
+  background-image: conic-gradient(
+    var(--transparency-grid-color-b) 90deg, transparent 90deg 180deg,
+    var(--transparency-grid-color-b) 180deg 270deg, transparent 270deg
+  );
+  background-size: var(--transparency-grid-size) var(--transparency-grid-size);
 }
 
 /* Table chrome matches da.live da-editor.css “COPY FROM TABLES”: wrapper holds the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When an image with a transparent bg is added, they can be hard to see in the editor window. This adds a checker board pattern behind all images, to make those easier to see

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

tested locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
