### PR TITLE
fix: filter DA asset picker to approved DM assets

### DIFF
--- a/blocks/canvas/ew-panel-extensions/aem-assets.js
+++ b/blocks/canvas/ew-panel-extensions/aem-assets.js
@@ -5,7 +5,7 @@ import {
   isDynamicMediaEnabled,
   shouldFilterApprovedAssets,
 } from '../../shared/aem-assets/config.js';
-import { getApprovedOnlyFilterProps } from '../../shared/aem-assets/filter-schema.js';
+import { buildAssetSelectorProps } from '../../shared/aem-assets/selector-props.js';
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
 
 const { fetchDaConfigs, getFirstSheet } = await import(`${getNx()}/utils/daConfig.js`);
@@ -122,23 +122,6 @@ function getAssetAlt(asset) {
     || '';
 }
 
-export function buildAssetSelectorProps({
-  token,
-  repoConfig,
-  onClose,
-  handleSelection,
-}) {
-  return {
-    imsToken: token,
-    repositoryId: repoConfig.repositoryId,
-    aemTierType: repoConfig.tierType,
-    featureSet: ['upload', 'collections', 'detail-panel', 'advisor'],
-    ...getApprovedOnlyFilterProps(repoConfig.approvedOnly),
-    ...(onClose && { onClose }),
-    handleSelection,
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Script loader
 // ---------------------------------------------------------------------------
@@ -165,8 +148,8 @@ export async function renderAssets({ container, org, site, onClose }) {
   const { loadIms, handleSignIn } = await import(`${getNx()}/utils/ims.js`);
   const ims = await loadIms();
   if (ims?.anonymous) handleSignIn();
-  const token = ims?.accessToken?.token;
-  if (!token) return;
+  const imsToken = ims?.accessToken?.token;
+  if (!imsToken) return;
 
   const repoConfig = await getRepositoryConfig(org, site);
   if (!repoConfig) return;
@@ -189,7 +172,7 @@ export async function renderAssets({ container, org, site, onClose }) {
   };
 
   const selectorProps = buildAssetSelectorProps({
-    token,
+    imsToken,
     repoConfig,
     onClose,
     handleSelection,

--- a/blocks/canvas/ew-panel-extensions/aem-assets.js
+++ b/blocks/canvas/ew-panel-extensions/aem-assets.js
@@ -1,6 +1,11 @@
 /* eslint-disable import/no-unresolved -- importmap */
 import { DOMParser as PMDOMParser } from 'da-y-wrapper';
 import { getNx } from '../../../scripts/utils.js';
+import {
+  isDynamicMediaEnabled,
+  shouldFilterApprovedAssets,
+} from '../../shared/aem-assets/config.js';
+import { getApprovedOnlyFilterProps } from '../../shared/aem-assets/filter-schema.js';
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
 
 const { fetchDaConfigs, getFirstSheet } = await import(`${getNx()}/utils/daConfig.js`);
@@ -25,9 +30,19 @@ export async function getRepositoryConfig(org, site) {
 
   const tierType = repositoryId.startsWith('delivery') ? 'delivery' : 'author';
   const customOrigin = getValue('aem.assets.prod.origin');
-  const isDmEnabled = getValue('aem.asset.dm.delivery') === 'on'
-    || getValue('aem.asset.smartcrop.select') === 'on'
-    || tierType === 'delivery';
+  const dmDelivery = getValue('aem.asset.dm.delivery');
+  const smartCrop = getValue('aem.asset.smartcrop.select');
+  const isDmEnabled = isDynamicMediaEnabled({
+    repositoryId,
+    customOrigin,
+    dmDelivery,
+    smartCrop,
+  });
+  const approvedOnly = shouldFilterApprovedAssets({
+    tierType,
+    isDmEnabled,
+    configuredValue: getValue('aem.asset.dm.approvedonly'),
+  });
 
   let assetOrigin;
   if (customOrigin) assetOrigin = customOrigin;
@@ -37,7 +52,14 @@ export async function getRepositoryConfig(org, site) {
 
   const assetBasePath = getValue('aem.assets.prod.basepath') || DEFAULT_BASE_PATH;
 
-  return { repositoryId, tierType, assetOrigin, assetBasePath, isDmEnabled };
+  return {
+    repositoryId,
+    tierType,
+    assetOrigin,
+    assetBasePath,
+    isDmEnabled,
+    approvedOnly,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -100,6 +122,23 @@ function getAssetAlt(asset) {
     || '';
 }
 
+export function buildAssetSelectorProps({
+  token,
+  repoConfig,
+  onClose,
+  handleSelection,
+}) {
+  return {
+    imsToken: token,
+    repositoryId: repoConfig.repositoryId,
+    aemTierType: repoConfig.tierType,
+    featureSet: ['upload', 'collections', 'detail-panel', 'advisor'],
+    ...getApprovedOnlyFilterProps(repoConfig.approvedOnly),
+    ...(onClose && { onClose }),
+    handleSelection,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Script loader
 // ---------------------------------------------------------------------------
@@ -134,27 +173,27 @@ export async function renderAssets({ container, org, site, onClose }) {
 
   await loadSelectorScript();
 
-  const selectorProps = {
-    imsToken: token,
-    repositoryId: repoConfig.repositoryId,
-    aemTierType: repoConfig.tierType,
-    featureSet: ['upload', 'collections', 'detail-panel', 'advisor'],
-    ...(onClose && { onClose }),
-    handleSelection: (assets) => {
-      const [asset] = assets;
-      if (!asset) return;
-      const { view } = getExtensionsBridge();
-      if (!view) return;
-      const src = resolveAssetUrl(asset, repoConfig);
-      const mimetype = (asset.mimetype || asset['dc:format'] || '').toLowerCase();
-      const alt = getAssetAlt(asset);
-      if (mimetype.startsWith('image/')) {
-        insertImage(view, src, alt);
-      } else {
-        insertLink(view, src);
-      }
-    },
+  const handleSelection = (assets) => {
+    const [asset] = assets;
+    if (!asset) return;
+    const { view } = getExtensionsBridge();
+    if (!view) return;
+    const src = resolveAssetUrl(asset, repoConfig);
+    const mimetype = (asset.mimetype || asset['dc:format'] || '').toLowerCase();
+    const alt = getAssetAlt(asset);
+    if (mimetype.startsWith('image/')) {
+      insertImage(view, src, alt);
+    } else {
+      insertLink(view, src);
+    }
   };
+
+  const selectorProps = buildAssetSelectorProps({
+    token,
+    repoConfig,
+    onClose,
+    handleSelection,
+  });
 
   window.PureJSSelectors.renderAssetSelector(container, selectorProps);
 }

--- a/blocks/edit/da-assets/README.md
+++ b/blocks/edit/da-assets/README.md
@@ -39,7 +39,7 @@ The behaviour of the asset selector is determined entirely by the `aem.repositor
 - Asset browser shows the full **folder hierarchy** from AEM DAM.
 - Inserted URLs are **DM delivery URLs**: `https://delivery-p…/<basePath>/<id>/as/<name>.avif`
 - Assets must be **approved** (`dam:assetStatus = approved`) and **activated for delivery** (`dam:activationTarget = delivery`) before they can be inserted. Unapproved assets show an error panel.
-- Content Advisor filters the author-tier listing to **Approved** assets only when `aem.asset.dm.approvedonly = on`. Absent or `off` leaves Content Advisor unfiltered.
+- Content Advisor filters the author-tier listing to **Approved** assets by default. The filter is locked. Exact `aem.asset.dm.approvedonly = off` opts out and leaves Content Advisor unfiltered.
 - When `aem.asset.smartcrop.select = on`, a Smart Crop selection dialog is shown for images.
 
 ### 3. Delivery (DM Open API)
@@ -65,7 +65,7 @@ All keys are set in the DA site config at `https://da.live/config#/<org>/` or `h
 | `aem.assets.prod.basepath` | No | e.g. `/adobe/assets` | Overrides the default base path (`/adobe/assets`) used in DM and delivery URLs. |
 | `aem.assets.image.type` | No | `link` | Insert images as `<a>` links instead of `<img>` tags. Useful for Dynamic Media URLs that need to bypass Media Bus. |
 | `aem.asset.dm.delivery` | No | `on` | Use author for browsing but construct DM delivery URLs when inserting. Activates Author+DM mode. |
-| `aem.asset.dm.approvedonly` | No | `on` or `off` | For author-backed Dynamic Media modes, show only Approved assets through a locked Content Advisor filter when set to `on`. Absent or `off` leaves Content Advisor unfiltered. Has no effect for Author + Publish or delivery-tier browsing. |
+| `aem.asset.dm.approvedonly` | No | absent, `on`, or `off` | For author-backed Dynamic Media modes, the default is to show only Approved assets through a locked Content Advisor filter. Absent or `on` enables it; exact `off` opts out and leaves Content Advisor unfiltered. Has no effect for Author + Publish or delivery-tier browsing. |
 | `aem.asset.smartcrop.select` | No | `on` | Show the Smart Crop selection dialog when an image is selected. Implies DM delivery. |
 | `aem.asset.mime.renditions` | No | e.g. `image/vnd.adobe.photoshop:avif, image/*:original, video/*:original` | Comma-separated `mimetype:renditiontype` pairs that override the default rendition type for specific mime types. Supports exact types and prefix wildcards (`image/*`, `video/*`). See [Rendition resolution](#rendition-resolution). |
 

--- a/blocks/edit/da-assets/README.md
+++ b/blocks/edit/da-assets/README.md
@@ -39,6 +39,7 @@ The behaviour of the asset selector is determined entirely by the `aem.repositor
 - Asset browser shows the full **folder hierarchy** from AEM DAM.
 - Inserted URLs are **DM delivery URLs**: `https://delivery-p…/<basePath>/<id>/as/<name>.avif`
 - Assets must be **approved** (`dam:assetStatus = approved`) and **activated for delivery** (`dam:activationTarget = delivery`) before they can be inserted. Unapproved assets show an error panel.
+- Content Advisor filters the author-tier listing to **Approved** assets by default. The filter is locked so authors cannot remove it. Set `aem.asset.dm.approvedonly` to `off` to spawn the selector without a custom filter schema.
 - When `aem.asset.smartcrop.select = on`, a Smart Crop selection dialog is shown for images.
 
 ### 3. Delivery (DM Open API)
@@ -48,6 +49,8 @@ The behaviour of the asset selector is determined entirely by the `aem.repositor
 - Asset browser shows a **flat listing** (no folder structure) of all approved assets.
 - Inserted URLs follow the [AEM Delivery API spec](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/manage/asset-selector/asset-selector-integration/integrate-asset-selector-dynamic-media-open-api): `https://<host>/<basePath>/<asset-id>/as/<seo-name>.avif`
 - No approval check is needed — the delivery tier only exposes approved assets.
+
+The approved-only picker behavior is shared by the document editor and Canvas/Experience Workspace.
 
 ---
 
@@ -62,6 +65,7 @@ All keys are set in the DA site config at `https://da.live/config#/<org>/` or `h
 | `aem.assets.prod.basepath` | No | e.g. `/adobe/assets` | Overrides the default base path (`/adobe/assets`) used in DM and delivery URLs. |
 | `aem.assets.image.type` | No | `link` | Insert images as `<a>` links instead of `<img>` tags. Useful for Dynamic Media URLs that need to bypass Media Bus. |
 | `aem.asset.dm.delivery` | No | `on` | Use author for browsing but construct DM delivery URLs when inserting. Activates Author+DM mode. |
+| `aem.asset.dm.approvedonly` | No | `on` (default) or `off` | For author-backed Dynamic Media modes, show only Approved assets through a locked Content Advisor filter. Absent and `on` enable the filter; `off` restores Content Advisor's unfiltered initialization. Has no effect for Author + Publish or delivery-tier browsing. |
 | `aem.asset.smartcrop.select` | No | `on` | Show the Smart Crop selection dialog when an image is selected. Implies DM delivery. |
 | `aem.asset.mime.renditions` | No | e.g. `image/vnd.adobe.photoshop:avif, image/*:original, video/*:original` | Comma-separated `mimetype:renditiontype` pairs that override the default rendition type for specific mime types. Supports exact types and prefix wildcards (`image/*`, `video/*`). See [Rendition resolution](#rendition-resolution). |
 

--- a/blocks/edit/da-assets/README.md
+++ b/blocks/edit/da-assets/README.md
@@ -39,7 +39,7 @@ The behaviour of the asset selector is determined entirely by the `aem.repositor
 - Asset browser shows the full **folder hierarchy** from AEM DAM.
 - Inserted URLs are **DM delivery URLs**: `https://delivery-p…/<basePath>/<id>/as/<name>.avif`
 - Assets must be **approved** (`dam:assetStatus = approved`) and **activated for delivery** (`dam:activationTarget = delivery`) before they can be inserted. Unapproved assets show an error panel.
-- Content Advisor filters the author-tier listing to **Approved** assets by default. The filter is locked so authors cannot remove it. Set `aem.asset.dm.approvedonly` to `off` to spawn the selector without a custom filter schema.
+- Content Advisor filters the author-tier listing to **Approved** assets only when `aem.asset.dm.approvedonly = on`. Absent or `off` leaves Content Advisor unfiltered.
 - When `aem.asset.smartcrop.select = on`, a Smart Crop selection dialog is shown for images.
 
 ### 3. Delivery (DM Open API)
@@ -65,7 +65,7 @@ All keys are set in the DA site config at `https://da.live/config#/<org>/` or `h
 | `aem.assets.prod.basepath` | No | e.g. `/adobe/assets` | Overrides the default base path (`/adobe/assets`) used in DM and delivery URLs. |
 | `aem.assets.image.type` | No | `link` | Insert images as `<a>` links instead of `<img>` tags. Useful for Dynamic Media URLs that need to bypass Media Bus. |
 | `aem.asset.dm.delivery` | No | `on` | Use author for browsing but construct DM delivery URLs when inserting. Activates Author+DM mode. |
-| `aem.asset.dm.approvedonly` | No | `on` (default) or `off` | For author-backed Dynamic Media modes, show only Approved assets through a locked Content Advisor filter. Absent and `on` enable the filter; `off` restores Content Advisor's unfiltered initialization. Has no effect for Author + Publish or delivery-tier browsing. |
+| `aem.asset.dm.approvedonly` | No | `on` or `off` | For author-backed Dynamic Media modes, show only Approved assets through a locked Content Advisor filter when set to `on`. Absent or `off` leaves Content Advisor unfiltered. Has no effect for Author + Publish or delivery-tier browsing. |
 | `aem.asset.smartcrop.select` | No | `on` | Show the Smart Crop selection dialog when an image is selected. Implies DM delivery. |
 | `aem.asset.mime.renditions` | No | e.g. `image/vnd.adobe.photoshop:avif, image/*:original, video/*:original` | Comma-separated `mimetype:renditiontype` pairs that override the default rendition type for specific mime types. Supports exact types and prefix wildcards (`image/*`, `video/*`). See [Rendition resolution](#rendition-resolution). |
 
@@ -161,6 +161,11 @@ Exports `DEFAULT_ASSET_BASE_PATH` (`/adobe/assets`), the default base path segme
 }
 ```
 
+### `blocks/shared/aem-assets/selector-props.js`
+
+- `buildFeatureSet(isDmEnabled)` — returns the asset-selector feature list. Base features: `upload`, `collections`, `detail-panel`, `advisor`. Adds `dynamic-media` only when DM is enabled.
+- `buildAssetSelectorProps({ imsToken, repoConfig, externalBrief, onClose, handleSelection })` — builds the shared AEM Asset Selector props, including approved-only filter props when enabled.
+
 ### `helpers/urls.js`
 
 URL builder functions keyed to the mode:
@@ -206,7 +211,6 @@ Entry point. Key exports:
   3. Creates the `<dialog>` with two panels (asset selector and secondary for crops/errors) and mounts the AEM Asset Selector via `window.PureJSSelectors.renderAssetSelector`.
   4. Handles selection by routing to the correct URL builder, approval check, or Smart Crop dialog based on the mode.
 - `formatExternalBrief(doc)` — extracts the document title and plain-text content from the ProseMirror doc to build an AI advisor brief for the asset selector.
-- `buildFeatureSet(isDmEnabled)` — returns the feature set array for the selector. Base features: `upload`, `collections`, `detail-panel`, `advisor`. Adds `dynamic-media` when DM is enabled.
 - `resolveAssetUrl(asset, repoConfig)` — routes to the correct URL builder based on mode and config.
 - `createDialogPanels()` — creates the two dialog inner panels (asset panel and secondary panel).
 - `buildHandleSelection(dialog, assetPanel, secondaryPanel, repoConfig, responsiveImageConfigPromise)` — returns the selection handler callback wired to the dialog lifecycle.

--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -1,5 +1,6 @@
 import { getNx } from '../../../scripts/utils.js';
 import getPathDetails from '../../shared/pathDetails.js';
+import { getApprovedOnlyFilterProps } from '../../shared/aem-assets/filter-schema.js';
 import { getRepositoryConfig, getResponsiveImageConfig } from './helpers/config.js';
 import {
   buildAuthorUrl, buildDmUrl, buildDeliveryUrl,
@@ -39,6 +40,25 @@ export function buildFeatureSet(isDmEnabled) {
   const features = ['upload', 'collections', 'detail-panel', 'advisor'];
   if (isDmEnabled) features.push('dynamic-media');
   return features;
+}
+
+export function buildAssetSelectorProps({
+  imsToken,
+  repoConfig,
+  externalBrief,
+  onClose,
+  handleSelection,
+}) {
+  return {
+    imsToken,
+    repositoryId: repoConfig.repositoryId,
+    aemTierType: repoConfig.tierType,
+    featureSet: buildFeatureSet(repoConfig.isDmEnabled),
+    externalBrief,
+    ...getApprovedOnlyFilterProps(repoConfig.approvedOnly),
+    onClose,
+    handleSelection,
+  };
 }
 
 export function resolveAssetUrl(asset, repoConfig) {
@@ -221,11 +241,9 @@ export async function openAssets() {
   const responsiveImageConfigPromise = getResponsiveImageConfig(owner, repo);
   const externalBrief = formatExternalBrief(window.view.state.doc);
 
-  const selectorProps = {
+  const selectorProps = buildAssetSelectorProps({
     imsToken: details.accessToken.token,
-    repositoryId: repoConfig.repositoryId,
-    aemTierType: repoConfig.tierType,
-    featureSet: buildFeatureSet(repoConfig.isDmEnabled),
+    repoConfig,
     externalBrief,
     onClose: () => assetPanel.style.display !== 'none' && dialog.close(),
     handleSelection: buildHandleSelection(
@@ -235,7 +253,7 @@ export async function openAssets() {
       repoConfig,
       responsiveImageConfigPromise,
     ),
-  };
+  });
 
   window.PureJSSelectors.renderAssetSelector(assetPanel, selectorProps);
 }

--- a/blocks/edit/da-assets/da-assets.js
+++ b/blocks/edit/da-assets/da-assets.js
@@ -1,6 +1,6 @@
 import { getNx } from '../../../scripts/utils.js';
 import getPathDetails from '../../shared/pathDetails.js';
-import { getApprovedOnlyFilterProps } from '../../shared/aem-assets/filter-schema.js';
+import { buildAssetSelectorProps } from '../../shared/aem-assets/selector-props.js';
 import { getRepositoryConfig, getResponsiveImageConfig } from './helpers/config.js';
 import {
   buildAuthorUrl, buildDmUrl, buildDeliveryUrl,
@@ -34,31 +34,6 @@ export function formatExternalBrief(doc) {
   ${contentPlainText}
 
   Please suggest Assets that are visually appealing and relevant to the subject.`;
-}
-
-export function buildFeatureSet(isDmEnabled) {
-  const features = ['upload', 'collections', 'detail-panel', 'advisor'];
-  if (isDmEnabled) features.push('dynamic-media');
-  return features;
-}
-
-export function buildAssetSelectorProps({
-  imsToken,
-  repoConfig,
-  externalBrief,
-  onClose,
-  handleSelection,
-}) {
-  return {
-    imsToken,
-    repositoryId: repoConfig.repositoryId,
-    aemTierType: repoConfig.tierType,
-    featureSet: buildFeatureSet(repoConfig.isDmEnabled),
-    externalBrief,
-    ...getApprovedOnlyFilterProps(repoConfig.approvedOnly),
-    onClose,
-    handleSelection,
-  };
 }
 
 export function resolveAssetUrl(asset, repoConfig) {

--- a/blocks/edit/da-assets/helpers/config.js
+++ b/blocks/edit/da-assets/helpers/config.js
@@ -1,4 +1,8 @@
 import { getFirstSheet, fetchDaConfigs } from '../../../shared/utils.js';
+import {
+  isDynamicMediaEnabled,
+  shouldFilterApprovedAssets,
+} from '../../../shared/aem-assets/config.js';
 import DEFAULT_ASSET_BASE_PATH from './constants.js';
 import { parseSiteImageModifiers } from './imageModifiers.js';
 
@@ -70,7 +74,8 @@ export async function getResponsiveImageConfig(owner, repo) {
  *   already carry the same key, so per-asset overrides (smartcrop, future
  *   per-image presets) win.
  *
- * @returns {{ repositoryId, tierType, assetOrigin, assetBasePath, isDmEnabled, isSmartCrop,
+ * @returns {{ repositoryId, tierType, assetOrigin, assetBasePath, isDmEnabled,
+ *             isSmartCrop, approvedOnly,
  *             insertAsLink, mimeRenditionOverrides, siteImageModifiers }}
  */
 export async function getRepositoryConfig(owner, repo) {
@@ -85,9 +90,20 @@ export async function getRepositoryConfig(owner, repo) {
 
   const customOrigin = getValue('aem.assets.prod.origin');
   const customBasePath = getValue('aem.assets.prod.basepath');
-  const isSmartCrop = getValue('aem.asset.smartcrop.select') === 'on';
-  const isDmDeliveryFlag = getValue('aem.asset.dm.delivery') === 'on';
-  const isDmEnabled = isSmartCrop || isDmDeliveryFlag || customOrigin?.startsWith('delivery-') || tierType === 'delivery';
+  const smartCrop = getValue('aem.asset.smartcrop.select');
+  const dmDelivery = getValue('aem.asset.dm.delivery');
+  const isSmartCrop = smartCrop === 'on';
+  const isDmEnabled = isDynamicMediaEnabled({
+    repositoryId,
+    customOrigin,
+    dmDelivery,
+    smartCrop,
+  });
+  const approvedOnly = shouldFilterApprovedAssets({
+    tierType,
+    isDmEnabled,
+    configuredValue: getValue('aem.asset.dm.approvedonly'),
+  });
   const insertAsLink = getValue('aem.assets.image.type') === 'link';
   const mimeRenditionOverrides = parseMimeRenditions(getValue('aem.asset.mime.renditions'));
   const siteImageModifiers = parseSiteImageModifiers(getValue('aem.asset.image.modifiers'));
@@ -112,6 +128,7 @@ export async function getRepositoryConfig(owner, repo) {
     assetBasePath,
     isDmEnabled,
     isSmartCrop,
+    approvedOnly,
     insertAsLink,
     mimeRenditionOverrides,
     siteImageModifiers,

--- a/blocks/shared/aem-assets/config.js
+++ b/blocks/shared/aem-assets/config.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Resolves every documented Dynamic Media activation path.
+ *
+ * @param {object} config
+ * @param {string} config.repositoryId
+ * @param {string|null} [config.customOrigin]
+ * @param {string|null} [config.dmDelivery]
+ * @param {string|null} [config.smartCrop]
+ * @returns {boolean}
+ */
+export function isDynamicMediaEnabled({
+  repositoryId,
+  customOrigin,
+  dmDelivery,
+  smartCrop,
+}) {
+  return dmDelivery === 'on'
+    || smartCrop === 'on'
+    || customOrigin?.startsWith('delivery-')
+    || repositoryId.startsWith('delivery-');
+}
+
+/**
+ * Resolves whether DA should supply the locked author approval filter.
+ *
+ * @param {object} config
+ * @param {'author'|'delivery'} config.tierType
+ * @param {boolean} config.isDmEnabled
+ * @param {string|null} config.configuredValue
+ * @returns {boolean}
+ */
+export function shouldFilterApprovedAssets({
+  tierType,
+  isDmEnabled,
+  configuredValue,
+}) {
+  return tierType === 'author'
+    && isDmEnabled
+    && configuredValue !== 'off';
+}

--- a/blocks/shared/aem-assets/config.js
+++ b/blocks/shared/aem-assets/config.js
@@ -38,7 +38,7 @@ export function isDynamicMediaEnabled({
  * @param {object} config
  * @param {'author'|'delivery'} config.tierType
  * @param {boolean} config.isDmEnabled
- * @param {string|null} config.configuredValue
+ * @param {'on'|'off'|null|undefined} [config.configuredValue]
  * @returns {boolean}
  */
 export function shouldFilterApprovedAssets({
@@ -48,5 +48,5 @@ export function shouldFilterApprovedAssets({
 }) {
   return tierType === 'author'
     && isDmEnabled
-    && configuredValue === 'on';
+    && configuredValue !== 'off';
 }

--- a/blocks/shared/aem-assets/config.js
+++ b/blocks/shared/aem-assets/config.js
@@ -48,5 +48,5 @@ export function shouldFilterApprovedAssets({
 }) {
   return tierType === 'author'
     && isDmEnabled
-    && configuredValue !== 'off';
+    && configuredValue === 'on';
 }

--- a/blocks/shared/aem-assets/filter-schema.js
+++ b/blocks/shared/aem-assets/filter-schema.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * DA-compatible snapshot of Content Advisor's default file-filter controls.
+ *
+ * Sources pinned at CQ/assets-selectors commit
+ * 8a25725fa6324396e8f3844b95ce11095e343f54:
+ * - src/connected/asset-selector/src/components/searchNext/schemas/DefaultFileSchema.js
+ * - src/pure/asset-selector/src/utils/FilterUtils.js
+ *
+ * Content Advisor's live default uses an internal Adaptive Form schema. The public
+ * filterSchema prop accepts this array schema, so file-format facets are represented
+ * by the pinned static option list below.
+ *
+ * @returns {Array<object>}
+ */
+export function createApprovedOnlyFilterSchema() {
+  return [
+    {
+      fields: [{
+        element: 'checkbox',
+        name: 'type',
+        options: [
+          { label: 'Images', value: 'image/*' },
+          { label: 'Documents', value: 'text/*,application/*' },
+          { label: 'Videos', value: 'video/*' },
+        ],
+        orientation: 'vertical',
+        columns: 2,
+      }],
+      header: 'File Type',
+      groupKey: 'FileTypeGroup',
+    },
+    {
+      fields: [{
+        element: 'checkbox',
+        name: 'property=dc:format=',
+        options: [
+          { label: 'JPG', value: 'image/jpeg' },
+          { label: 'PNG', value: 'image/png' },
+          { label: 'TIFF', value: 'image/tiff' },
+          { label: 'PSD', value: 'image/vnd.adobe.photoshop' },
+          { label: 'INDD', value: 'application/x-indesign' },
+          { label: 'GIF', value: 'image/gif' },
+          { label: 'MP4', value: 'video/mp4' },
+          { label: 'PDF', value: 'application/pdf' },
+          { label: 'AI', value: 'application/postscript' },
+          { label: 'INDT', value: 'application/vnd.adobe.indesign.template' },
+          {
+            label: 'PPTX',
+            value: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          },
+          {
+            label: 'DOCX',
+            value: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          },
+          {
+            label: 'XLSX',
+            value: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          },
+          { label: 'PSB', value: 'application/vnd.3gpp.pic-bw-small' },
+          { label: 'WEBP', value: 'image/webp' },
+          { label: 'SVG', value: 'image/svg+xml' },
+        ],
+        columns: 3,
+      }],
+      header: 'File Format',
+      groupKey: 'FileFormatGroup',
+    },
+    {
+      fields: [{
+        element: 'radiogroup',
+        name: 'property=dam:assetStatus=',
+        defaultValue: ['approved'],
+        readOnly: true,
+        orientation: 'vertical',
+        options: [
+          { label: 'Approved', value: 'approved', readOnly: true },
+        ],
+      }],
+      header: 'Asset Status',
+      groupKey: 'AssetStatusGroup',
+    },
+    {
+      fields: [{
+        element: 'Number',
+        name: 'property=repo:size',
+        range: true,
+        quiet: true,
+        label: 'File Size',
+        minLabel: 'Min File Size',
+        maxLabel: 'Max File Size',
+        hideArrows: true,
+        columns: 2,
+      }],
+      header: 'File Size',
+      groupKey: 'FileSizeGroup',
+    },
+    {
+      fields: [
+        {
+          element: 'Number',
+          name: 'property=tiff:imageWidth',
+          range: true,
+          quiet: true,
+          label: 'Width',
+          minLabel: 'Width Min',
+          maxLabel: 'Width Max',
+          hideArrows: true,
+          columns: 2,
+        },
+        {
+          element: 'Number',
+          name: 'property=tiff:imageLength',
+          range: true,
+          quiet: true,
+          label: 'Height',
+          minLabel: 'Height Min',
+          maxLabel: 'Height Max',
+          hideArrows: true,
+          columns: 2,
+        },
+      ],
+      header: 'Image Dimensions',
+      groupKey: 'ImageDimensionsGroup',
+    },
+    {
+      fields: [{
+        element: 'DateRange',
+        name: 'property=repo:modifyDate',
+        position: 'top',
+        label: 'Modified Date',
+        orientation: 'horizontal',
+      }],
+      header: 'Modified Date',
+      groupKey: 'ModifiedDateGroup',
+    },
+    {
+      fields: [{
+        element: 'DateRange',
+        name: 'property=repo:createDate',
+        position: 'top',
+        label: 'Created Date',
+        orientation: 'horizontal',
+      }],
+      header: 'Created Date',
+      groupKey: 'CreatedDateGroup',
+    },
+  ];
+}
+
+/**
+ * Builds the optional selector-prop fragment without emitting filterSchema when disabled.
+ *
+ * @param {boolean} approvedOnly
+ * @returns {{ filterSchema: Array<object> } | {}}
+ */
+export function getApprovedOnlyFilterProps(approvedOnly) {
+  return approvedOnly ? { filterSchema: createApprovedOnlyFilterSchema() } : {};
+}

--- a/blocks/shared/aem-assets/filter-schema.js
+++ b/blocks/shared/aem-assets/filter-schema.js
@@ -10,73 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
+const HYBRID_FILTER_SCHEMA_SOURCE = 'hybrid-merge-deep';
+
 /**
- * DA-compatible snapshot of Content Advisor's default file-filter controls.
- *
- * Sources pinned at CQ/assets-selectors commit
- * 8a25725fa6324396e8f3844b95ce11095e343f54:
- * - src/connected/asset-selector/src/components/searchNext/schemas/DefaultFileSchema.js
- * - src/pure/asset-selector/src/utils/FilterUtils.js
- *
- * Content Advisor's live default uses an internal Adaptive Form schema. The public
- * filterSchema prop accepts this array schema, so file-format facets are represented
- * by the pinned static option list below.
+ * Creates the locked asset-status overlay merged with Content Advisor's defaults.
  *
  * @returns {Array<object>}
  */
 export function createApprovedOnlyFilterSchema() {
   return [
-    {
-      fields: [{
-        element: 'checkbox',
-        name: 'type',
-        options: [
-          { label: 'Images', value: 'image/*' },
-          { label: 'Documents', value: 'text/*,application/*' },
-          { label: 'Videos', value: 'video/*' },
-        ],
-        orientation: 'vertical',
-        columns: 2,
-      }],
-      header: 'File Type',
-      groupKey: 'FileTypeGroup',
-    },
-    {
-      fields: [{
-        element: 'checkbox',
-        name: 'property=dc:format=',
-        options: [
-          { label: 'JPG', value: 'image/jpeg' },
-          { label: 'PNG', value: 'image/png' },
-          { label: 'TIFF', value: 'image/tiff' },
-          { label: 'PSD', value: 'image/vnd.adobe.photoshop' },
-          { label: 'INDD', value: 'application/x-indesign' },
-          { label: 'GIF', value: 'image/gif' },
-          { label: 'MP4', value: 'video/mp4' },
-          { label: 'PDF', value: 'application/pdf' },
-          { label: 'AI', value: 'application/postscript' },
-          { label: 'INDT', value: 'application/vnd.adobe.indesign.template' },
-          {
-            label: 'PPTX',
-            value: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-          },
-          {
-            label: 'DOCX',
-            value: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-          },
-          {
-            label: 'XLSX',
-            value: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-          },
-          { label: 'PSB', value: 'application/vnd.3gpp.pic-bw-small' },
-          { label: 'WEBP', value: 'image/webp' },
-          { label: 'SVG', value: 'image/svg+xml' },
-        ],
-        columns: 3,
-      }],
-      header: 'File Format',
-      groupKey: 'FileFormatGroup',
-    },
     {
       fields: [{
         element: 'radiogroup',
@@ -91,80 +33,18 @@ export function createApprovedOnlyFilterSchema() {
       header: 'Asset Status',
       groupKey: 'AssetStatusGroup',
     },
-    {
-      fields: [{
-        element: 'Number',
-        name: 'property=repo:size',
-        range: true,
-        quiet: true,
-        label: 'File Size',
-        minLabel: 'Min File Size',
-        maxLabel: 'Max File Size',
-        hideArrows: true,
-        columns: 2,
-      }],
-      header: 'File Size',
-      groupKey: 'FileSizeGroup',
-    },
-    {
-      fields: [
-        {
-          element: 'Number',
-          name: 'property=tiff:imageWidth',
-          range: true,
-          quiet: true,
-          label: 'Width',
-          minLabel: 'Width Min',
-          maxLabel: 'Width Max',
-          hideArrows: true,
-          columns: 2,
-        },
-        {
-          element: 'Number',
-          name: 'property=tiff:imageLength',
-          range: true,
-          quiet: true,
-          label: 'Height',
-          minLabel: 'Height Min',
-          maxLabel: 'Height Max',
-          hideArrows: true,
-          columns: 2,
-        },
-      ],
-      header: 'Image Dimensions',
-      groupKey: 'ImageDimensionsGroup',
-    },
-    {
-      fields: [{
-        element: 'DateRange',
-        name: 'property=repo:modifyDate',
-        position: 'top',
-        label: 'Modified Date',
-        orientation: 'horizontal',
-      }],
-      header: 'Modified Date',
-      groupKey: 'ModifiedDateGroup',
-    },
-    {
-      fields: [{
-        element: 'DateRange',
-        name: 'property=repo:createDate',
-        position: 'top',
-        label: 'Created Date',
-        orientation: 'horizontal',
-      }],
-      header: 'Created Date',
-      groupKey: 'CreatedDateGroup',
-    },
   ];
 }
 
 /**
- * Builds the optional selector-prop fragment without emitting filterSchema when disabled.
+ * Builds the optional selector-prop fragment without enabling a filter when disabled.
  *
  * @param {boolean} approvedOnly
- * @returns {{ filterSchema: Array<object> } | {}}
+ * @returns {{ filterSchema: Array<object>, filterSchemaSource: string } | {}}
  */
 export function getApprovedOnlyFilterProps(approvedOnly) {
-  return approvedOnly ? { filterSchema: createApprovedOnlyFilterSchema() } : {};
+  return approvedOnly ? {
+    filterSchema: createApprovedOnlyFilterSchema(),
+    filterSchemaSource: HYBRID_FILTER_SCHEMA_SOURCE,
+  } : {};
 }

--- a/blocks/shared/aem-assets/selector-props.js
+++ b/blocks/shared/aem-assets/selector-props.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { getApprovedOnlyFilterProps } from './filter-schema.js';
+
+export function buildFeatureSet(isDmEnabled) {
+  const features = ['upload', 'collections', 'detail-panel', 'advisor'];
+  if (isDmEnabled) features.push('dynamic-media');
+  return features;
+}
+
+export function buildAssetSelectorProps({
+  imsToken,
+  repoConfig,
+  externalBrief,
+  onClose,
+  handleSelection,
+}) {
+  return {
+    imsToken,
+    repositoryId: repoConfig.repositoryId,
+    aemTierType: repoConfig.tierType,
+    featureSet: buildFeatureSet(repoConfig.isDmEnabled),
+    ...(externalBrief !== undefined && { externalBrief }),
+    ...getApprovedOnlyFilterProps(repoConfig.approvedOnly),
+    ...(onClose && { onClose }),
+    handleSelection,
+  };
+}

--- a/test/fixtures/nx/utils/daConfig.js
+++ b/test/fixtures/nx/utils/daConfig.js
@@ -1,3 +1,12 @@
 // Mock NX /utils/daConfig.js utils for tests
-export const fetchDaConfigs = async () => ({});
-export const getFirstSheet = () => null;
+const daConfigsKey = '__daConfigsFixture__';
+let daConfigs = globalThis[daConfigsKey] || [];
+
+export const setDaConfigs = (configs) => {
+  daConfigs = configs;
+  globalThis[daConfigsKey] = configs;
+};
+
+export const fetchDaConfigs = () => (globalThis[daConfigsKey] || daConfigs)
+  .map((config) => Promise.resolve(config));
+export const getFirstSheet = (config) => config?.data || null;

--- a/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from '@esm-bundle/chai';
+
+const { setNx } = await import('../../../../../scripts/utils.js');
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+/* eslint-disable import/no-absolute-path, import/no-unresolved -- NX test fixture */
+const { setDaConfigs } = await import('/test/fixtures/nx/utils/daConfig.js');
+/* eslint-enable import/no-absolute-path, import/no-unresolved */
+const { getRepositoryConfig, buildAssetSelectorProps } = await import(
+  '../../../../../blocks/canvas/ew-panel-extensions/aem-assets.js'
+);
+
+describe('Canvas AEM Assets repository config', () => {
+  afterEach(() => setDaConfigs([]));
+
+  [
+    ['DM delivery', [
+      { key: 'aem.repositoryId', value: 'author-p1-e1.adobeaemcloud.com' },
+      { key: 'aem.asset.dm.delivery', value: 'on' },
+    ]],
+    ['Smart Crop', [
+      { key: 'aem.repositoryId', value: 'author-p1-e1.adobeaemcloud.com' },
+      { key: 'aem.asset.smartcrop.select', value: 'on' },
+    ]],
+    ['delivery production origin', [
+      { key: 'aem.repositoryId', value: 'author-p1-e1.adobeaemcloud.com' },
+      { key: 'aem.assets.prod.origin', value: 'delivery-p1-e1.adobeaemcloud.com' },
+    ]],
+  ].forEach(([name, entries]) => {
+    it(`defaults approvedOnly on for ${name}`, async () => {
+      setDaConfigs([{ data: entries }]);
+      const config = await getRepositoryConfig('org', 'site');
+      expect(config.isDmEnabled).to.be.true;
+      expect(config.approvedOnly).to.be.true;
+    });
+  });
+
+  it('honors site off over org on', async () => {
+    setDaConfigs([
+      {
+        data: [
+          { key: 'aem.repositoryId', value: 'author-p1-e1.adobeaemcloud.com' },
+          { key: 'aem.asset.dm.delivery', value: 'on' },
+          { key: 'aem.asset.dm.approvedonly', value: 'on' },
+        ],
+      },
+      { data: [{ key: 'aem.asset.dm.approvedonly', value: 'off' }] },
+    ]);
+    const config = await getRepositoryConfig('org', 'site');
+    expect(config.approvedOnly).to.be.false;
+  });
+
+  it('does not apply the author filter to delivery tier', async () => {
+    setDaConfigs([{ data: [{ key: 'aem.repositoryId', value: 'delivery-p1-e1.adobeaemcloud.com' }] }]);
+    const config = await getRepositoryConfig('org', 'site');
+    expect(config.approvedOnly).to.be.false;
+  });
+});
+
+describe('Canvas AEM Assets selector props', () => {
+  const baseArgs = {
+    token: 'token',
+    repoConfig: {
+      repositoryId: 'author-p1-e1.adobeaemcloud.com',
+      tierType: 'author',
+      approvedOnly: true,
+    },
+    onClose: () => {},
+    handleSelection: () => {},
+  };
+
+  it('adds the locked filter schema when approvedOnly is enabled', () => {
+    const props = buildAssetSelectorProps(baseArgs);
+    expect(props.filterSchema).to.be.an('array').and.not.empty;
+  });
+
+  it('omits filterSchema when approvedOnly is disabled', () => {
+    const props = buildAssetSelectorProps({
+      ...baseArgs,
+      repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
+    });
+    expect(props).to.not.have.property('filterSchema');
+  });
+});

--- a/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
@@ -39,11 +39,11 @@ describe('Canvas AEM Assets repository config', () => {
       { key: 'aem.assets.prod.origin', value: 'delivery-p1-e1.adobeaemcloud.com' },
     ]],
   ].forEach(([name, entries]) => {
-    it(`keeps approvedOnly off unless explicitly enabled for ${name}`, async () => {
+    it(`defaults approvedOnly on for ${name}`, async () => {
       setDaConfigs([{ data: entries }]);
       const config = await getRepositoryConfig('org', 'site');
       expect(config.isDmEnabled).to.be.true;
-      expect(config.approvedOnly).to.be.false;
+      expect(config.approvedOnly).to.be.true;
     });
   });
 

--- a/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
@@ -81,16 +81,18 @@ describe('Canvas AEM Assets selector props', () => {
     handleSelection: () => {},
   };
 
-  it('adds the locked filter schema when approvedOnly is enabled', () => {
+  it('adds the hybrid locked filter contract when approvedOnly is enabled', () => {
     const props = buildAssetSelectorProps(baseArgs);
-    expect(props.filterSchema).to.be.an('array').and.not.empty;
+    expect(props.filterSchema.map(({ groupKey }) => groupKey)).to.deep.equal(['AssetStatusGroup']);
+    expect(props).to.include({ filterSchemaSource: 'hybrid-merge-deep' });
   });
 
-  it('omits filterSchema when approvedOnly is disabled', () => {
+  it('omits the hybrid filter contract when approvedOnly is disabled', () => {
     const props = buildAssetSelectorProps({
       ...baseArgs,
       repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
     });
     expect(props).to.not.have.property('filterSchema');
+    expect(props).to.not.have.property('filterSchemaSource');
   });
 });

--- a/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/aem-assets.test.js
@@ -18,7 +18,7 @@ setNx('/test/fixtures/nx', { hostname: 'example.com' });
 /* eslint-disable import/no-absolute-path, import/no-unresolved -- NX test fixture */
 const { setDaConfigs } = await import('/test/fixtures/nx/utils/daConfig.js');
 /* eslint-enable import/no-absolute-path, import/no-unresolved */
-const { getRepositoryConfig, buildAssetSelectorProps } = await import(
+const { getRepositoryConfig } = await import(
   '../../../../../blocks/canvas/ew-panel-extensions/aem-assets.js'
 );
 
@@ -39,12 +39,25 @@ describe('Canvas AEM Assets repository config', () => {
       { key: 'aem.assets.prod.origin', value: 'delivery-p1-e1.adobeaemcloud.com' },
     ]],
   ].forEach(([name, entries]) => {
-    it(`defaults approvedOnly on for ${name}`, async () => {
+    it(`keeps approvedOnly off unless explicitly enabled for ${name}`, async () => {
       setDaConfigs([{ data: entries }]);
       const config = await getRepositoryConfig('org', 'site');
       expect(config.isDmEnabled).to.be.true;
-      expect(config.approvedOnly).to.be.true;
+      expect(config.approvedOnly).to.be.false;
     });
+  });
+
+  it('enables approvedOnly when aem.asset.dm.approvedonly is on', async () => {
+    setDaConfigs([{
+      data: [
+        { key: 'aem.repositoryId', value: 'author-p1-e1.adobeaemcloud.com' },
+        { key: 'aem.asset.dm.delivery', value: 'on' },
+        { key: 'aem.asset.dm.approvedonly', value: 'on' },
+      ],
+    }]);
+    const config = await getRepositoryConfig('org', 'site');
+    expect(config.isDmEnabled).to.be.true;
+    expect(config.approvedOnly).to.be.true;
   });
 
   it('honors site off over org on', async () => {
@@ -66,33 +79,5 @@ describe('Canvas AEM Assets repository config', () => {
     setDaConfigs([{ data: [{ key: 'aem.repositoryId', value: 'delivery-p1-e1.adobeaemcloud.com' }] }]);
     const config = await getRepositoryConfig('org', 'site');
     expect(config.approvedOnly).to.be.false;
-  });
-});
-
-describe('Canvas AEM Assets selector props', () => {
-  const baseArgs = {
-    token: 'token',
-    repoConfig: {
-      repositoryId: 'author-p1-e1.adobeaemcloud.com',
-      tierType: 'author',
-      approvedOnly: true,
-    },
-    onClose: () => {},
-    handleSelection: () => {},
-  };
-
-  it('adds the hybrid locked filter contract when approvedOnly is enabled', () => {
-    const props = buildAssetSelectorProps(baseArgs);
-    expect(props.filterSchema.map(({ groupKey }) => groupKey)).to.deep.equal(['AssetStatusGroup']);
-    expect(props).to.include({ filterSchemaSource: 'hybrid-merge-deep' });
-  });
-
-  it('omits the hybrid filter contract when approvedOnly is disabled', () => {
-    const props = buildAssetSelectorProps({
-      ...baseArgs,
-      repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
-    });
-    expect(props).to.not.have.property('filterSchema');
-    expect(props).to.not.have.property('filterSchemaSource');
   });
 });

--- a/test/unit/blocks/edit/da-assets/config.test.js
+++ b/test/unit/blocks/edit/da-assets/config.test.js
@@ -270,7 +270,7 @@ describe('getRepositoryConfig', () => {
     }
   });
 
-  it('defaults approvedOnly on for author-backed effective DM', async () => {
+  it('keeps approvedOnly off without explicit opt-in for author-backed effective DM', async () => {
     const orgFetch = window.fetch;
     window.fetch = makeFetch({
       '/approved-default/site/': makeSheet([
@@ -280,7 +280,7 @@ describe('getRepositoryConfig', () => {
     });
     try {
       const cfg = await getRepositoryConfig('approved-default', 'site');
-      expect(cfg.approvedOnly).to.be.true;
+      expect(cfg.approvedOnly).to.be.false;
     } finally {
       window.fetch = orgFetch;
     }

--- a/test/unit/blocks/edit/da-assets/config.test.js
+++ b/test/unit/blocks/edit/da-assets/config.test.js
@@ -270,7 +270,7 @@ describe('getRepositoryConfig', () => {
     }
   });
 
-  it('keeps approvedOnly off without explicit opt-in for author-backed effective DM', async () => {
+  it('defaults approvedOnly on for author-backed effective DM opt-out', async () => {
     const orgFetch = window.fetch;
     window.fetch = makeFetch({
       '/approved-default/site/': makeSheet([
@@ -280,7 +280,7 @@ describe('getRepositoryConfig', () => {
     });
     try {
       const cfg = await getRepositoryConfig('approved-default', 'site');
-      expect(cfg.approvedOnly).to.be.false;
+      expect(cfg.approvedOnly).to.be.true;
     } finally {
       window.fetch = orgFetch;
     }

--- a/test/unit/blocks/edit/da-assets/config.test.js
+++ b/test/unit/blocks/edit/da-assets/config.test.js
@@ -269,6 +269,77 @@ describe('getRepositoryConfig', () => {
       window.fetch = orgFetch;
     }
   });
+
+  it('defaults approvedOnly on for author-backed effective DM', async () => {
+    const orgFetch = window.fetch;
+    window.fetch = makeFetch({
+      '/approved-default/site/': makeSheet([
+        { key: 'aem.repositoryId', value: 'author-p101-e101.adobeaemcloud.com' },
+        { key: 'aem.asset.smartcrop.select', value: 'on' },
+      ]),
+    });
+    try {
+      const cfg = await getRepositoryConfig('approved-default', 'site');
+      expect(cfg.approvedOnly).to.be.true;
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
+
+  it('allows site config to opt out of org approved-only filtering', async () => {
+    const orgFetch = window.fetch;
+    window.fetch = makeFetch({
+      '/approved-precedence/site/': makeSheet([
+        { key: 'aem.asset.dm.approvedonly', value: 'off' },
+      ]),
+      '/approved-precedence/': makeSheet([
+        { key: 'aem.repositoryId', value: 'author-p102-e102.adobeaemcloud.com' },
+        { key: 'aem.asset.dm.delivery', value: 'on' },
+        { key: 'aem.asset.dm.approvedonly', value: 'on' },
+      ]),
+    });
+    try {
+      const cfg = await getRepositoryConfig('approved-precedence', 'site');
+      expect(cfg.approvedOnly).to.be.false;
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
+
+  it('allows site config to enable approved-only over an org opt-out', async () => {
+    const orgFetch = window.fetch;
+    window.fetch = makeFetch({
+      '/approved-site-on/site/': makeSheet([
+        { key: 'aem.asset.dm.approvedonly', value: 'on' },
+      ]),
+      '/approved-site-on/': makeSheet([
+        { key: 'aem.repositoryId', value: 'author-p103-e103.adobeaemcloud.com' },
+        { key: 'aem.asset.dm.delivery', value: 'on' },
+        { key: 'aem.asset.dm.approvedonly', value: 'off' },
+      ]),
+    });
+    try {
+      const cfg = await getRepositoryConfig('approved-site-on', 'site');
+      expect(cfg.approvedOnly).to.be.true;
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
+
+  it('does not apply approvedOnly to delivery tier', async () => {
+    const orgFetch = window.fetch;
+    window.fetch = makeFetch({
+      '/approved-delivery/site/': makeSheet([
+        { key: 'aem.repositoryId', value: 'delivery-p104-e104.adobeaemcloud.com' },
+      ]),
+    });
+    try {
+      const cfg = await getRepositoryConfig('approved-delivery', 'site');
+      expect(cfg.approvedOnly).to.be.false;
+    } finally {
+      window.fetch = orgFetch;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/blocks/edit/da-assets/da-assets.test.js
+++ b/test/unit/blocks/edit/da-assets/da-assets.test.js
@@ -165,17 +165,19 @@ describe('buildAssetSelectorProps', () => {
     handleSelection: () => {},
   };
 
-  it('adds the locked filter schema when approvedOnly is enabled', () => {
+  it('adds the hybrid locked filter contract when approvedOnly is enabled', () => {
     const props = buildAssetSelectorProps(baseArgs);
-    expect(props.filterSchema).to.be.an('array').and.not.empty;
+    expect(props.filterSchema.map(({ groupKey }) => groupKey)).to.deep.equal(['AssetStatusGroup']);
+    expect(props).to.include({ filterSchemaSource: 'hybrid-merge-deep' });
   });
 
-  it('omits filterSchema when approvedOnly is disabled', () => {
+  it('omits the hybrid filter contract when approvedOnly is disabled', () => {
     const props = buildAssetSelectorProps({
       ...baseArgs,
       repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
     });
     expect(props).to.not.have.property('filterSchema');
+    expect(props).to.not.have.property('filterSchemaSource');
   });
 });
 

--- a/test/unit/blocks/edit/da-assets/da-assets.test.js
+++ b/test/unit/blocks/edit/da-assets/da-assets.test.js
@@ -6,6 +6,7 @@ setNx('/test/fixtures/nx', { hostname: 'example.com' });
 const {
   formatExternalBrief,
   buildFeatureSet,
+  buildAssetSelectorProps,
   resolveAssetUrl,
   buildHandleSelection,
   createDialogPanels,
@@ -143,6 +144,38 @@ describe('buildFeatureSet', () => {
     const features = buildFeatureSet(true);
     expect(features).to.include('dynamic-media');
     expect(features).to.include('upload');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAssetSelectorProps
+// ---------------------------------------------------------------------------
+
+describe('buildAssetSelectorProps', () => {
+  const baseArgs = {
+    imsToken: 'token',
+    repoConfig: {
+      repositoryId: 'author-p1-e1.adobeaemcloud.com',
+      tierType: 'author',
+      isDmEnabled: true,
+      approvedOnly: true,
+    },
+    externalBrief: 'brief',
+    onClose: () => {},
+    handleSelection: () => {},
+  };
+
+  it('adds the locked filter schema when approvedOnly is enabled', () => {
+    const props = buildAssetSelectorProps(baseArgs);
+    expect(props.filterSchema).to.be.an('array').and.not.empty;
+  });
+
+  it('omits filterSchema when approvedOnly is disabled', () => {
+    const props = buildAssetSelectorProps({
+      ...baseArgs,
+      repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
+    });
+    expect(props).to.not.have.property('filterSchema');
   });
 });
 

--- a/test/unit/blocks/edit/da-assets/da-assets.test.js
+++ b/test/unit/blocks/edit/da-assets/da-assets.test.js
@@ -5,8 +5,6 @@ setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
 const {
   formatExternalBrief,
-  buildFeatureSet,
-  buildAssetSelectorProps,
   resolveAssetUrl,
   buildHandleSelection,
   createDialogPanels,
@@ -127,57 +125,6 @@ describe('formatExternalBrief', () => {
     const brief = formatExternalBrief(doc);
     expect(brief).to.not.include('Title:');
     expect(brief).to.include('Some page content without a heading.');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildFeatureSet
-// ---------------------------------------------------------------------------
-
-describe('buildFeatureSet', () => {
-  it('returns base features when DM is not enabled', () => {
-    const features = buildFeatureSet(false);
-    expect(features).to.deep.equal(['upload', 'collections', 'detail-panel', 'advisor']);
-  });
-
-  it('adds dynamic-media feature when DM is enabled', () => {
-    const features = buildFeatureSet(true);
-    expect(features).to.include('dynamic-media');
-    expect(features).to.include('upload');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildAssetSelectorProps
-// ---------------------------------------------------------------------------
-
-describe('buildAssetSelectorProps', () => {
-  const baseArgs = {
-    imsToken: 'token',
-    repoConfig: {
-      repositoryId: 'author-p1-e1.adobeaemcloud.com',
-      tierType: 'author',
-      isDmEnabled: true,
-      approvedOnly: true,
-    },
-    externalBrief: 'brief',
-    onClose: () => {},
-    handleSelection: () => {},
-  };
-
-  it('adds the hybrid locked filter contract when approvedOnly is enabled', () => {
-    const props = buildAssetSelectorProps(baseArgs);
-    expect(props.filterSchema.map(({ groupKey }) => groupKey)).to.deep.equal(['AssetStatusGroup']);
-    expect(props).to.include({ filterSchemaSource: 'hybrid-merge-deep' });
-  });
-
-  it('omits the hybrid filter contract when approvedOnly is disabled', () => {
-    const props = buildAssetSelectorProps({
-      ...baseArgs,
-      repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
-    });
-    expect(props).to.not.have.property('filterSchema');
-    expect(props).to.not.have.property('filterSchemaSource');
   });
 });
 

--- a/test/unit/blocks/shared/aem-assets/config.test.js
+++ b/test/unit/blocks/shared/aem-assets/config.test.js
@@ -47,7 +47,7 @@ describe('AEM Assets delivery config', () => {
   });
 
   [
-    { configuredValue: null, expected: true },
+    { configuredValue: null, expected: false },
     { configuredValue: 'on', expected: true },
     { configuredValue: 'off', expected: false },
   ].forEach(({ configuredValue, expected }) => {

--- a/test/unit/blocks/shared/aem-assets/config.test.js
+++ b/test/unit/blocks/shared/aem-assets/config.test.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from '@esm-bundle/chai';
+import {
+  isDynamicMediaEnabled,
+  shouldFilterApprovedAssets,
+} from '../../../../../blocks/shared/aem-assets/config.js';
+
+describe('AEM Assets delivery config', () => {
+  const authorRepositoryId = 'author-p1-e1.adobeaemcloud.com';
+
+  [
+    {
+      name: 'explicit DM delivery',
+      input: { repositoryId: authorRepositoryId, dmDelivery: 'on' },
+    },
+    {
+      name: 'Smart Crop',
+      input: { repositoryId: authorRepositoryId, smartCrop: 'on' },
+    },
+    {
+      name: 'delivery production origin',
+      input: { repositoryId: authorRepositoryId, customOrigin: 'delivery-p1-e1.adobeaemcloud.com' },
+    },
+    {
+      name: 'delivery repository',
+      input: { repositoryId: 'delivery-p1-e1.adobeaemcloud.com' },
+    },
+  ].forEach(({ name, input }) => {
+    it(`enables Dynamic Media for ${name}`, () => {
+      expect(isDynamicMediaEnabled(input)).to.be.true;
+    });
+  });
+
+  it('keeps author + publish out of Dynamic Media mode', () => {
+    expect(isDynamicMediaEnabled({ repositoryId: authorRepositoryId })).to.be.false;
+  });
+
+  [
+    { configuredValue: null, expected: true },
+    { configuredValue: 'on', expected: true },
+    { configuredValue: 'off', expected: false },
+  ].forEach(({ configuredValue, expected }) => {
+    it(`resolves approved-only value ${configuredValue}`, () => {
+      expect(shouldFilterApprovedAssets({
+        tierType: 'author',
+        isDmEnabled: true,
+        configuredValue,
+      })).to.equal(expected);
+    });
+  });
+
+  it('does not add the author approval filter to delivery tier', () => {
+    expect(shouldFilterApprovedAssets({
+      tierType: 'delivery',
+      isDmEnabled: true,
+      configuredValue: 'on',
+    })).to.be.false;
+  });
+
+  it('does not filter author + publish mode', () => {
+    expect(shouldFilterApprovedAssets({
+      tierType: 'author',
+      isDmEnabled: false,
+      configuredValue: 'on',
+    })).to.be.false;
+  });
+});

--- a/test/unit/blocks/shared/aem-assets/config.test.js
+++ b/test/unit/blocks/shared/aem-assets/config.test.js
@@ -47,7 +47,8 @@ describe('AEM Assets delivery config', () => {
   });
 
   [
-    { configuredValue: null, expected: false },
+    { configuredValue: undefined, expected: true },
+    { configuredValue: null, expected: true },
     { configuredValue: 'on', expected: true },
     { configuredValue: 'off', expected: false },
   ].forEach(({ configuredValue, expected }) => {

--- a/test/unit/blocks/shared/aem-assets/filter-schema.test.js
+++ b/test/unit/blocks/shared/aem-assets/filter-schema.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from '@esm-bundle/chai';
+import {
+  createApprovedOnlyFilterSchema,
+  getApprovedOnlyFilterProps,
+} from '../../../../../blocks/shared/aem-assets/filter-schema.js';
+
+describe('approved-only AEM Assets filter schema', () => {
+  it('preserves the pinned Content Advisor filter groups', () => {
+    const schema = createApprovedOnlyFilterSchema();
+    expect(schema.map(({ groupKey }) => groupKey)).to.deep.equal([
+      'FileTypeGroup',
+      'FileFormatGroup',
+      'AssetStatusGroup',
+      'FileSizeGroup',
+      'ImageDimensionsGroup',
+      'ModifiedDateGroup',
+      'CreatedDateGroup',
+    ]);
+  });
+
+  it('locks Asset Status to Approved', () => {
+    const statusGroup = createApprovedOnlyFilterSchema()
+      .find(({ groupKey }) => groupKey === 'AssetStatusGroup');
+    const [statusField] = statusGroup.fields;
+
+    expect(statusField).to.include({
+      element: 'radiogroup',
+      name: 'property=dam:assetStatus=',
+      readOnly: true,
+    });
+    expect(statusField.defaultValue).to.deep.equal(['approved']);
+    expect(statusField.options).to.deep.equal([
+      { label: 'Approved', value: 'approved', readOnly: true },
+    ]);
+  });
+
+  it('returns a fresh nested schema for every call', () => {
+    const first = createApprovedOnlyFilterSchema();
+    const second = createApprovedOnlyFilterSchema();
+
+    expect(first).to.not.equal(second);
+    expect(first[0]).to.not.equal(second[0]);
+    expect(first[0].fields[0]).to.not.equal(second[0].fields[0]);
+  });
+
+  it('adds filterSchema only when approved-only is enabled', () => {
+    const enabled = getApprovedOnlyFilterProps(true);
+    const disabled = getApprovedOnlyFilterProps(false);
+
+    expect(enabled.filterSchema).to.be.an('array').and.not.empty;
+    expect(disabled).to.deep.equal({});
+    expect(disabled).to.not.have.property('filterSchema');
+  });
+});

--- a/test/unit/blocks/shared/aem-assets/filter-schema.test.js
+++ b/test/unit/blocks/shared/aem-assets/filter-schema.test.js
@@ -17,16 +17,10 @@ import {
 } from '../../../../../blocks/shared/aem-assets/filter-schema.js';
 
 describe('approved-only AEM Assets filter schema', () => {
-  it('preserves the pinned Content Advisor filter groups', () => {
+  it('contains only the locked Asset Status group', () => {
     const schema = createApprovedOnlyFilterSchema();
     expect(schema.map(({ groupKey }) => groupKey)).to.deep.equal([
-      'FileTypeGroup',
-      'FileFormatGroup',
       'AssetStatusGroup',
-      'FileSizeGroup',
-      'ImageDimensionsGroup',
-      'ModifiedDateGroup',
-      'CreatedDateGroup',
     ]);
   });
 
@@ -55,12 +49,18 @@ describe('approved-only AEM Assets filter schema', () => {
     expect(first[0].fields[0]).to.not.equal(second[0].fields[0]);
   });
 
-  it('adds filterSchema only when approved-only is enabled', () => {
+  it('adds the hybrid filter contract only when approved-only is enabled', () => {
     const enabled = getApprovedOnlyFilterProps(true);
     const disabled = getApprovedOnlyFilterProps(false);
 
-    expect(enabled.filterSchema).to.be.an('array').and.not.empty;
+    expect(enabled).to.include({ filterSchemaSource: 'hybrid-merge-deep' });
+    expect(Object.keys(enabled).sort()).to.deep.equal([
+      'filterSchema',
+      'filterSchemaSource',
+    ]);
+    expect(enabled.filterSchema.map(({ groupKey }) => groupKey)).to.deep.equal(['AssetStatusGroup']);
     expect(disabled).to.deep.equal({});
     expect(disabled).to.not.have.property('filterSchema');
+    expect(disabled).to.not.have.property('filterSchemaSource');
   });
 });

--- a/test/unit/blocks/shared/aem-assets/selector-props.test.js
+++ b/test/unit/blocks/shared/aem-assets/selector-props.test.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from '@esm-bundle/chai';
+
+import { buildFeatureSet, buildAssetSelectorProps } from '../../../../../blocks/shared/aem-assets/selector-props.js';
+
+describe('shared AEM asset selector props', () => {
+  const baseArgs = {
+    imsToken: 'token',
+    repoConfig: {
+      repositoryId: 'author-p1-e1.adobeaemcloud.com',
+      tierType: 'author',
+      isDmEnabled: false,
+      approvedOnly: false,
+    },
+    externalBrief: 'brief',
+    onClose: () => {},
+    handleSelection: () => {},
+  };
+
+  describe('buildFeatureSet', () => {
+    it('returns the base feature list when DM is disabled', () => {
+      expect(buildFeatureSet(false)).to.deep.equal(['upload', 'collections', 'detail-panel', 'advisor']);
+    });
+
+    it('adds dynamic-media when DM is enabled', () => {
+      expect(buildFeatureSet(true)).to.deep.equal([
+        'upload',
+        'collections',
+        'detail-panel',
+        'advisor',
+        'dynamic-media',
+      ]);
+    });
+  });
+
+  describe('buildAssetSelectorProps', () => {
+    it('maps the core selector props', () => {
+      const props = buildAssetSelectorProps(baseArgs);
+      expect(props.imsToken).to.equal('token');
+      expect(props.repositoryId).to.equal('author-p1-e1.adobeaemcloud.com');
+      expect(props.aemTierType).to.equal('author');
+      expect(props.handleSelection).to.equal(baseArgs.handleSelection);
+    });
+
+    it('preserves an explicitly supplied empty externalBrief', () => {
+      const props = buildAssetSelectorProps({ ...baseArgs, externalBrief: '' });
+      expect(props).to.have.property('externalBrief', '');
+    });
+
+    it('includes the approved-only filter when enabled', () => {
+      const props = buildAssetSelectorProps({
+        ...baseArgs,
+        repoConfig: { ...baseArgs.repoConfig, approvedOnly: true },
+      });
+      expect(props.filterSchema.map(({ groupKey }) => groupKey)).to.deep.equal(['AssetStatusGroup']);
+      expect(props).to.include({ filterSchemaSource: 'hybrid-merge-deep' });
+    });
+
+    it('omits the approved-only filter when disabled', () => {
+      const props = buildAssetSelectorProps({
+        ...baseArgs,
+        repoConfig: { ...baseArgs.repoConfig, approvedOnly: false },
+      });
+      expect(props).to.not.have.property('filterSchema');
+      expect(props).to.not.have.property('filterSchemaSource');
+    });
+
+    it('includes onClose when a function is supplied', () => {
+      const props = buildAssetSelectorProps(baseArgs);
+      expect(props.onClose).to.equal(baseArgs.onClose);
+    });
+
+    it('omits onClose when undefined', () => {
+      const props = buildAssetSelectorProps({ ...baseArgs, onClose: undefined });
+      expect(props).to.not.have.property('onClose');
+    });
+
+    it('omits onClose when null', () => {
+      const props = buildAssetSelectorProps({ ...baseArgs, onClose: null });
+      expect(props).to.not.have.property('onClose');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Filters author-tier Dynamic Media asset browsing to Approved assets by supplying a
custom Content Advisor filter schema. Applies to both the document editor and the
Canvas/Experience Workspace asset-selector surfaces.

## What DA sends to the selector

When enabled, `renderAssetSelector` receives two additional props
(`blocks/shared/aem-assets/filter-schema.js`):

- `filterSchema` — a single `AssetStatusGroup` containing a read-only `radiogroup`
  on `property=dam:assetStatus=`, with `Approved` as its only option and default value.
- `filterSchemaSource: 'hybrid-merge-deep'`

`filterSchema` is documented in
[Content Advisor properties](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/content-advisor/content-advisor-properties)
as "Model that is used to configure filter properties. This is useful when you want to
limit certain filter options in Content Advisor." Consistent with that, and with the
sample in
[Content Advisor customizations](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/content-advisor/content-advisor-customization),
a supplied `filterSchema` defines the filter panel. **The filter panel is therefore
reduced to the locked Asset Status group while this is enabled.**

Selector prop construction is shared by the document editor and Canvas through
`blocks/shared/aem-assets/selector-props.js`. Both retain `upload`, `collections`,
`detail-panel`, and `advisor`; effective Dynamic Media configurations also enable
`dynamic-media` on both surfaces.

`filterSchemaSource` is not covered by the public Content Advisor properties
documentation. It is set to request that the supplied schema be reconciled with any
schema the tenant already has, rather than replacing it outright. Its effect is
tenant-dependent and is not relied on for correctness — see Safety below.

## Configuration

Opt-out key: `aem.asset.dm.approvedonly`.

- Absent or `on` → filter enabled. `off` (exact value) → disabled, selector spawns with
  no custom filter schema.
- Applies only when browsing an **author-tier** repository in an **effective Dynamic
  Media** configuration. No effect on delivery-tier browsing or Author + Publish mode.
- Site configuration takes precedence over organization configuration.
- Enabled is the default, so the key need not appear in the `admin.da.live/config`
  response.

Effective Dynamic Media (`blocks/shared/aem-assets/config.js`) is any of:
`aem.asset.dm.delivery: on`, `aem.asset.smartcrop.select: on`, an
`aem.assets.prod.origin` beginning `delivery-`, or a repository ID beginning
`delivery-`.

## Safety

On the editor surface this is a discoverability improvement layered on an existing
enforced check: `blocks/edit/da-assets/da-assets.js` already blocks insertion of assets
that are not `dam:assetStatus = approved` / `dam:activationTarget = delivery` in
Author + DM mode, and shows an error panel instead. If the filter does not take effect
on a given tenant, behavior degrades to exactly the pre-PR experience.

**Known limitation:** `blocks/canvas/ew-panel-extensions/aem-assets.js` has no
equivalent insertion-time approval check, so on Canvas the filter is not backed by a
second gate.

## Behavior change beyond the filter

Canvas `getRepositoryConfig` now shares the editor's Dynamic Media predicate, which adds
the `aem.assets.prod.origin` starting with `delivery-` condition that Canvas previously
did not evaluate. For an author-tier site configured with a delivery production origin,
Canvas now builds a DM delivery URL where it previously built an author URL — aligning
Canvas with the editor.

Canvas also includes the selector's `dynamic-media` feature when Dynamic Media is
effective, matching the document editor's existing behavior and enabling the same DM
status and rendition support on both surfaces.

## Verification

- New unit coverage: default-on behavior, explicit `off` opt-out, org/site precedence,
  author vs delivery tier, and shared selector-prop construction
  (`test/unit/blocks/shared/aem-assets/`, `test/unit/blocks/canvas/ew-panel-extensions/`,
  `test/unit/blocks/edit/da-assets/`).
- Lint and unit suites pass in CI.
- Manual smoke test on an author-tier Dynamic Media tenant confirmed:
  - the locked `Asset Status: Approved` filter is displayed;
  - the AEM search request contains `property=dam:assetStatus==approved`; and
  - the selector's active feature set includes `dynamic-media`.
