### PR TITLE
fix: validate setHref postMessage payload to prevent DOM XSS

### DIFF
--- a/blocks/canvas/ew-panel-extensions/iframe-protocol.js
+++ b/blocks/canvas/ew-panel-extensions/iframe-protocol.js
@@ -1,6 +1,6 @@
 import { insertText, insertHTML, getEditorSelection } from './helpers.js';
 import { getNx } from '../../../scripts/utils.js';
-import { getPostMessageTargetOrigin } from '../../shared/utils.js';
+import { getPostMessageTargetOrigin, isValidHref } from '../../shared/utils.js';
 
 /**
  * Wire a two-way MessageChannel between the host and a BYO plugin iframe.
@@ -36,7 +36,7 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
       window.location.hash = details;
     }
 
-    if (action === 'setHref') {
+    if (action === 'setHref' && isValidHref(details)) {
       window.location.href = details;
     }
 

--- a/blocks/edit/da-library/da-library.js
+++ b/blocks/edit/da-library/da-library.js
@@ -2,7 +2,7 @@ import { LitElement, html, nothing } from 'da-lit';
 import { DOMParser as proseDOMParser, DOMSerializer, Slice, TextSelection } from 'da-y-wrapper';
 import { htmlToProse } from '../utils/helpers.js';
 import { getNx, sanitizePathParts } from '../../../scripts/utils.js';
-import { getPostMessageTargetOrigin } from '../../shared/utils.js';
+import { getPostMessageTargetOrigin, isValidHref } from '../../shared/utils.js';
 import getSheet from '../../shared/sheet.js';
 import inlinesvg from '../../shared/inlinesvg.js';
 import searchFor from './helpers/search.js';
@@ -270,7 +270,7 @@ class DaLibrary extends LitElement {
       if (e.data.action === 'setHash') {
         window.location.hash = e.data.details;
       }
-      if (e.data.action === 'setHref') {
+      if (e.data.action === 'setHref' && isValidHref(e.data.details)) {
         window.location.href = e.data.details;
       }
       if (e.data.action === 'closeLibrary') {

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -264,6 +264,16 @@ export const getSheetByName = (json, name) => {
 
 export const getFirstSheet = (json) => getSheetByIndex(json, 0);
 
+export function isValidHref(href) {
+  if (typeof href !== 'string' || !href) return false;
+  if (href.startsWith('/') && !href.startsWith('//')) return true;
+  try {
+    return new URL(href).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export function getPostMessageTargetOrigin(url, fallback = '/') {
   try {
     return new URL(url, window.location.href).origin;

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -15,6 +15,7 @@ import {
   sanitizeName,
   fetchDaConfigs,
   getAuthToken,
+  isValidHref,
 } from '../../../../blocks/shared/utils.js';
 
 // daFetch's 401-no-token path lazy-loads the banner module, which resolves
@@ -745,6 +746,46 @@ describe('aemAction', () => {
 
     const result = await aemAction('/org/site/doc', 'publish', { onScheduled: async () => false });
     expect(result.cancelled).to.be.true;
+  });
+});
+
+describe('isValidHref', () => {
+  it('Accepts a root-relative path', () => {
+    expect(isValidHref('/foo/bar')).to.be.true;
+  });
+
+  it('Accepts an https URL', () => {
+    expect(isValidHref('https://example.com/foo')).to.be.true;
+  });
+
+  it('Rejects an http URL', () => {
+    expect(isValidHref('http://example.com/foo')).to.be.false;
+  });
+
+  it('Rejects a javascript: URL', () => {
+    expect(isValidHref(`${'javascript'}:alert(1)`)).to.be.false;
+  });
+
+  it('Rejects a data: URL', () => {
+    expect(isValidHref('data:text/html,<script>alert(1)</script>')).to.be.false;
+  });
+
+  it('Rejects a protocol-relative URL', () => {
+    expect(isValidHref('//evil.example.com')).to.be.false;
+  });
+
+  it('Rejects a bare host with no scheme or leading slash', () => {
+    expect(isValidHref('evil.example.com')).to.be.false;
+  });
+
+  it('Rejects an empty string', () => {
+    expect(isValidHref('')).to.be.false;
+  });
+
+  it('Rejects non-string input', () => {
+    expect(isValidHref(undefined)).to.be.false;
+    expect(isValidHref(null)).to.be.false;
+    expect(isValidHref({})).to.be.false;
   });
 });
 


### PR DESCRIPTION
## Summary
- `setHref` message handlers in `iframe-protocol.js` and `da-library.js` assigned the raw `details` payload from a plugin/iframe postMessage directly to `window.location.href` with no validation, allowing a compromised or malicious plugin to navigate the host app via `javascript:`, `data:`, or other unexpected schemes/origins.
- Added a shared `isValidHref()` helper in `blocks/shared/utils.js` that accepts only root-relative paths (`/foo`, rejecting protocol-relative `//host`) or absolute `https:` URLs.
- Both `setHref` handlers now gate the `window.location.href` assignment on `isValidHref()`.

## Test plan
- [x] Added `isValidHref` unit tests in `test/unit/blocks/shared/utils.test.js` covering root-relative paths, https URLs, and rejection of http, `javascript:`, `data:`, protocol-relative, bare-host, empty, and non-string inputs.
- [x] Ran full unit test suite (`npm test`) — 1706 passed, 0 failed.
- [x] `npx eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)