### PR TITLE
fix(scheduler): make Scheduler App link visible

### DIFF
--- a/blocks/edit/da-prepare/actions/scheduler/scheduler.js
+++ b/blocks/edit/da-prepare/actions/scheduler/scheduler.js
@@ -33,7 +33,7 @@ class DaScheduler extends LitElement {
       this._statusText = null;
       this._instructions = html`
         <p>This site is not registered.</p>
-        <p>Please register your site in the Scheduler App <a href="${REGISTER_PATH}"></a> first.</p>`;
+        <p>Please register your site in the <a href="${REGISTER_PATH}">Scheduler App</a> first.</p>`;
       return;
     }
 


### PR DESCRIPTION
## Summary
Fixed missing link text in scheduler registration message.

## Test plan
- Open Schedule Publish dialog on an unregistered site
- Verify "Scheduler App" is now a clickable link

<img width="335" height="293" alt="image" src="https://github.com/user-attachments/assets/6305b021-dc41-4715-b8f2-64f8475e27cc" />

vs 

<img width="347" height="298" alt="image" src="https://github.com/user-attachments/assets/71443d96-7110-4491-a026-fefc12043883" />
