### PR TITLE
fix(sheet): normalize weak ETags so saves don't misfire drift detection

### DIFF
--- a/blocks/sheet/utils/utils.js
+++ b/blocks/sheet/utils/utils.js
@@ -4,6 +4,12 @@ import { getNx2Api } from '../../../scripts/utils.js';
 const DEBOUNCE_TIME = 1000;
 const POLL_INTERVAL = 30000;
 
+// Cloudflare downgrades strong ETags to weak (W/"...") whenever it transforms a
+// response body (e.g. gzip/brotli on GETs), so the same file's POST response and a
+// later GET can carry the identical hash with and without the W/ prefix. Strip it
+// before comparing, or every save after the first misfires drift detection.
+const normalizeEtag = (etag) => etag?.replace(/^W\//, '') ?? null;
+
 class StaleCheck {
   constructor() {
     this._intervalId = null;
@@ -37,7 +43,7 @@ class StaleCheck {
   }
 
   markSynced(etag) {
-    this._lastEtag = etag;
+    this._lastEtag = normalizeEtag(etag);
     this._hasLocalEdits = false;
     // Clear the post-Cancel block: a fresh sync (load or save) is the recovery path.
     this._saveBlocked = false;
@@ -89,7 +95,7 @@ class StaleCheck {
         ? await config.get({ org, site, cachebust: true })
         : await source.get({ org, site, path, cachebust: true });
       if (!resp.ok) return false;
-      const etag = resp.headers.get('etag');
+      const etag = normalizeEtag(resp.headers.get('etag'));
       if (!etag || !this._lastEtag || etag === this._lastEtag) return false;
       const json = await resp.json();
       this._onStale({ json, dirty: this._hasLocalEdits });

--- a/test/unit/blocks/sheet/utils-utils.test.js
+++ b/test/unit/blocks/sheet/utils-utils.test.js
@@ -116,6 +116,32 @@ describe('sheet/utils utils', () => {
       const result = await saveSheets(sheets);
       expect(result).to.be.true;
     });
+
+    it('proceeds when the server etag only differs by the weak W/ prefix', async () => {
+      // Cloudflare downgrades strong ETags to weak (W/"...") when it transforms
+      // the response body (gzip/brotli on GETs), so a POST can record a strong
+      // baseline that a later GET echoes back weak with the same hash. That must
+      // not read as drift, otherwise every save after the first misfires.
+      let onStaleFired = false;
+      staleCheck.start({ details: DETAILS, onStale: () => { onStaleFired = true; } });
+      staleCheck.markSynced('"abc123"');
+
+      window.location.hash = '#/org/repo/sheet';
+      window.fetch = wrap(async (url, opts) => {
+        if (opts?.method === 'POST' || opts?.method === 'PUT') {
+          return new Response('', { status: 200, headers: { ETag: '"def456"' } });
+        }
+        return new Response(JSON.stringify(serverJson), {
+          status: 200,
+          headers: { ETag: 'W/"abc123"', 'Content-Type': 'application/json' },
+        });
+      });
+
+      const sheets = [buildSheet('data', [['key'], ['a']])];
+      const result = await saveSheets(sheets);
+      expect(result).to.be.true;
+      expect(onStaleFired).to.be.false;
+    });
   });
 
   describe('handleSave', () => {


### PR DESCRIPTION
Cloudflare returns a strong ETag on the source POST response but downgrades it to weak (W/"...") on the subsequent GET whenever it transforms the body (gzip/brotli). The etag-based drift check introduced in #1113 compared the raw strings, so W/"<hash>" never matched the recorded "<hash>" baseline. Every save after the first therefore read as remote drift: checkForDrift fired onStale and returned true, and saveSheets bailed before POSTing.

This surfaced as the sheet.spec.js delete/move e2e tests timing out on waitForSave (the mutation applied to the local jexcel DOM but never reached the server) and, for real users, as spurious "Content changed" dialogs and silent reloads on the second and later autosaves.

Strip the W/ prefix before comparing, applied at ingestion (markSynced, covering both POST and load-GET etags) and at the drift-check read so both sides are normalized consistently.