### PR TITLE
fix(ew): reduce spacing between list items in doc editor (#1109)

### DIFF
--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.css
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.css
@@ -54,6 +54,10 @@
   height: auto;
 }
 
+.ew-editor-doc .ProseMirror li p {
+  margin: 0;
+}
+
 /* Table chrome matches da.live da-editor.css “COPY FROM TABLES”: wrapper holds the
    outer border; table uses border-style hidden so cell borders do not stack on it. */
 .ew-editor-doc .ProseMirror table {


### PR DESCRIPTION
https://i1109--da-live--adobe.aem.live

Fix #1109 

<img width="282" height="224" alt="Screenshot 2026-07-22 at 12 32 22" src="https://github.com/user-attachments/assets/1aa09e93-4e23-4610-a191-2897fafb07ba" />
