### PR TITLE
fix: show add block on selection

### DIFF
--- a/blocks/canvas/ew-page-outline/ew-page-outline.css
+++ b/blocks/canvas/ew-page-outline/ew-page-outline.css
@@ -150,7 +150,8 @@
     height: 16px;
   }
 
-.outline-section:has(.selected) .action-btn,
+.outline-section:has(.selected) .section-header .action-btn,
+.selected .action-btn,
 .action-btn:focus-visible,
 .section-header:hover .action-btn,
 .block-item:hover .action-btn {

--- a/blocks/canvas/ew-page-outline/ew-page-outline.css
+++ b/blocks/canvas/ew-page-outline/ew-page-outline.css
@@ -81,7 +81,7 @@
     background: var(--s2-gray-75);
   }
 
-  &[aria-selected="true"] {
+  &.selected {
     background: var(--s2-blue-100);
     color: var(--s2-blue-900);
   }
@@ -139,17 +139,18 @@
   color: var(--s2-gray-800);
   cursor: pointer;
 
+  &:hover {
+    background: var(--s2-gray-200);
+  }
+}
+
   svg.icon {
     display: block;
     width: 16px;
     height: 16px;
   }
 
-  &:hover {
-    background: var(--s2-gray-200);
-  }
-}
-
+.outline-section:has(.selected) .action-btn,
 .action-btn:focus-visible,
 .section-header:hover .action-btn,
 .block-item:hover .action-btn {

--- a/blocks/canvas/ew-page-outline/ew-page-outline.js
+++ b/blocks/canvas/ew-page-outline/ew-page-outline.js
@@ -14,6 +14,7 @@ import { fetchExtensions } from '../ew-panel-extensions/helpers.js';
 
 const DELETE_ICON_SRC = '/img/icons/s2-icon-delete-20-n.svg';
 const ADD_BLOCK_ICON_SRC = '/img/icons/s2-icon-tableadd-20-n.svg';
+const DRAG_ICON_SRC = '/img/icons/s2-icon-draghandle-20-n.svg';
 
 const { loadStyle, hashChange } = await import(`${getNx()}/utils/utils.js`);
 
@@ -256,6 +257,9 @@ class EwPageOutline extends LitElement {
               </svg>
             </button>` : nothing}
           ${this._renderDeleteButton(OUTLINE_TYPES.SECTION, sec.sectionIndex)}
+          <svg aria-hidden="true" class="icon" viewBox="0 0 20 20">
+                <use href="${DRAG_ICON_SRC}#icon"></use>
+              </svg>
         </div>
         <ul class="block-list" role="group"
             aria-label="Blocks in section ${sec.sectionIndex + 1}">
@@ -265,7 +269,7 @@ class EwPageOutline extends LitElement {
                 <span class="empty-label">No blocks</span>
               </li>`
         : sec.blocks.map(({ name, blockIndex }, blockIdx) => html`
-            <li class="block-item" role="treeitem"
+            <li class="block-item ${this._selectedBlockIndex === blockIndex ? 'selected' : ''}" role="treeitem"
                 data-block-index="${blockIndex}"
                 tabindex="${isFirstSection && blockIdx === 0 ? '0' : '-1'}"
                 aria-selected="${this._selectedBlockIndex === blockIndex}"
@@ -277,6 +281,9 @@ class EwPageOutline extends LitElement {
                 @click=${() => this._select(blockIndex)}>
               <span class="block-name">${name}</span>
               ${this._renderDeleteButton(OUTLINE_TYPES.BLOCK, blockIndex)}
+              <svg aria-hidden="true" class="icon drag" viewBox="0 0 20 20">
+                <use href="${DRAG_ICON_SRC}#icon"></use>
+              </svg>
             </li>`)}
         </ul>
       </li>`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- show add block if item selected within section
- show drag icon on all items

Preview: https://ewadd--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/coffee

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
