### PR TITLE
fix: handle legacy section metadata in live preview/quick-edit correctly

### DIFF
--- a/blocks/shared/prose2aem.js
+++ b/blocks/shared/prose2aem.js
@@ -219,7 +219,7 @@ function applySectionMetadata(editor) {
         section.dataset[camelKey] = value;
       }
     });
-    block.remove();
+    block.style.display = 'none';
   });
 }
 

--- a/test/unit/blocks/shared/prose2aem.test.js
+++ b/test/unit/blocks/shared/prose2aem.test.js
@@ -111,7 +111,7 @@ describe('prose2aem section-metadata handling', () => {
     expect(section.classList.contains('divider-light')).to.be.false;
   });
 
-  it('removes the section-metadata block from the output', () => {
+  it('hides the section-metadata block instead of removing it, so client-side processing (if any) can still find it', () => {
     const editor = makeEditor(`
       <p>Content</p>
       <div class="tableWrapper">
@@ -122,7 +122,9 @@ describe('prose2aem section-metadata handling', () => {
       </div>
     `);
     const main = parseMain(prose2aem(editor, true, false));
-    expect(main.querySelector('.section-metadata')).to.not.exist;
+    const block = main.querySelector('.section-metadata');
+    expect(block).to.exist;
+    expect(block.style.display).to.equal('none');
   });
 
   it('sets non-style keys as data attributes on the parent section', () => {


### PR DESCRIPTION
#971 added section metadata handling for DA live preview & quick-edit, but it didn't handle cases where an older site isn't enrolled into `features.rendering.v2`, so if an existing site relies on `div.section-metadata` existing for any custom metadata related stuff, this breaks.

Instead of removing the `section-metadata` div after applying section metadata, hide it instead so legacy projects can still use it and do whatever custom stuff they need to.

**TESTING**

Tested on:

- https://main--da-testing-p--doe-app-svc.aem.page/drafts/allen/section-metadata-issue where this issue was reported
- On https://main--att-business--usman-khalid.aem.page/ which has server side metadata enabled.