### PR TITLE
fix(sheet): weak-compare ETags so save-after-create is not dropped

### DIFF
--- a/blocks/sheet/utils/utils.js
+++ b/blocks/sheet/utils/utils.js
@@ -4,6 +4,11 @@ import { getNx2Api } from '../../../scripts/utils.js';
 const DEBOUNCE_TIME = 1000;
 const POLL_INTERVAL = 30000;
 
+// A gzipped response through Cloudflare carries a weak etag (W/"h") while a
+// create carries a strong etag ("h") for the same content. Strip the weak
+// prefix so the two compare equal (HTTP weak comparison).
+const normalizeEtag = (etag) => etag?.replace(/^W\//, '');
+
 class StaleCheck {
   constructor() {
     this._intervalId = null;
@@ -37,7 +42,7 @@ class StaleCheck {
   }
 
   markSynced(etag) {
-    this._lastEtag = etag;
+    this._lastEtag = normalizeEtag(etag);
     this._hasLocalEdits = false;
     // Clear the post-Cancel block: a fresh sync (load or save) is the recovery path.
     this._saveBlocked = false;
@@ -89,7 +94,7 @@ class StaleCheck {
         ? await config.get({ org, site, cachebust: true })
         : await source.get({ org, site, path, cachebust: true });
       if (!resp.ok) return false;
-      const etag = resp.headers.get('etag');
+      const etag = normalizeEtag(resp.headers.get('etag'));
       if (!etag || !this._lastEtag || etag === this._lastEtag) return false;
       const json = await resp.json();
       this._onStale({ json, dirty: this._hasLocalEdits });

--- a/test/unit/blocks/sheet/utils-utils.test.js
+++ b/test/unit/blocks/sheet/utils-utils.test.js
@@ -116,6 +116,30 @@ describe('sheet/utils utils', () => {
       const result = await saveSheets(sheets);
       expect(result).to.be.true;
     });
+
+    it('treats a weak server etag as equal to a strong baseline (no phantom drift)', async () => {
+      // Cloudflare returns a weak etag (W/"h") on the gzipped GET while a create
+      // returns a strong etag ("h") for the same content. These must compare equal.
+      let onStaleFired = false;
+      staleCheck.start({ details: DETAILS, onStale: () => { onStaleFired = true; } });
+      staleCheck.markSynced('"baseline"');
+
+      window.location.hash = '#/org/repo/sheet';
+      window.fetch = wrap(async (url, opts) => {
+        if (opts?.method === 'POST' || opts?.method === 'PUT') {
+          return new Response('', { status: 200, headers: { ETag: '"next"' } });
+        }
+        return new Response(JSON.stringify(serverJson), {
+          status: 200,
+          headers: { ETag: 'W/"baseline"', 'Content-Type': 'application/json' },
+        });
+      });
+
+      const sheets = [buildSheet('data', [['key'], ['a']])];
+      const result = await saveSheets(sheets);
+      expect(result).to.be.true;
+      expect(onStaleFired).to.be.false;
+    });
   });
 
   describe('handleSave', () => {


### PR DESCRIPTION
## Description

Sheet saves right after a file create were dropped. The drift check bailed the save before the POST.

The check compared ETags as raw strings. admin.da.live is behind Cloudflare, which gzips the GET and returns a weak ETag (`W/"hash"`), while a create returns a strong ETag (`"hash"`) for the same content. So `W/"hash"` did not equal `"hash"`, and the check reported drift that was not there. Editing an existing sheet was unaffected, since its overwrite responses are also weak.

## What changed

Compare ETags with HTTP weak comparison. A `normalizeEtag` helper strips a leading `W/`. It runs in `StaleCheck.markSynced` (the single setter of `_lastEtag`) and on the drift-check GET ETag before the comparison. Weak and strong ETags for the same content now match.

## How Has This Been Tested?

- Unit test, red then green: strong baseline `"baseline"` vs a weak drift GET `W/"baseline"` must not drift. Full unit suite: 1675 passed.
- Live check against admin.da.live: a create returns `"hash"`, the gzipped GET returns `W/"hash"`. The weak compare treats them as equal, so the save proceeds.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
