### PR TITLE
fix(canvas): allow dropping blocks into empty outline sections

### DIFF
--- a/blocks/canvas/editor-utils/blocks.js
+++ b/blocks/canvas/editor-utils/blocks.js
@@ -108,6 +108,38 @@ export function insertBlockAtSectionStart(view, dom, sectionIndex) {
   view.dispatch(view.state.tr.insert(pos, parsed).scrollIntoView());
 }
 
+function getSectionCount(view) {
+  const { doc, schema } = view.state;
+  let count = 1;
+  doc.forEach((node) => {
+    if (node.type === schema.nodes.horizontal_rule) count += 1;
+  });
+  return count;
+}
+
+export function moveBlockToSection(view, fromIndex, sectionIndex) {
+  if (!view) return;
+  const positions = getBlockPositions(view);
+  if (fromIndex < 0 || fromIndex >= positions.length) return;
+  if (sectionIndex < 0 || sectionIndex >= getSectionCount(view)) return;
+
+  const fromBlockPos = positions[fromIndex];
+  const fromBlockNode = view.state.doc.nodeAt(fromBlockPos);
+  if (!fromBlockNode) return;
+  const fromBlockSize = fromBlockNode.nodeSize;
+
+  const insertPos = getSectionStartOffset(view, sectionIndex);
+  const adjustedInsertPos = insertPos > fromBlockPos
+    ? insertPos - fromBlockSize
+    : insertPos;
+
+  view.dispatch(
+    view.state.tr
+      .delete(fromBlockPos, fromBlockPos + fromBlockSize)
+      .insert(adjustedInsertPos, fromBlockNode),
+  );
+}
+
 export function deleteSection(view, sectionIndex) {
   if (!view) return;
   const { doc, schema } = view.state;

--- a/blocks/canvas/ew-page-outline/ew-page-outline.js
+++ b/blocks/canvas/ew-page-outline/ew-page-outline.js
@@ -8,6 +8,7 @@ import {
   deleteSection,
   insertBlockAtSectionStart,
   moveBlock,
+  moveBlockToSection,
   moveSection,
 } from '../editor-utils/blocks.js';
 import { fetchExtensions } from '../ew-panel-extensions/helpers.js';
@@ -148,8 +149,16 @@ class EwPageOutline extends LitElement {
         : e.currentTarget;
 
       this._setDropIndicator(el, { sectionIndex: sec.sectionIndex, dropPosition });
+    } else if (!sec.blocks.length) {
+      e.preventDefault();
+
+      const emptyEl = e.currentTarget.querySelector('[data-empty-section]');
+      if (!emptyEl) return;
+      this._setDropIndicator(
+        emptyEl,
+        { sectionIndex: sec.sectionIndex, dropPosition: DROP_POSITIONS.AFTER, emptySection: true },
+      );
     } else {
-      if (!sec.blocks.length) return;
       if (sec.blocks.some((b) => b.blockIndex === this._dragging?.index)) return;
       const { blockIndex } = sec.blocks[sec.blocks.length - 1];
       e.preventDefault();
@@ -180,6 +189,9 @@ class EwPageOutline extends LitElement {
     if (_dropTarget.blockIndex != null) {
       if (_dragging.type !== OUTLINE_TYPES.BLOCK) return;
       moveBlock(view, _dragging.index, _dropTarget.blockIndex, _dropTarget.dropPosition);
+    } else if (_dropTarget.emptySection) {
+      if (_dragging.type !== OUTLINE_TYPES.BLOCK) return;
+      moveBlockToSection(view, _dragging.index, _dropTarget.sectionIndex);
     } else if (_dropTarget.sectionIndex != null) {
       if (_dragging.type !== OUTLINE_TYPES.SECTION) return;
       moveSection(view, _dragging.index, _dropTarget.sectionIndex, _dropTarget.dropPosition);
@@ -264,7 +276,7 @@ class EwPageOutline extends LitElement {
         <ul class="block-list" role="group"
             aria-label="Blocks in section ${sec.sectionIndex + 1}">
           ${sec.blocks.length === 0
-        ? html`<li class="block-item block-empty"
+        ? html`<li class="block-item block-empty" data-empty-section
                     role="treeitem" tabindex="-1">
                 <span class="empty-label">No blocks</span>
               </li>`

--- a/test/unit/blocks/canvas/editor-utils/blocks.test.js
+++ b/test/unit/blocks/canvas/editor-utils/blocks.test.js
@@ -1,0 +1,75 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { createTestEditor, destroyEditor } = await import('../../edit/prose/test-helpers.js');
+const { moveBlockToSection, getBlockPositions } = await import('../../../../../blocks/canvas/editor-utils/blocks.js');
+
+function makeBlockTable(schema, name) {
+  const para = schema.nodes.paragraph.create(null, schema.text(name));
+  const cell = schema.nodes.table_cell.create({ colspan: 1, colwidth: null }, para);
+  const row = schema.nodes.table_row.create(null, cell);
+  return schema.nodes.table.create(null, row);
+}
+
+describe('moveBlockToSection', () => {
+  let editor;
+  beforeEach(async () => { editor = await createTestEditor(); });
+  afterEach(() => destroyEditor(editor));
+
+  it('moves a block into an empty target section, removing it from its original location', () => {
+    const { state } = editor.view;
+    const { schema } = state;
+
+    const blockA = makeBlockTable(schema, 'blocka');
+    const hr = schema.nodes.horizontal_rule.create();
+
+    // Section 0: [blockA], Section 1: [] (empty - hr is the last node in the doc)
+    editor.view.dispatch(state.tr.replaceWith(0, state.doc.content.size, [blockA, hr]));
+
+    expect(getBlockPositions(editor.view).length).to.equal(1);
+
+    moveBlockToSection(editor.view, 0, 1);
+
+    const { doc } = editor.view.state;
+    const positions = getBlockPositions(editor.view);
+    expect(positions.length).to.equal(1);
+
+    // The single remaining block must now live in section 1, i.e. after the horizontal_rule.
+    let hrPos = -1;
+    doc.descendants((node, pos) => {
+      if (node.type.name === 'horizontal_rule') hrPos = pos;
+    });
+    expect(hrPos).to.be.greaterThan(-1);
+    expect(positions[0]).to.be.greaterThan(hrPos);
+
+    const movedNode = doc.nodeAt(positions[0]);
+    expect(movedNode.type.name).to.equal('table');
+    expect(movedNode.textContent).to.include('blocka');
+  });
+
+  it('does nothing when fromIndex is out of range', () => {
+    const { state } = editor.view;
+    const { schema } = state;
+    const blockA = makeBlockTable(schema, 'blocka');
+    const hr = schema.nodes.horizontal_rule.create();
+    editor.view.dispatch(state.tr.replaceWith(0, state.doc.content.size, [blockA, hr]));
+
+    const before = editor.view.state.doc.toString();
+    moveBlockToSection(editor.view, 5, 1);
+    expect(editor.view.state.doc.toString()).to.equal(before);
+  });
+
+  it('does nothing when sectionIndex is out of range', () => {
+    const { state } = editor.view;
+    const { schema } = state;
+    const blockA = makeBlockTable(schema, 'blocka');
+    const hr = schema.nodes.horizontal_rule.create();
+    editor.view.dispatch(state.tr.replaceWith(0, state.doc.content.size, [blockA, hr]));
+
+    const before = editor.view.state.doc.toString();
+    moveBlockToSection(editor.view, 0, 5);
+    expect(editor.view.state.doc.toString()).to.equal(before);
+  });
+});


### PR DESCRIPTION
## Summary
- The outline panel's `_onSectionDragOver` bailed out entirely (`if (!sec.blocks.length) return;`) when dragging a block over a section with zero blocks, making it impossible to drop a block into an empty section.
- Added `moveBlockToSection(view, fromIndex, sectionIndex)` in `blocks/canvas/editor-utils/blocks.js`, following the same delete-then-insert-with-offset-adjustment pattern as `moveBlock`, reusing `getBlockPositions`/`getSectionStartOffset`, and validating both `fromIndex` and `sectionIndex` are in range.
- Updated `_onSectionDragOver` to show a drop indicator on the "No blocks" placeholder `<li>` (tagged `data-empty-section`) when dragging a block over an empty section, and updated `_onDrop` to dispatch `moveBlockToSection` for this case (disambiguated via a new `emptySection` flag on `_dropTarget`, since a `sectionIndex`-only drop target previously always meant "reorder whole section").
- No CSS changes needed — the existing `[data-drop-position="before"/"after"]` selectors are unscoped attribute selectors, so they already apply to the empty-section placeholder `<li>`.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (1689 passed, 0 failed, 4 pre-existing skipped)
- [x] Added `test/unit/blocks/canvas/editor-utils/blocks.test.js` covering `moveBlockToSection`: moving a block into an empty section, out-of-range `fromIndex`, out-of-range `sectionIndex`
- [ ] Full browser/manual verification — NOT performed. This is a collaborative, IMS-authenticated editor requiring a real org/site; no dev server or browser session was run against it in this sandbox. Please verify drag-and-drop behavior manually before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)