### PR TITLE
fix: disable save button when the user has no write permission

### DIFF
--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -216,6 +216,9 @@ export default class DaTitle extends LitElement {
   }
 
   async handleAction(action) {
+    // Guard against a stale/bypassed disabled state (e.g. permissions changed mid-session).
+    if (action === 'save' && this._readOnly) return;
+
     this._status = null;
     this._isSending = true;
     this._actions.open = false;
@@ -357,16 +360,20 @@ export default class DaTitle extends LitElement {
   renderActions() {
     if (!this._actions?.available) return nothing;
 
-    return html`${this._actions.available?.map((action) => html`
+    return html`${this._actions.available?.map((action) => {
+      const readOnlyBlock = action === 'save' && this._readOnly;
+      const disabledText = this.disabledText ?? (readOnlyBlock ? 'You do not have permission to save.' : undefined);
+      return html`
       <button
         @click=${() => this.handleAction(action)}
         class="con-button blue da-title-action"
         aria-label="Send"
-        data-popup-content=${this.disabledText ?? nothing}
-        ?disabled=${this.disabledText}>
+        data-popup-content=${disabledText ?? nothing}
+        ?disabled=${this.disabledText || readOnlyBlock}>
         ${action.charAt(0).toUpperCase() + action.slice(1)}
       </button>
-    `)}`;
+    `;
+    })}`;
   }
 
   popover({ target }) {

--- a/test/unit/blocks/edit/da-title/da-title.test.js
+++ b/test/unit/blocks/edit/da-title/da-title.test.js
@@ -582,6 +582,22 @@ describe('DaTitle', () => {
         window.open = savedOpen;
       }
     });
+
+    it('Config view: does not save when the user has no write permission', async () => {
+      const element = buildEl({ details: { view: 'config' }, permissions: ['read'] });
+      element.sheet = [{
+        name: 'config',
+        getData: () => [['k'], ['v']],
+        getConfig: () => ({ columns: [{ width: '20' }] }),
+      }];
+      let fetchCalled = false;
+      window.fetch = () => {
+        fetchCalled = true;
+        return Promise.resolve(new Response('{}', { status: 200 }));
+      };
+      await element.handleAction('save');
+      expect(fetchCalled).to.be.false;
+    });
   });
 
   describe('sidekickCacheBust', () => {
@@ -666,6 +682,34 @@ describe('DaTitle', () => {
       await nextFrame();
       const buttons = element.shadowRoot.querySelectorAll('.da-title-action');
       expect(buttons.length).to.be.at.least(2);
+      element.remove();
+    });
+
+    it('Disables the save button when the user has no write permission', async () => {
+      const element = await fixture({
+        details: createDetails({ view: 'config' }),
+        permissions: ['read'],
+      });
+      element._actions = { available: ['save'] };
+      element.requestUpdate();
+      await nextFrame();
+      await nextFrame();
+      const saveBtn = element.shadowRoot.querySelector('.da-title-action');
+      expect(saveBtn.disabled).to.be.true;
+      element.remove();
+    });
+
+    it('Leaves the save button enabled when the user has write permission', async () => {
+      const element = await fixture({
+        details: createDetails({ view: 'config' }),
+        permissions: ['read', 'write'],
+      });
+      element._actions = { available: ['save'] };
+      element.requestUpdate();
+      await nextFrame();
+      await nextFrame();
+      const saveBtn = element.shadowRoot.querySelector('.da-title-action');
+      expect(saveBtn.disabled).to.be.false;
       element.remove();
     });
   });


### PR DESCRIPTION
## Summary
- The lock icon (`is-read-only` class, driven by `_readOnly` in da-title.js) already reflected read-only state correctly, but the Save action button's `disabled` binding only checked `this.disabledText` - it ignored `_readOnly` entirely.
- A user viewing a config/sheet in read-only mode could still click Save, only discovering the failure after the round-trip to the admin API.
- `renderActions()` now disables the `save` action (with a tooltip) when `_readOnly` is true. `handleAction('save')` also bails early as a guard against a stale/bypassed disabled state.

## Test plan
- [x] `npx eslint blocks/edit/da-title/da-title.js test/unit/blocks/edit/da-title/da-title.test.js`
- [x] `npx wtr "./test/unit/blocks/edit/da-title/da-title.test.js" --node-resolve` - 50 passing
- [x] Added tests: save button `disabled` reflects permissions in `renderActions`, and `handleAction('save')` is a no-op (no fetch) when read-only

(Supersedes #1161, closed when its branch got renamed out from under it.)