### PR TITLE
fix(canvas): convert fragment URLs to relative for live preview so that fragment block renders content

### DIFF
--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -232,6 +232,32 @@ function parseIcons(editor) {
 
 const removeEls = (els) => els.forEach((el) => el.remove());
 
+function convertFragmentUrlsToRelative(editor) {
+  const HELIX_URL_REGEXP = /^https:\/\/.*\.(aem|hlx3?)\.(live|page)(\/|$)/;
+
+  const links = editor.querySelectorAll('a[href]');
+  links.forEach((link) => {
+    const url = link.getAttribute('href');
+
+    if (!url || !url.startsWith('https://')) {
+      return;
+    }
+
+    try {
+      const parsed = new URL(url);
+      const { host, pathname, search, hash } = parsed;
+
+      if (pathname.includes('/fragments/')
+          && host.includes('--')
+          && HELIX_URL_REGEXP.test(url)) {
+        link.setAttribute('href', `${pathname}${search}${hash}`);
+      }
+    } catch {
+      // ignore
+    }
+  });
+}
+
 /**
  * A utility to take ProseMirror formatted DOM and convert to AEM semantic markup
  * @param {HTMLElement} editor the editor dom
@@ -244,6 +270,10 @@ export default function prose2aem(editor, livePreview, isFragment = false) {
 
   editor.removeAttribute('contenteditable');
   editor.removeAttribute('translate');
+
+  if (livePreview) {
+    convertFragmentUrlsToRelative(editor);
+  }
 
   const daDiffDeletedEls = editor.querySelectorAll('da-diff-deleted');
   removeEls(daDiffDeletedEls);

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -233,7 +233,7 @@ function parseIcons(editor) {
 const removeEls = (els) => els.forEach((el) => el.remove());
 
 function convertFragmentUrlsToRelative(editor) {
-  const EDS_FRAGMENT_URL = /^https:\/\/[^\/]*--[^\/]*\.aem\.(live|page)\/(?:.*\/)?fragments\//;
+  const EDS_FRAGMENT_URL = /^https:\/\/[^/]*--[^/]*\.aem\.(live|page)\/(?:.*\/)?fragments\//;
 
   const links = editor.querySelectorAll('a[href]');
   links.forEach((link) => {

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -233,19 +233,23 @@ function parseIcons(editor) {
 const removeEls = (els) => els.forEach((el) => el.remove());
 
 function convertFragmentUrlsToRelative(editor) {
-  const EDS_FRAGMENT_URL = /^https:\/\/[^/]*--[^/]*\.aem\.(live|page)\/(?:.*\/)?fragments\//;
+  const hashParts = window.location.hash.slice(2).split('/');
+  const [org, site] = hashParts;
+
+  if (!org || !site) return;
 
   const links = editor.querySelectorAll('a[href]');
   links.forEach((link) => {
     const url = link.getAttribute('href');
-
-    if (!url || !EDS_FRAGMENT_URL.test(url)) {
-      return;
-    }
+    if (!url || !url.startsWith('https://')) return;
 
     try {
-      const { pathname, search, hash } = new URL(url);
-      link.setAttribute('href', `${pathname}${search}${hash}`);
+      const { hostname, pathname, search, hash } = new URL(url);
+
+      const sameSitePattern = `--${site}--${org}.aem.`;
+      if (hostname.includes(sameSitePattern)) {
+        link.setAttribute('href', `${pathname}${search}${hash}`);
+      }
     } catch {
       // ignore
     }

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -1,3 +1,5 @@
+import getPathDetails from './pathDetails.js';
+
 function setCursor(cursor, el) {
   el.id = cursor.id;
   cursor.remove();
@@ -232,11 +234,11 @@ function parseIcons(editor) {
 
 const removeEls = (els) => els.forEach((el) => el.remove());
 
-function convertFragmentUrlsToRelative(editor) {
-  const hashParts = window.location.hash.slice(2).split('/');
-  const [org, site] = hashParts;
+function convertLocalUrlsToRelative(editor) {
+  const pathDetails = getPathDetails();
+  if (!pathDetails?.org || !pathDetails?.site) return;
 
-  if (!org || !site) return;
+  const { org, site } = pathDetails;
 
   const links = editor.querySelectorAll('a[href]');
   links.forEach((link) => {
@@ -270,7 +272,7 @@ export default function prose2aem(editor, livePreview, isFragment = false) {
   editor.removeAttribute('translate');
 
   if (livePreview) {
-    convertFragmentUrlsToRelative(editor);
+    convertLocalUrlsToRelative(editor);
   }
 
   const daDiffDeletedEls = editor.querySelectorAll('da-diff-deleted');

--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -233,25 +233,19 @@ function parseIcons(editor) {
 const removeEls = (els) => els.forEach((el) => el.remove());
 
 function convertFragmentUrlsToRelative(editor) {
-  const HELIX_URL_REGEXP = /^https:\/\/.*\.(aem|hlx3?)\.(live|page)(\/|$)/;
+  const EDS_FRAGMENT_URL = /^https:\/\/[^\/]*--[^\/]*\.aem\.(live|page)\/(?:.*\/)?fragments\//;
 
   const links = editor.querySelectorAll('a[href]');
   links.forEach((link) => {
     const url = link.getAttribute('href');
 
-    if (!url || !url.startsWith('https://')) {
+    if (!url || !EDS_FRAGMENT_URL.test(url)) {
       return;
     }
 
     try {
-      const parsed = new URL(url);
-      const { host, pathname, search, hash } = parsed;
-
-      if (pathname.includes('/fragments/')
-          && host.includes('--')
-          && HELIX_URL_REGEXP.test(url)) {
-        link.setAttribute('href', `${pathname}${search}${hash}`);
-      }
+      const { pathname, search, hash } = new URL(url);
+      link.setAttribute('href', `${pathname}${search}${hash}`);
     } catch {
       // ignore
     }

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -384,7 +384,18 @@ describe('prose2aem fragment URL conversion', () => {
     return editor;
   }
 
-  it('converts fragment URLs to relative when livePreview=true', () => {
+  let originalHash;
+
+  before(() => {
+    originalHash = window.location.hash;
+  });
+
+  after(() => {
+    window.location.hash = originalHash;
+  });
+
+  it('converts same-site fragment URLs to relative when livePreview=true', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/fragments/tabs-homepage">Fragment</a></p>
     `);
@@ -396,6 +407,7 @@ describe('prose2aem fragment URL conversion', () => {
   });
 
   it('does not convert fragment URLs when livePreview=false', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/fragments/tabs-homepage">Fragment</a></p>
     `);
@@ -406,7 +418,8 @@ describe('prose2aem fragment URL conversion', () => {
     expect(link.getAttribute('href')).to.equal('https://main--repo--org.aem.live/fragments/tabs-homepage');
   });
 
-  it('converts fragment URLs with nested paths', () => {
+  it('converts same-site URLs with nested paths', () => {
+    window.location.hash = '#/org/site/path';
     const editor = makeEditor(`
       <p><a href="https://main--site--org.aem.live/en/fragments/footer">Fragment</a></p>
     `);
@@ -418,6 +431,7 @@ describe('prose2aem fragment URL conversion', () => {
   });
 
   it('preserves search params and hash in converted URLs', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/fragments/tabs?param=value#section">Fragment</a></p>
     `);
@@ -428,7 +442,8 @@ describe('prose2aem fragment URL conversion', () => {
     expect(link.getAttribute('href')).to.equal('/fragments/tabs?param=value#section');
   });
 
-  it('does not convert non-fragment URLs', () => {
+  it('converts same-site non-fragment URLs to relative', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/products/page">Regular page</a></p>
     `);
@@ -436,10 +451,23 @@ describe('prose2aem fragment URL conversion', () => {
     prose2aem(editor, true, false);
     const link = editor.querySelector('a');
 
-    expect(link.getAttribute('href')).to.equal('https://main--repo--org.aem.live/products/page');
+    expect(link.getAttribute('href')).to.equal('/products/page');
+  });
+
+  it('does not convert cross-site URLs', () => {
+    window.location.hash = '#/org/repo/path';
+    const editor = makeEditor(`
+      <p><a href="https://main--otherrepo--otherorg.aem.live/fragments/something">Different site</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('https://main--otherrepo--otherorg.aem.live/fragments/something');
   });
 
   it('does not convert non-EDS URLs', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://example.com/fragments/something">External</a></p>
     `);
@@ -450,7 +478,8 @@ describe('prose2aem fragment URL conversion', () => {
     expect(link.getAttribute('href')).to.equal('https://example.com/fragments/something');
   });
 
-  it('converts both .aem.live and .aem.page URLs', () => {
+  it('converts both .aem.live and .aem.page same-site URLs', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/fragments/hero">Fragment 1</a></p>
       <p><a href="https://main--repo--org.aem.page/fragments/footer">Fragment 2</a></p>
@@ -464,6 +493,7 @@ describe('prose2aem fragment URL conversion', () => {
   });
 
   it('handles relative fragment URLs without conversion', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="/fragments/tabs">Fragment</a></p>
     `);
@@ -475,6 +505,7 @@ describe('prose2aem fragment URL conversion', () => {
   });
 
   it('handles invalid URLs gracefully', () => {
+    window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="not-a-valid-url">Invalid</a></p>
     `);
@@ -482,5 +513,17 @@ describe('prose2aem fragment URL conversion', () => {
     expect(() => prose2aem(editor, true, false)).to.not.throw();
     const link = editor.querySelector('a');
     expect(link.getAttribute('href')).to.equal('not-a-valid-url');
+  });
+
+  it('does not convert when org/site not in hash', () => {
+    window.location.hash = '';
+    const editor = makeEditor(`
+      <p><a href="https://main--repo--org.aem.live/fragments/tabs">Fragment</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('https://main--repo--org.aem.live/fragments/tabs');
   });
 });

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -376,3 +376,111 @@ describe('prose2aem with isFragment parameter', () => {
     expect(result).to.include('data-title="data-focal:30.5,70.2"');
   });
 });
+
+describe('prose2aem fragment URL conversion', () => {
+  function makeEditor(innerHtml) {
+    const editor = document.createElement('div');
+    editor.innerHTML = innerHtml;
+    return editor;
+  }
+
+  it('converts fragment URLs to relative when livePreview=true', () => {
+    const editor = makeEditor(`
+      <p><a href="https://main--repo--org.aem.live/fragments/tabs-homepage">Fragment</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('/fragments/tabs-homepage');
+  });
+
+  it('does not convert fragment URLs when livePreview=false', () => {
+    const editor = makeEditor(`
+      <p><a href="https://main--repo--org.aem.live/fragments/tabs-homepage">Fragment</a></p>
+    `);
+
+    prose2aem(editor, false, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('https://main--repo--org.aem.live/fragments/tabs-homepage');
+  });
+
+  it('converts fragment URLs with nested paths', () => {
+    const editor = makeEditor(`
+      <p><a href="https://main--site--org.aem.live/en/fragments/footer">Fragment</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('/en/fragments/footer');
+  });
+
+  it('preserves search params and hash in converted URLs', () => {
+    const editor = makeEditor(`
+      <p><a href="https://main--repo--org.aem.live/fragments/tabs?param=value#section">Fragment</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('/fragments/tabs?param=value#section');
+  });
+
+  it('does not convert non-fragment URLs', () => {
+    const editor = makeEditor(`
+      <p><a href="https://main--repo--org.aem.live/products/page">Regular page</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('https://main--repo--org.aem.live/products/page');
+  });
+
+  it('does not convert non-EDS URLs', () => {
+    const editor = makeEditor(`
+      <p><a href="https://example.com/fragments/something">External</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('https://example.com/fragments/something');
+  });
+
+  it('converts hlx.live and hlx.page URLs', () => {
+    const editor = makeEditor(`
+      <p><a href="https://main--repo--org.hlx.live/fragments/hero">Fragment 1</a></p>
+      <p><a href="https://main--repo--org.hlx.page/fragments/footer">Fragment 2</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const links = editor.querySelectorAll('a');
+
+    expect(links[0].getAttribute('href')).to.equal('/fragments/hero');
+    expect(links[1].getAttribute('href')).to.equal('/fragments/footer');
+  });
+
+  it('handles relative fragment URLs without conversion', () => {
+    const editor = makeEditor(`
+      <p><a href="/fragments/tabs">Fragment</a></p>
+    `);
+
+    prose2aem(editor, true, false);
+    const link = editor.querySelector('a');
+
+    expect(link.getAttribute('href')).to.equal('/fragments/tabs');
+  });
+
+  it('handles invalid URLs gracefully', () => {
+    const editor = makeEditor(`
+      <p><a href="not-a-valid-url">Invalid</a></p>
+    `);
+
+    expect(() => prose2aem(editor, true, false)).to.not.throw();
+    const link = editor.querySelector('a');
+    expect(link.getAttribute('href')).to.equal('not-a-valid-url');
+  });
+});

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -450,10 +450,10 @@ describe('prose2aem fragment URL conversion', () => {
     expect(link.getAttribute('href')).to.equal('https://example.com/fragments/something');
   });
 
-  it('converts hlx.live and hlx.page URLs', () => {
+  it('converts both .aem.live and .aem.page URLs', () => {
     const editor = makeEditor(`
-      <p><a href="https://main--repo--org.hlx.live/fragments/hero">Fragment 1</a></p>
-      <p><a href="https://main--repo--org.hlx.page/fragments/footer">Fragment 2</a></p>
+      <p><a href="https://main--repo--org.aem.live/fragments/hero">Fragment 1</a></p>
+      <p><a href="https://main--repo--org.aem.page/fragments/footer">Fragment 2</a></p>
     `);
 
     prose2aem(editor, true, false);

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -377,7 +377,7 @@ describe('prose2aem with isFragment parameter', () => {
   });
 });
 
-describe('prose2aem fragment URL conversion', () => {
+describe('prose2aem same-site URL conversion', () => {
   function makeEditor(innerHtml) {
     const editor = document.createElement('div');
     editor.innerHTML = innerHtml;
@@ -394,7 +394,7 @@ describe('prose2aem fragment URL conversion', () => {
     window.location.hash = originalHash;
   });
 
-  it('converts same-site fragment URLs to relative when livePreview=true', () => {
+  it('converts same-site URLs to relative when livePreview=true', () => {
     window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/fragments/tabs-homepage">Fragment</a></p>
@@ -406,7 +406,7 @@ describe('prose2aem fragment URL conversion', () => {
     expect(link.getAttribute('href')).to.equal('/fragments/tabs-homepage');
   });
 
-  it('does not convert fragment URLs when livePreview=false', () => {
+  it('does not convert URLs when livePreview=false', () => {
     window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="https://main--repo--org.aem.live/fragments/tabs-homepage">Fragment</a></p>
@@ -492,7 +492,7 @@ describe('prose2aem fragment URL conversion', () => {
     expect(links[1].getAttribute('href')).to.equal('/fragments/footer');
   });
 
-  it('handles relative fragment URLs without conversion', () => {
+  it('handles relative URLs without conversion', () => {
     window.location.hash = '#/org/repo/path';
     const editor = makeEditor(`
       <p><a href="/fragments/tabs">Fragment</a></p>


### PR DESCRIPTION
## Description

- Convert absolute EDS/Helix fragment URLs to relative paths during live preview
- Only applies to links containing `/fragments/` in their pathname
- Minimal blast radius: only affects live preview rendering, not saved HTML

## Related Issue

Fixes #1126

## How Has This Been Tested?

- Added 9 test cases covering fragment URL conversion scenarios
- All tests passing (1658 passed, 0 failed)
- Manually tested in canvas with fragment blocks

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.