### PR TITLE
fix(media): load HLX6 media through source API

### DIFF
--- a/blocks/media/da-media.js
+++ b/blocks/media/da-media.js
@@ -13,6 +13,11 @@ class DaMedia extends LitElement {
     document.title = `View ${this.details.name} - Experience Workspace`;
   }
 
+  disconnectedCallback() {
+    if (this.details.contentUrl.startsWith('blob:')) URL.revokeObjectURL(this.details.contentUrl);
+    super.disconnectedCallback();
+  }
+
   get _mediaType() {
     const ext = this.details.name.split('.').pop();
     return ext;

--- a/blocks/media/media.js
+++ b/blocks/media/media.js
@@ -68,14 +68,27 @@ export default async function init(el) {
   const { name, fullpath, owner, repo } = details;
   const ext = name.split('.').pop();
 
-  await contentLogin(owner, repo);
+  const { isHlx6, source } = await getNx2Api();
+  const hlx6 = await isHlx6(owner, repo);
+  let mediaDetails = details;
+
+  if (hlx6 && ext !== 'pdf') {
+    const resp = await source.get(fullpath);
+    if (!resp.ok) throw new Error(`Unable to load media: ${resp.status}`);
+    mediaDetails = {
+      ...details,
+      contentUrl: URL.createObjectURL(await resp.blob()),
+    };
+  } else {
+    await contentLogin(owner, repo);
+  }
 
   const daTitle = document.createElement('da-title');
 
   const daMedia = ext === 'pdf' ? await getPdfMedia() : await getDefaultMedia();
 
   daTitle.details = details;
-  daMedia.details = details;
+  daMedia.details = mediaDetails;
   el.append(daTitle, daMedia);
 
   if (ext === 'pdf') loadPdfMedia(fullpath, name);

--- a/blocks/shared/constants.js
+++ b/blocks/shared/constants.js
@@ -42,7 +42,9 @@ const DA_ETC_ENVS = {
   local: 'http://localhost:8787',
 };
 
-function getDaEnv(location, key, envs, localDefault = 'prod') {
+const LOCALHOST_DEFAULTS = { 'da-admin': 'stage' };
+
+function getDaEnv(location, key, envs) {
   const { href } = location;
   const url = new URL(href);
   const query = url.searchParams.get(key);
@@ -51,11 +53,9 @@ function getDaEnv(location, key, envs, localDefault = 'prod') {
   } else if (query) {
     localStorage.setItem(key, query);
   }
-  // On localhost the IMS token is always minted against IMS stage, so the DA
-  // admin default must be stage there too — otherwise a stage token hits prod
-  // admin, 401s, and da-nx redirects to /not-found.
   const isLocal = url.hostname.includes('local');
-  const env = envs[localStorage.getItem(key)] || envs[isLocal ? localDefault : 'prod'] || envs.prod;
+  const fallback = isLocal ? (LOCALHOST_DEFAULTS[key] || 'prod') : 'prod';
+  const env = envs[localStorage.getItem(key)] || envs[fallback] || envs.prod;
   // TODO: INFRA
   return location.origin === 'https://da.page' ? env.replace('.live', '.page') : env;
 }
@@ -64,12 +64,12 @@ export const getDaAdmin = (() => {
   let daAdmin;
   return (location) => {
     if (!location && daAdmin) return daAdmin;
-    daAdmin = getDaEnv(location || window.location, 'da-admin', DA_ADMIN_ENVS, 'stage');
+    daAdmin = getDaEnv(location || window.location, 'da-admin', DA_ADMIN_ENVS);
     return daAdmin;
   };
 })();
 
-export const DA_ORIGIN = (() => getDaEnv(window.location, 'da-admin', DA_ADMIN_ENVS, 'stage'))();
+export const DA_ORIGIN = (() => getDaEnv(window.location, 'da-admin', DA_ADMIN_ENVS))();
 export const COLLAB_ORIGIN = (() => getDaEnv(window.location, 'da-collab', DA_COLLAB_ENVS))();
 export const CON_ORIGIN = (() => getDaEnv(window.location, 'da-content', DA_CONTENT_ENVS))();
 export const LIVE_PREVIEW_DOMAIN = (() => getDaEnv(window.location, 'da-live-preview', DA_LIVE_PREVIEW_ENVS))();

--- a/blocks/shared/constants.js
+++ b/blocks/shared/constants.js
@@ -42,15 +42,20 @@ const DA_ETC_ENVS = {
   local: 'http://localhost:8787',
 };
 
-function getDaEnv(location, key, envs) {
+function getDaEnv(location, key, envs, localDefault = 'prod') {
   const { href } = location;
-  const query = new URL(href).searchParams.get(key);
+  const url = new URL(href);
+  const query = url.searchParams.get(key);
   if (query && query === 'reset') {
     localStorage.removeItem(key);
   } else if (query) {
     localStorage.setItem(key, query);
   }
-  const env = envs[localStorage.getItem(key) || 'prod'];
+  // On localhost the IMS token is always minted against IMS stage, so the DA
+  // admin default must be stage there too — otherwise a stage token hits prod
+  // admin, 401s, and da-nx redirects to /not-found.
+  const isLocal = url.hostname.includes('local');
+  const env = envs[localStorage.getItem(key)] || envs[isLocal ? localDefault : 'prod'] || envs.prod;
   // TODO: INFRA
   return location.origin === 'https://da.page' ? env.replace('.live', '.page') : env;
 }
@@ -59,12 +64,12 @@ export const getDaAdmin = (() => {
   let daAdmin;
   return (location) => {
     if (!location && daAdmin) return daAdmin;
-    daAdmin = getDaEnv(location || window.location, 'da-admin', DA_ADMIN_ENVS);
+    daAdmin = getDaEnv(location || window.location, 'da-admin', DA_ADMIN_ENVS, 'stage');
     return daAdmin;
   };
 })();
 
-export const DA_ORIGIN = (() => getDaEnv(window.location, 'da-admin', DA_ADMIN_ENVS))();
+export const DA_ORIGIN = (() => getDaEnv(window.location, 'da-admin', DA_ADMIN_ENVS, 'stage'))();
 export const COLLAB_ORIGIN = (() => getDaEnv(window.location, 'da-collab', DA_COLLAB_ENVS))();
 export const CON_ORIGIN = (() => getDaEnv(window.location, 'da-content', DA_CONTENT_ENVS))();
 export const LIVE_PREVIEW_DOMAIN = (() => getDaEnv(window.location, 'da-live-preview', DA_LIVE_PREVIEW_ENVS))();

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -99,7 +99,7 @@ describe('prose/index createConnection', () => {
     expect(result.wsProvider).to.exist;
     expect(result.ydoc).to.exist;
     expect(result.wsProvider.maxBackoffTime).to.equal(30000);
-    // Legacy (non-hlx6) docs keep the DA admin collab room (stage on localhost).
+    // Legacy (non-hlx6) docs keep the admin.da.live collab room.
     expect(result.wsProvider.roomname).to.equal(`${DA_ORIGIN}/source/org/repo/page.html`);
     // Clean up the underlying WS connection
     result.wsProvider.disconnect({ data: 'Client navigation' });

--- a/test/unit/blocks/edit/prose/index.test.js
+++ b/test/unit/blocks/edit/prose/index.test.js
@@ -8,6 +8,7 @@ import initProse, {
   createAwarenessStatusWidget,
 } from '../../../../../blocks/edit/prose/index.js';
 import { forceSave } from '../../../../../blocks/edit/prose/forcesave.js';
+import { DA_ORIGIN } from '../../../../../blocks/shared/constants.js';
 
 // initProse lazily imports da-library.js, which (a) builds URLs from
 // `${getNx()}/...` and (b) calls loadLibrary() at module import time.
@@ -98,8 +99,8 @@ describe('prose/index createConnection', () => {
     expect(result.wsProvider).to.exist;
     expect(result.ydoc).to.exist;
     expect(result.wsProvider.maxBackoffTime).to.equal(30000);
-    // Legacy (non-hlx6) docs keep the admin.da.live collab room.
-    expect(result.wsProvider.roomname).to.equal('https://admin.da.live/source/org/repo/page.html');
+    // Legacy (non-hlx6) docs keep the DA admin collab room (stage on localhost).
+    expect(result.wsProvider.roomname).to.equal(`${DA_ORIGIN}/source/org/repo/page.html`);
     // Clean up the underlying WS connection
     result.wsProvider.disconnect({ data: 'Client navigation' });
     result.wsProvider.destroy?.();

--- a/test/unit/blocks/media/da-media.test.js
+++ b/test/unit/blocks/media/da-media.test.js
@@ -10,6 +10,8 @@ const nextFrame = () => new Promise((resolve) => { setTimeout(resolve, 0); });
 
 describe('da-media', () => {
   let el;
+  let revokedObjectUrls;
+  let savedRevokeObjectURL;
 
   async function fixture(details) {
     const element = document.createElement('da-media');
@@ -19,8 +21,15 @@ describe('da-media', () => {
     return element;
   }
 
+  beforeEach(() => {
+    revokedObjectUrls = [];
+    savedRevokeObjectURL = URL.revokeObjectURL;
+    URL.revokeObjectURL = (url) => revokedObjectUrls.push(url);
+  });
+
   afterEach(() => {
     if (el && el.parentElement) el.remove();
+    URL.revokeObjectURL = savedRevokeObjectURL;
     el = null;
   });
 
@@ -50,5 +59,12 @@ describe('da-media', () => {
   it('Sets the document title from details.name', async () => {
     el = await fixture({ name: 'doc.png', contentUrl: '/x.png' });
     expect(document.title).to.contain('View doc.png');
+  });
+
+  it('Revokes Blob URLs when disconnected', async () => {
+    el = await fixture({ name: 'image.png', contentUrl: 'blob:hlx6-media' });
+    el.remove();
+
+    expect(revokedObjectUrls).to.deep.equal(['blob:hlx6-media']);
   });
 });

--- a/test/unit/blocks/media/media.test.js
+++ b/test/unit/blocks/media/media.test.js
@@ -1,0 +1,80 @@
+import { expect } from '@esm-bundle/chai';
+
+const { setNx } = await import('../../../../scripts/utils.js');
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { default: init } = await import('../../../../blocks/media/media.js');
+
+const AEM_API = 'https://api.aem.live';
+const HLX_ADMIN = 'https://admin.hlx.page';
+const BLOB_URL = 'blob:hlx6-media';
+
+function makeFetchMock({ hlx6Paths = [] } = {}) {
+  const calls = [];
+
+  const fetchMock = (url) => {
+    const requestUrl = url.toString();
+    calls.push(requestUrl);
+
+    if (requestUrl.startsWith(`${HLX_ADMIN}/ping/`)) {
+      const path = requestUrl.slice(`${HLX_ADMIN}/ping`.length);
+      const headers = new Headers();
+      if (hlx6Paths.some((candidate) => path.startsWith(candidate))) {
+        headers.set('x-api-upgrade-available', 'true');
+      }
+      return Promise.resolve(new Response('', { status: 200, headers }));
+    }
+
+    if (requestUrl.startsWith(AEM_API)) {
+      return Promise.resolve(new Response(new Blob(['image'], { type: 'image/png' }), { status: 200 }));
+    }
+
+    return Promise.resolve(new Response('', { status: 404 }));
+  };
+
+  return { calls, fetchMock };
+}
+
+describe('media init', () => {
+  let el;
+  let savedFetch;
+  let savedCreateObjectURL;
+
+  beforeEach(() => {
+    savedFetch = window.fetch;
+    savedCreateObjectURL = URL.createObjectURL;
+    URL.createObjectURL = () => BLOB_URL;
+    el = document.createElement('div');
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    window.fetch = savedFetch;
+    URL.createObjectURL = savedCreateObjectURL;
+    localStorage.removeItem('hlx6-upgrade');
+    el.remove();
+  });
+
+  async function expectHlx6MediaUrl(path) {
+    const { calls, fetchMock } = makeFetchMock({ hlx6Paths: ['/rofe/media-hlx6'] });
+    window.fetch = fetchMock;
+    history.pushState(null, '', `/media#/rofe/media-hlx6/${path}`);
+
+    await init(el);
+
+    const daMedia = el.querySelector('da-media');
+    const daTitle = el.querySelector('da-title');
+    expect(daMedia).to.exist;
+    expect(daMedia.details.contentUrl).to.equal(BLOB_URL);
+    expect(daMedia.details).to.not.equal(daTitle.details);
+    expect(calls).to.include(`${AEM_API}/rofe/sites/media-hlx6/source/${path}`);
+  }
+
+  it('loads HLX6 images through the source API', async () => {
+    await expectHlx6MediaUrl('photo.png');
+  });
+
+  it('loads HLX6 videos through the source API', async () => {
+    await expectHlx6MediaUrl('movie.mp4');
+  });
+});

--- a/test/unit/blocks/shared/constants.test.js
+++ b/test/unit/blocks/shared/constants.test.js
@@ -35,6 +35,26 @@ describe('DA Admin', () => {
   });
 });
 
+describe('Local dev defaults to stage', () => {
+  it('Defaults localhost to stage admin', () => {
+    localStorage.removeItem('da-admin');
+    const env = getDaAdmin({ href: 'http://localhost:3000/' });
+    expect(env).to.equal('https://stage-admin.da.live');
+  });
+
+  it('Keeps prod default for non-local hosts', () => {
+    localStorage.removeItem('da-admin');
+    const env = getDaAdmin({ href: 'https://da.live/' });
+    expect(env).to.equal('https://admin.da.live');
+  });
+
+  it('Honors an explicit override on localhost', () => {
+    const env = getDaAdmin({ href: 'http://localhost:3000/?da-admin=prod' });
+    expect(env).to.equal('https://admin.da.live');
+    getDaAdmin({ href: 'http://localhost:3000/?da-admin=reset' });
+  });
+});
+
 describe('Other origins', () => {
   it('Sets DA Origin', () => {
     expect(DA_ORIGIN).to.equal('https://admin.da.live');

--- a/test/unit/blocks/shared/constants.test.js
+++ b/test/unit/blocks/shared/constants.test.js
@@ -16,7 +16,7 @@ import '../../milo.js';
 describe('DA Admin', () => {
   it('Sets DA admin default', () => {
     const env = getDaAdmin();
-    expect(env).to.equal('https://admin.da.live');
+    expect(env).to.equal('https://stage-admin.da.live');
   });
 
   it('Sets DA admin stage', () => {
@@ -29,9 +29,9 @@ describe('DA Admin', () => {
     expect(env).to.equal('https://stage-admin.da.live');
   });
 
-  it('Resets DA admin', () => {
+  it('Resets DA admin to the localhost default', () => {
     const env = getDaAdmin({ href: 'http://localhost:3000/?da-admin=reset' });
-    expect(env).to.equal('https://admin.da.live');
+    expect(env).to.equal('https://stage-admin.da.live');
   });
 });
 
@@ -57,7 +57,7 @@ describe('Local dev defaults to stage', () => {
 
 describe('Other origins', () => {
   it('Sets DA Origin', () => {
-    expect(DA_ORIGIN).to.equal('https://admin.da.live');
+    expect(DA_ORIGIN).to.equal('https://stage-admin.da.live');
   });
 
   it('Sets Content Origin', () => {

--- a/test/unit/blocks/shared/pathDetails.test.js
+++ b/test/unit/blocks/shared/pathDetails.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import '../../milo.js';
+import { DA_ORIGIN } from '../../../../blocks/shared/constants.js';
 
 // Dynamic import because Milo dependency
 const { default: getPathDetails } = await import('../../../../blocks/shared/pathDetails.js');
@@ -66,10 +67,10 @@ describe('Path details', () => {
       it('Handles folder config (/)', () => {
         const loc = { pathname: '/config', hash: '#/adobe/' };
         const details = getPathDetails(loc);
-        expect(details.origin).to.equal('https://admin.da.live');
+        expect(details.origin).to.equal(DA_ORIGIN);
         expect(details.fullpath).to.equal('/adobe/');
         expect(details.repo).to.equal(undefined);
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe`);
         expect(details.name).to.equal('config');
         expect(details.parent).to.equal('/adobe');
         expect(details.parentName).to.equal('adobe');
@@ -79,7 +80,7 @@ describe('Path details', () => {
         const loc = { pathname: '/config', hash: '#/adobe.json' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe.json');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe.json');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe.json`);
         expect(details.parent).to.equal('/');
         expect(details.parentName).to.equal('Root');
       });
@@ -88,7 +89,7 @@ describe('Path details', () => {
         const loc = { pathname: '/config', hash: '#/adobe' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe.html`);
       });
     });
 
@@ -97,7 +98,7 @@ describe('Path details', () => {
         const loc = { pathname: '/sheet', hash: '#/adobe' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe.json');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe.json');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe.json`);
       });
     });
 
@@ -106,7 +107,7 @@ describe('Path details', () => {
         const loc = { pathname: '/edit', hash: '#/adobe' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe.html`);
       });
     });
 
@@ -128,7 +129,7 @@ describe('Path details', () => {
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/');
         expect(details.repo).to.equal('geometrixx');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe/geometrixx`);
         expect(details.name).to.equal('geometrixx config');
         expect(details.parent).to.equal('/adobe/geometrixx');
         expect(details.parentName).to.equal('geometrixx');
@@ -138,7 +139,7 @@ describe('Path details', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx.json' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx.json');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx.json');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe/geometrixx.json`);
         expect(details.parent).to.equal('/adobe');
         expect(details.parentName).to.equal('adobe');
       });
@@ -147,7 +148,7 @@ describe('Path details', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe/geometrixx.html`);
       });
     });
 
@@ -156,7 +157,7 @@ describe('Path details', () => {
         const loc = { pathname: '/sheet', hash: '#/adobe/geometrixx' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx.json');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx.json');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx.json`);
       });
     });
 
@@ -165,7 +166,7 @@ describe('Path details', () => {
         const loc = { pathname: '/edit', hash: '#/adobe/geometrixx' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx.html`);
       });
     });
   });
@@ -177,7 +178,7 @@ describe('Path details', () => {
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123/');
         expect(details.repo).to.equal('geometrixx');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx/testing-123');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe/geometrixx/testing-123`);
         expect(details.name).to.equal('config');
         expect(details.parent).to.equal('/adobe/geometrixx/testing-123');
         expect(details.parentName).to.equal('testing-123');
@@ -187,7 +188,7 @@ describe('Path details', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx/testing-123.json' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123.json');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx/testing-123.json');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe/geometrixx/testing-123.json`);
         expect(details.parent).to.equal('/adobe/geometrixx');
         expect(details.parentName).to.equal('geometrixx');
       });
@@ -196,7 +197,7 @@ describe('Path details', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx/testing-123' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx/testing-123.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/config/adobe/geometrixx/testing-123.html`);
       });
     });
 
@@ -205,7 +206,7 @@ describe('Path details', () => {
         const loc = { pathname: '/sheet', hash: '#/adobe/geometrixx/testing-123' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123.json');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx/testing-123.json');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx/testing-123.json`);
       });
     });
 
@@ -214,35 +215,35 @@ describe('Path details', () => {
         const loc = { pathname: '/edit', hash: '#/adobe/geometrixx/testing-123' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx/testing-123.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx/testing-123.html`);
       });
 
       it('Handles HTML edit if page has .html extension ()', () => {
         const loc = { pathname: '/edit', hash: '#/adobe/geometrixx/testing-123.html' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx/testing-123.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx/testing-123.html`);
       });
 
       it('Handles HTML edit if page name is html and no extension ()', () => {
         const loc = { pathname: '/edit', hash: '#/adobe/geometrixx/html' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/html.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx/html.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx/html.html`);
       });
 
       it('Handles HTML edit if page name is "ilikehtml" and no extension ()', () => {
         const loc = { pathname: '/edit', hash: '#/adobe/geometrixx/ilikehtml' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/ilikehtml.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx/ilikehtml.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx/ilikehtml.html`);
       });
 
       it('Handles HTML edit if page name is html and no extension and has .html extension ()', () => {
         const loc = { pathname: '/edit', hash: '#/adobe/geometrixx/html.html' };
         const details = getPathDetails(loc);
         expect(details.fullpath).to.equal('/adobe/geometrixx/html.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/source/adobe/geometrixx/html.html');
+        expect(details.sourceUrl).to.equal(`${DA_ORIGIN}/source/adobe/geometrixx/html.html`);
       });
     });
   });


### PR DESCRIPTION
# fix(media): load HLX6 media through source API

## Description

HLX6 image and video views load media through the authenticated source API.
DA Live passes a Blob URL to `<da-media>`.
`<da-media>` releases the URL when the view closes.

The existing `content.da.live` URL remains for non-HLX6 repositories.
PDF loading is unchanged.

Fixes #1098

## Tests passed:

`npm test` passes 
a hlx6 source-bus JPEG rendered at 3087x4631 from `api.aem.live`.
no media request went to `content.da.live`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
