### PR TITLE
fix(ew): add Block Library to the tool panel dropdown

### DIFF
--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -470,7 +470,7 @@ function createVersioningView() {
   };
 }
 
-function extensionToPanelView(ext, section) {
+export function extensionToPanelView(ext, section) {
   // Block library opens its own dedicated modal (used by the slash menu and
   // outline "+" button) rather than the generic inline panel or iframe dialog.
   if (ext.name === 'blocks') {

--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -471,6 +471,28 @@ function createVersioningView() {
 }
 
 function extensionToPanelView(ext, section) {
+  // Block library opens its own dedicated modal (used by the slash menu and
+  // outline "+" button) rather than the generic inline panel or iframe dialog.
+  if (ext.name === 'blocks') {
+    return {
+      id: ext.name,
+      label: ext.title,
+      section,
+      firstParty: ext.ootb,
+      experience: 'modal',
+      icon: ext.icon,
+      openModal: async () => {
+        const { openBlockLibraryModal } = await import('../ew-block-library-modal/ew-block-library-modal.js');
+        openBlockLibraryModal({
+          onInsert: (dom) => {
+            const { view } = getExtensionsBridge();
+            if (view) insertBlock(view, dom);
+          },
+        });
+      },
+    };
+  }
+
   const view = {
     id: ext.name,
     label: ext.title,
@@ -530,8 +552,7 @@ function extensionToPanelView(ext, section) {
  */
 export async function getCanvasToolPanelViews({ org, site }) {
   const extensions = await fetchExtensions(org, site);
-  const library = sortLibraryExtensions(extensions.filter(isLibraryExtension))
-    .filter((ext) => ext.name !== 'blocks');
+  const library = sortLibraryExtensions(extensions.filter(isLibraryExtension));
   const thirdParty = extensions.filter((ext) => !isLibraryExtension(ext));
 
   return [

--- a/blocks/canvas/ew-tool-panel/tool-panel.js
+++ b/blocks/canvas/ew-tool-panel/tool-panel.js
@@ -52,7 +52,8 @@ class EwToolPanel extends LitElement {
         items.push({ section: v.section });
         lastSection = v.section;
       }
-      const opensExternally = v.experience === 'window' || v.experience === 'fullsize-dialog';
+      const opensExternally = v.experience === 'window' || v.experience === 'fullsize-dialog'
+        || v.experience === 'modal';
       items.push({
         value: v.id,
         label: v.label,
@@ -151,6 +152,10 @@ class EwToolPanel extends LitElement {
     }
     if (consumer.experience === 'fullsize-dialog') {
       this._fullsizeDialogViewId = name;
+      return;
+    }
+    if (consumer.experience === 'modal') {
+      await consumer.openModal?.();
       return;
     }
     if (!this._loaded[name]) {

--- a/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
@@ -4,10 +4,12 @@ import { setNx } from '../../../../../scripts/utils.js';
 setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
 let getBlockVariants;
+let extensionToPanelView;
 
 before(async () => {
   const mod = await import('../../../../../blocks/canvas/ew-panel-extensions/helpers.js');
   getBlockVariants = mod.getBlockVariants;
+  extensionToPanelView = mod.extensionToPanelView;
 });
 
 describe('EW panel helpers transformBlock', () => {
@@ -177,5 +179,32 @@ describe('EW panel helpers transformBlock', () => {
     expect(dom).to.be.instanceOf(window.HTMLDivElement);
     expect(dom.querySelector('table')).to.not.be.null;
     expect(dom.querySelector('p')).to.not.be.null;
+  });
+});
+
+describe('extensionToPanelView', () => {
+  it('gives the "blocks" extension a dedicated modal experience', () => {
+    const ext = { name: 'blocks', title: 'Blocks', ootb: true, icon: '#icon-blocks' };
+    const view = extensionToPanelView(ext, 'Library');
+    expect(view.id).to.equal('blocks');
+    expect(view.label).to.equal('Blocks');
+    expect(view.section).to.equal('Library');
+    expect(view.firstParty).to.be.true;
+    expect(view.experience).to.equal('modal');
+    expect(view.icon).to.equal('#icon-blocks');
+    expect(view.openModal).to.be.a('function');
+    // The modal view opts out of the generic inline-panel loader.
+    expect(view.load).to.be.undefined;
+  });
+
+  it('leaves non-blocks extensions on the standard inline/load experience', () => {
+    const ext = {
+      name: 'templates', title: 'Templates', ootb: true, experience: 'inline', sources: ['/tpl'], icon: '',
+    };
+    const view = extensionToPanelView(ext, 'Library');
+    expect(view.id).to.equal('templates');
+    expect(view.experience).to.equal('inline');
+    expect(view.load).to.be.a('function');
+    expect(view.openModal).to.be.undefined;
   });
 });

--- a/test/unit/blocks/canvas/ew-tool-panel/tool-panel.test.js
+++ b/test/unit/blocks/canvas/ew-tool-panel/tool-panel.test.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-underscore-dangle */
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+before(async () => {
+  await import('../../../../../blocks/canvas/ew-tool-panel/tool-panel.js');
+});
+
+// The element is used detached (never appended), so Lit never runs an update
+// cycle — we call the changed methods directly. The 'modal' branch of showPanel
+// returns before touching the shadow root, so this stays safe without rendering.
+function createPanel(views) {
+  const el = document.createElement('ew-tool-panel');
+  el.views = views;
+  return el;
+}
+
+describe('EwToolPanel — modal experience', () => {
+  describe('_pickerItemsFromViews', () => {
+    it('marks a modal view as an external-opening action item', () => {
+      const el = createPanel([
+        { id: 'blocks', label: 'Blocks', section: 'Library', experience: 'modal' },
+      ]);
+      const item = el._pickerItemsFromViews().find((i) => i.value === 'blocks');
+      expect(item.action).to.be.true;
+      expect(item.trailingIcon).to.exist;
+      expect(item.ariaLabel).to.equal('Blocks (opens in dialog)');
+    });
+
+    it('leaves a plain inline view as a non-action item', () => {
+      const el = createPanel([
+        { id: 'files', label: 'Files', section: 'Editor', experience: 'inline' },
+      ]);
+      const item = el._pickerItemsFromViews().find((i) => i.value === 'files');
+      expect(item.action).to.be.undefined;
+      expect(item.trailingIcon).to.be.undefined;
+    });
+  });
+
+  describe('showPanel', () => {
+    it('invokes openModal and does not activate the view for a modal experience', async () => {
+      let opened = 0;
+      const openModal = async () => { opened += 1; };
+      const el = createPanel([{ id: 'blocks', label: 'Blocks', experience: 'modal', openModal }]);
+      await el.showPanel('blocks');
+      expect(opened).to.equal(1);
+      expect(el.activeId).to.be.undefined;
+    });
+
+    it('does not throw when a modal view has no openModal handler', async () => {
+      const el = createPanel([{ id: 'blocks', label: 'Blocks', experience: 'modal' }]);
+      let threw = false;
+      try {
+        await el.showPanel('blocks');
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.be.false;
+      expect(el.activeId).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
# Adds Block Library to the ew canvas tool panel dropdown

## Description
Adds Block Library to the right tool panel dropdown, alongside the other tools (Outline, Files, Versions, Templates, Icons, Placeholders, AEM Assets).

Selecting it opens the same block library dialog that the slash menu and outline "+" button already open — inserting a variant drops it at the current cursor position in the editor.

## Motivation and Context
Block Library is the odd one out: every other tool is reachable from the tool panel dropdown, but the block library was only accessible via the slash menu and a small, easy-to-miss + button on the outline section header rows. This puts it where users already look for tools, so it's discoverable in the same place as everything else — without removing the existing entry points.

Rather than rendering it inline like the other library tools (its tree + preview layout needs far more room than the side panel offers), the dropdown entry reuses the existing openBlockLibraryModal() flow. This keeps a single block-library UI and avoids offering two different experiences for the same feature.

**Implementation**
`extensionToPanelView` special-cases the blocks extension to produce a view with a new `experience: 'modal'` and an `openModal()` that calls the existing `openBlockLibraryModal()`, wiring insertion into the active editor view.
`ew-tool-panel` handles the new modal experience in `showPanel` — mirroring the existing window case: it fires the action and returns without mounting anything inline or changing the active tab. The dropdown item shows the "opens externally" affordance.

No changes to the block library modal component or its styles — it's the exact same dialog, now reachable from a third entry point.

## How Has This Been Tested?

https://shwblock--da-live--adobe.aem.live/canvas#/aem-sandbox/block-collection/drafts/amol/shwblock

Verified Block Library appears in the tool panel dropdown for a site with a configured blocks library, grouped under Library.
Selecting it opens the block library dialog; searching, expanding blocks, and previewing variants all work as before.
Inserting a variant places the block at the current cursor position in the editor.
Confirmed the existing entry points (slash menu, outline section "+" button) still work unchanged.
Confirmed the dropdown entry does not appear for sites with no blocks library configured.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
