### PR TITLE
fix: support new version shortcut in wyswyg

### DIFF
--- a/blocks/canvas/ew-canvas-versions/ew-canvas-versions.js
+++ b/blocks/canvas/ew-canvas-versions/ew-canvas-versions.js
@@ -247,10 +247,15 @@ class EwCanvasVersions extends LitElement {
   get _filteredVersions() {
     if (!this._versions) return [];
     if (this._filter === 'all' || !this._imsEmail) return this._versions;
-    return this._versions.filter((entry) => {
-      if (entry.isVersion) return entry.users?.some((u) => u.email === this._imsEmail);
-      return entry.audits?.some((a) => a.users?.some((u) => u.email === this._imsEmail));
-    });
+    return this._versions.reduce((acc, entry) => {
+      if (entry.isVersion) {
+        if (entry.users?.some((u) => u.email === this._imsEmail)) acc.push(entry);
+        return acc;
+      }
+      const audits = entry.audits?.filter((a) => a.users?.some((u) => u.email === this._imsEmail));
+      if (audits?.length) acc.push({ ...entry, audits });
+      return acc;
+    }, []);
   }
 
   renderNewRow() {

--- a/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.js
+++ b/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.js
@@ -3,6 +3,7 @@ import { handleImageReplace } from './utils/image.js';
 import {
   handleCursorMove,
   handleUndoRedo,
+  handleNewVersion,
   handleIframeSelectionChange,
 } from './utils/handlers.js';
 
@@ -20,6 +21,8 @@ export function createControllerOnMessage(ctx) {
       updateState(e.data, ctx);
     } else if (e.data.type === 'history') {
       handleUndoRedo(e.data, ctx);
+    } else if (e.data.type === 'new-version') {
+      handleNewVersion();
     } else if (e.data.type === 'selection-change') {
       handleIframeSelectionChange(e.data, ctx);
     }

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -95,6 +95,10 @@ export function handleUndoRedo(data, ctx) {
   if (hadHasFocus) view.hasFocus = () => true;
 }
 
+export function handleNewVersion() {
+  document.dispatchEvent(new CustomEvent('nx-canvas-new-version', { bubbles: true, composed: true }));
+}
+
 export function handleStoredMarks({ marks }, ctx) {
   const { view } = ctx;
   if (!view) return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduces support for creating version via shortcut while in wyswyg mode
Needs https://github.com/adobe/da-nx/pull/601 in parallel

Also includes a minor fix for filtering audit entries on selecting "Only me" in the version panel

Preview: https://ewquick--da-live--adobe.aem.live/canvas?nx=verquick&quick-edit=verquick&nxver=2#/exp-workspace/frescopa/drafts/svinod/test1

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
