### PR TITLE
refactor: introduce new eventing mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,18 @@ Good: `multiimg`, `fixauth`, `tabfix`
 Bad: `fix-auth`, `my-feature-branch`, `Fix_Tabs`
 
 Always enforce this when creating or suggesting branch names.
+
+## Canvas Eventing
+
+Inside `blocks/canvas/**`, use `canvasBus` (`blocks/canvas/utils/canvas-bus.js`) for any new in-process event or state broadcast — don't dispatch a new DOM `CustomEvent` and don't write a new one-off observable.
+
+This exists because the canvas block used to have three uncoordinated event mechanisms doing the same job with different shapes; `canvas-bus.js` consolidated the in-process ones into one `canvasBus.<name>.emit()`/`.subscribe()` API. Adding a new bespoke event mechanism instead of a new `canvasBus` channel reintroduces exactly that problem. See `canvas-bus.js`'s own comments for the naming convention (`*Request` for a command, `*State`/`*Ready` for a broadcast).
+
+For anything crossing a boundary `canvasBus` can't reach — it's in-process only, nothing to do with panels, chat, or the quick-edit iframe — use the mechanism that already owns that boundary instead of inventing a new one:
+- **Shared panel or chat**: da-nx's `PANEL_EVENT` / `CHAT_EVENT` DOM CustomEvents (documented in da-nx's `docs/workspace.md` and `docs/chat-ui-component.md`).
+- **The quick-edit iframe boundary** (host ↔ the WYSIWYG overlay): `MESSAGE_TYPES` (`blocks/canvas/utils/quick-edit-messages.js`, re-exporting da-nx's `nx/utils/message-types.js`; documented in da-nx's `docs/quick-edit-events.md`). If the data you need is already carried by an existing type, extend its payload rather than adding a parallel one.
+
+Good: adding `canvasBus.someNewThing = createChannel()` for a new canvas-local signal.
+Bad: `element.dispatchEvent(new CustomEvent('nx-canvas-something', ...))`, a second module-level `Set`-based observable next to `canvas-bus.js`, or a new ad-hoc `postMessage` shape for something `MESSAGE_TYPES` already covers.
+
+Always check `canvas-bus.js`, da-nx's `PANEL_EVENT`/`CHAT_EVENT`, and `MESSAGE_TYPES` before adding a new event mechanism anywhere in the canvas editor.

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -1,5 +1,4 @@
 import { getNx } from '../../scripts/utils.js';
-import { editorSelectChange } from './editor-utils/editor-utils.js';
 import {
   normalizeCanvasEditorView,
   readInitialCanvasEditorView,
@@ -19,6 +18,7 @@ import { resolveEditorDocSession } from './ew-editor-doc/utils/load-editor-doc.j
 import { sourceUrlFromEditorCtx } from './ew-editor-doc/utils/ctx.js';
 import { SEL_BLOCK, SEL_ITEM, SEL_TEXT } from './ew-editor-doc/utils/selection.js';
 import { getChatPanelContent } from '../shared/chat-panel.js';
+import { canvasBus } from './utils/canvas-bus.js';
 
 const { loadStyle, hashChange } = await import(`${getNx()}/utils/utils.js`);
 const { CHAT_EVENT } = await import(`${getNx()}/blocks/chat/constants.js`);
@@ -37,22 +37,13 @@ function buildCanvasDocPath(state) {
   return `${org}/${site}/${path}`;
 }
 
-function notifyCanvasEditorActive(mountRoot, view) {
+function notifyCanvasEditorActive(view) {
   const v = normalizeCanvasEditorView(view);
-  mountRoot.dispatchEvent(new CustomEvent('nx-canvas-editor-active', {
-    bubbles: false,
-    detail: { view: v },
-  }));
+  canvasBus.editorViewState.emit({ view: v });
 }
 
 function canvasEditorMountRoot(block) {
   return block.querySelector('.default-content') || block;
-}
-
-function canvasHeaderApplyTarget(block) {
-  return block.querySelector('.nx-canvas-editor-mount')
-    || block.querySelector('.default-content')
-    || block;
 }
 
 function removeCanvasEditors(mountRoot) {
@@ -136,7 +127,7 @@ async function syncCanvasEditorsToHash({ mountRoot, header, state }) {
   frameEl.canWrite = canWrite;
   frameEl.ctx = ctx;
   finalizeSplitEditorMountOrder(mountRoot);
-  notifyCanvasEditorActive(mountRoot, header.editorView);
+  notifyCanvasEditorActive(header.editorView);
   syncEditorSplitLayout({ mountRoot, view: header.editorView });
 }
 
@@ -168,17 +159,16 @@ function hashState() {
 async function installCanvasHeader(block, { org, site }) {
   const header = document.createElement('ew-canvas-header');
   header.editorView = await readInitialCanvasEditorView({ org, site });
-  header.addEventListener('nx-canvas-editor-view', (e) => {
-    const view = normalizeCanvasEditorView(e.detail?.view);
+  canvasBus.editorViewRequest.subscribe(({ view: rawView }) => {
+    const view = normalizeCanvasEditorView(rawView);
     persistCanvasEditorView(view);
-    const applyTarget = canvasHeaderApplyTarget(block);
-    notifyCanvasEditorActive(applyTarget, view);
+    notifyCanvasEditorActive(view);
     syncEditorSplitLayout({ mountRoot: canvasEditorMountRoot(block), view });
   });
-  header.addEventListener('nx-canvas-undo', () => {
+  canvasBus.undoRequest.subscribe(() => {
     canvasEditorMountRoot(block).querySelector('ew-editor-doc')?.undo();
   });
-  header.addEventListener('nx-canvas-redo', () => {
+  canvasBus.redoRequest.subscribe(() => {
     canvasEditorMountRoot(block).querySelector('ew-editor-doc')?.redo();
   });
   block.before(header);
@@ -200,7 +190,7 @@ const SHORTCUTS = [
     code: 'KeyS',
     mod: true,
     altKey: true,
-    action: openNewVersionRow,
+    channel: canvasBus.newVersionRequest,
   },
 ];
 document.addEventListener('keydown', (e) => {
@@ -214,10 +204,10 @@ document.addEventListener('keydown', (e) => {
   ));
   if (!match) return;
   e.preventDefault();
-  match.action();
+  match.channel.emit();
 });
 
-document.addEventListener('nx-canvas-new-version', openNewVersionRow);
+canvasBus.newVersionRequest.subscribe(openNewVersionRow);
 
 export default async function decorate(block) {
   const { org, site } = hashState();
@@ -261,9 +251,9 @@ export default async function decorate(block) {
   syncEditorSplitLayout({ mountRoot, view: header.editorView });
   installEditorSplitDrag(mountRoot);
 
-  mountRoot.addEventListener('nx-editor-undo-state', (e) => {
-    header.undoAvailable = e.detail?.canUndo ?? false;
-    header.redoAvailable = e.detail?.canRedo ?? false;
+  canvasBus.undoState.subscribe((detail) => {
+    header.undoAvailable = detail?.canUndo ?? false;
+    header.redoAvailable = detail?.canRedo ?? false;
   });
 
   hashChange.subscribe((state) => {
@@ -286,7 +276,7 @@ export default async function decorate(block) {
   const CANVAS_CHAT_KEY = 'canvas-selection';
   const SELECTION_LABEL = 'Selection';
   let hasContext = false;
-  editorSelectChange.subscribe(({
+  canvasBus.editorSelectState.subscribe(({
     blockIndex, blockName, proseIndex, innerText, source,
     selectionType, selectedHTML, selFrom, selTo,
   }) => {

--- a/blocks/canvas/canvas.js
+++ b/blocks/canvas/canvas.js
@@ -272,7 +272,7 @@ export default async function decorate(block) {
   }
 
   // Any non-empty selection in doc mode is sent as chat context.
-  // wysiwyg has no block-select equivalent yet — see docs/canvas-events.md.
+  // wysiwyg has no block-select equivalent yet.
   const CANVAS_CHAT_KEY = 'canvas-selection';
   const SELECTION_LABEL = 'Selection';
   let hasContext = false;

--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -4,6 +4,7 @@ import { getNx } from '../../../scripts/utils.js';
 import { daFetch, fetchDaConfigs, getFirstSheet } from '../../shared/utils.js';
 import { getSelectionToolbar } from './selection-toolbar.js';
 import { MESSAGE_TYPES } from '../utils/quick-edit-messages.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 
 const { DA_CONTENT } = await import(`${getNx()}/utils/utils.js`);
 
@@ -366,73 +367,29 @@ export function parseSections(htmlText) {
   });
 }
 
-// State observable — replays last value on subscribe. See docs/canvas-events.md.
-export const editorHtmlChange = (() => {
-  const listeners = new Set();
-  let currentHtml = '';
-  return {
-    emit(html) {
-      currentHtml = html;
-      listeners.forEach((fn) => fn(html));
-    },
-    subscribe(fn) {
-      listeners.add(fn);
-      if (currentHtml) fn(currentHtml);
-      return () => listeners.delete(fn);
-    },
-  };
-})();
-
-// Event observable — no replay on subscribe. See docs/canvas-events.md.
-// emit() enriches the detail with blockName/proseIndex/innerText from the last parsed HTML.
-export const editorSelectChange = (() => {
-  const listeners = new Set();
-  let blockMeta = new Map();
-
-  editorHtmlChange.subscribe((html) => {
-    if (!html.trim()) {
-      blockMeta = new Map();
-      return;
+let selectBlockMeta = new Map();
+canvasBus.editorHtmlState.subscribe((html) => {
+  if (!html.trim()) {
+    selectBlockMeta = new Map();
+    return;
+  }
+  const next = new Map();
+  for (const { blocks } of parseSections(html)) {
+    for (const { name, blockIndex, proseIndex, innerText } of blocks) {
+      next.set(blockIndex, { name, proseIndex, innerText });
     }
-    const next = new Map();
-    for (const { blocks } of parseSections(html)) {
-      for (const { name, blockIndex, proseIndex, innerText } of blocks) {
-        next.set(blockIndex, { name, proseIndex, innerText });
-      }
-    }
-    blockMeta = next;
-  });
+  }
+  selectBlockMeta = next;
+});
 
-  return {
-    emit(detail) {
-      const meta = blockMeta.get(detail.blockIndex);
-      const { name: blockName, proseIndex, innerText } = meta || {};
-      const enriched = meta
-        ? { ...detail, blockName, proseIndex, innerText }
-        : detail;
-      listeners.forEach((fn) => fn(enriched));
-    },
-    subscribe(fn) {
-      listeners.add(fn);
-      return () => listeners.delete(fn);
-    },
-  };
-})();
-
-// Event observable — no replay on subscribe. See docs/canvas-events.md.
-// Carries a raw ProseMirror position, not a block index, for the outline's default-content entries.
-export const editorProseSelectChange = (() => {
-  const listeners = new Set();
-  return {
-    emit(detail) {
-      listeners.forEach((fn) => fn(detail));
-    },
-    subscribe(fn) {
-      listeners.add(fn);
-      return () => listeners.delete(fn);
-    },
-  };
-})();
+export function emitEditorSelectState(detail) {
+  const meta = selectBlockMeta.get(detail.blockIndex);
+  const { name: blockName, proseIndex, innerText } = meta || {};
+  const enriched = meta
+    ? { ...detail, blockName, proseIndex, innerText }
+    : detail;
+  canvasBus.editorSelectState.emit(enriched);
+}
 
 export function updateDocument(ctx) {
   if (ctx.suppressRerender) return undefined;

--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -382,6 +382,8 @@ canvasBus.editorHtmlState.subscribe((html) => {
   selectBlockMeta = next;
 });
 
+// Runs once, at load, so canvas-bus.js's editorSelectState.emit is enriched for
+// every caller from here on — see canvas-bus.js for why this file owns the lookup.
 registerEditorSelectEnricher((detail) => {
   const meta = selectBlockMeta.get(detail.blockIndex);
   if (!meta) return detail;

--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -4,7 +4,7 @@ import { getNx } from '../../../scripts/utils.js';
 import { daFetch, fetchDaConfigs, getFirstSheet } from '../../shared/utils.js';
 import { getSelectionToolbar } from './selection-toolbar.js';
 import { MESSAGE_TYPES } from '../utils/quick-edit-messages.js';
-import { canvasBus } from '../utils/canvas-bus.js';
+import { canvasBus, registerEditorSelectEnricher } from '../utils/canvas-bus.js';
 
 const { DA_CONTENT } = await import(`${getNx()}/utils/utils.js`);
 
@@ -382,14 +382,12 @@ canvasBus.editorHtmlState.subscribe((html) => {
   selectBlockMeta = next;
 });
 
-export function emitEditorSelectState(detail) {
+registerEditorSelectEnricher((detail) => {
   const meta = selectBlockMeta.get(detail.blockIndex);
-  const { name: blockName, proseIndex, innerText } = meta || {};
-  const enriched = meta
-    ? { ...detail, blockName, proseIndex, innerText }
-    : detail;
-  canvasBus.editorSelectState.emit(enriched);
-}
+  if (!meta) return detail;
+  const { name: blockName, proseIndex, innerText } = meta;
+  return { ...detail, blockName, proseIndex, innerText };
+});
 
 export function updateDocument(ctx) {
   if (ctx.suppressRerender) return undefined;

--- a/blocks/canvas/ew-canvas-header/ew-canvas-header.js
+++ b/blocks/canvas/ew-canvas-header/ew-canvas-header.js
@@ -2,6 +2,7 @@ import { LitElement, html, nothing } from 'da-lit';
 
 import { getNx, getNx2, getNxEWFlags } from '../../../scripts/utils.js';
 import getSheet from '../../shared/sheet.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 
 const { loadStyle, hashChange } = await import(`${getNx()}/utils/utils.js`);
 const { PANEL_EVENT, getSectionAtPosition } = await import(`${getNx()}/utils/panel.js`);
@@ -73,27 +74,17 @@ class EWCanvasHeader extends LitElement {
   }
 
   _undo() {
-    this.dispatchEvent(
-      new CustomEvent('nx-canvas-undo', { bubbles: true, composed: true }),
-    );
+    canvasBus.undoRequest.emit();
   }
 
   _redo() {
-    this.dispatchEvent(
-      new CustomEvent('nx-canvas-redo', { bubbles: true, composed: true }),
-    );
+    canvasBus.redoRequest.emit();
   }
 
   _setEditorView(view) {
     if (!EDITOR_VIEWS.includes(view) || view === this.editorView) return;
     this.editorView = view;
-    this.dispatchEvent(
-      new CustomEvent('nx-canvas-editor-view', {
-        bubbles: true,
-        composed: true,
-        detail: { view },
-      }),
-    );
+    canvasBus.editorViewRequest.emit({ view });
   }
 
   _renderIcon(name) {

--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.js
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.js
@@ -1,10 +1,7 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { yUndo, yRedo, NodeSelection, TextSelection } from 'da-y-wrapper';
 import { getNx } from '../../../scripts/utils.js';
-import {
-  updateDocument, updateCursors, getInstrumentedHTML,
-  editorHtmlChange, editorSelectChange, editorProseSelectChange, getEditor,
-} from '../editor-utils/editor-utils.js';
+import { updateDocument, updateCursors, getInstrumentedHTML, emitEditorSelectState, getEditor } from '../editor-utils/editor-utils.js';
 import { getActiveBlockIndex, getBlockPositions } from '../editor-utils/blocks.js';
 import {
   editorDocCanLoad,
@@ -28,6 +25,7 @@ import { teardownEditorDocResources } from './utils/teardown.js';
 import { hideSelectionToolbar, setSelectionToolbarCtx } from '../editor-utils/selection-toolbar.js';
 import { createExtensionsBridgePlugin } from '../editor-utils/extensions-bridge.js';
 import { MESSAGE_TYPES } from '../utils/quick-edit-messages.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 
 // Maps ew-page-outline's default-content `kind` to the PM node type(s) it can back,
 // so a matching node at proseIndex can be selected as a whole (see _scrollDocToProseIndex).
@@ -63,7 +61,7 @@ export class EwEditorDoc extends LitElement {
       this._lastDocBlockIndex = undefined;
       this._lastDocSelKey = undefined;
       this._lastBroadcastNodeKey = undefined;
-      editorHtmlChange.emit('');
+      canvasBus.editorHtmlState.emit('');
     }
   }
 
@@ -87,18 +85,14 @@ export class EwEditorDoc extends LitElement {
   _emitHtmlChange() {
     const { view } = this._proseContext ?? {};
     if (!view) return;
-    editorHtmlChange.emit(getInstrumentedHTML(view));
+    canvasBus.editorHtmlState.emit(getInstrumentedHTML(view));
   }
 
   _emitUndoState() {
     const mgr = this._proseContext?.undoManager;
     const canUndo = mgr ? mgr.undoStack.length > 0 : false;
     const canRedo = mgr ? mgr.redoStack.length > 0 : false;
-    this.dispatchEvent(new CustomEvent('nx-editor-undo-state', {
-      bubbles: true,
-      composed: true,
-      detail: { canUndo, canRedo },
-    }));
+    canvasBus.undoState.emit({ canUndo, canRedo });
   }
 
   _observeUndoManager(mgr) {
@@ -294,7 +288,7 @@ export class EwEditorDoc extends LitElement {
               const body = this._controllerCtx
                 ? updateDocument(this._controllerCtx)
                 : getInstrumentedHTML(this._proseContext?.view);
-              if (body) editorHtmlChange.emit(body);
+              if (body) canvasBus.editorHtmlState.emit(body);
             },
             () => { if (this._controllerCtx) updateCursors(this._controllerCtx); },
             (data) => { if (this._controllerCtx) getEditor(data, this._controllerCtx); },
@@ -306,7 +300,7 @@ export class EwEditorDoc extends LitElement {
               if (blockIndex === this._lastDocBlockIndex && selKey === this._lastDocSelKey) return;
               this._lastDocBlockIndex = blockIndex;
               this._lastDocSelKey = selKey;
-              editorSelectChange.emit({
+              emitEditorSelectState({
                 blockIndex,
                 proseIndex,
                 source: 'doc',
@@ -343,27 +337,25 @@ export class EwEditorDoc extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
-    this._onCanvasEditorActive = (e) => {
-      const view = e.detail?.view;
+    this._unsubscribeEditorActive = canvasBus.editorViewState.subscribe(({ view }) => {
       this.hidden = view === 'layout';
       hideSelectionToolbar();
-    };
-    this.parentElement?.addEventListener('nx-canvas-editor-active', this._onCanvasEditorActive);
-    this._onWysiwygPortReady = (e) => {
-      const { port, iframe } = e.detail ?? {};
-      if (port) {
-        this._wysiwygIframe = iframe;
-        this.quickEditPort = port;
-      }
-    };
-    this.parentElement?.addEventListener('nx-wysiwyg-port-ready', this._onWysiwygPortReady);
-    this._unsubscribeSelect = editorSelectChange
+    });
+    this._unsubscribeWysiwygPortReady = canvasBus.wysiwygPortReady.subscribe(
+      ({ port, iframe } = {}) => {
+        if (port) {
+          this._wysiwygIframe = iframe;
+          this.quickEditPort = port;
+        }
+      },
+    );
+    this._unsubscribeSelect = canvasBus.editorSelectState
       .subscribe(({ blockIndex, source }) => {
         if (source === 'doc') return;
         this._scrollDocToBlock(blockIndex);
         if (source === 'outline') this._broadcastSelectedNode(true);
       });
-    this._unsubscribeProseSelect = editorProseSelectChange
+    this._unsubscribeProseSelect = canvasBus.editorProseSelectState
       .subscribe(({ proseIndex, kind }) => this._scrollDocToProseIndex(proseIndex, kind));
     this._onCanvasHighlight = (e) => this._applyHighlight(e.detail);
     document.addEventListener(CHAT_EVENT.HIGHLIGHT_SELECTION, this._onCanvasHighlight);
@@ -374,8 +366,8 @@ export class EwEditorDoc extends LitElement {
   }
 
   disconnectedCallback() {
-    this.parentElement?.removeEventListener('nx-canvas-editor-active', this._onCanvasEditorActive);
-    this.parentElement?.removeEventListener('nx-wysiwyg-port-ready', this._onWysiwygPortReady);
+    this._unsubscribeEditorActive?.();
+    this._unsubscribeWysiwygPortReady?.();
     document.removeEventListener(CHAT_EVENT.HIGHLIGHT_SELECTION, this._onCanvasHighlight);
     this._unsubscribeSelect?.();
     this._unsubscribeProseSelect?.();

--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.js
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.js
@@ -1,7 +1,7 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { yUndo, yRedo, NodeSelection, TextSelection } from 'da-y-wrapper';
 import { getNx } from '../../../scripts/utils.js';
-import { updateDocument, updateCursors, getInstrumentedHTML, emitEditorSelectState, getEditor } from '../editor-utils/editor-utils.js';
+import { updateDocument, updateCursors, getInstrumentedHTML, getEditor } from '../editor-utils/editor-utils.js';
 import { getActiveBlockIndex, getBlockPositions } from '../editor-utils/blocks.js';
 import {
   editorDocCanLoad,
@@ -300,7 +300,7 @@ export class EwEditorDoc extends LitElement {
               if (blockIndex === this._lastDocBlockIndex && selKey === this._lastDocSelKey) return;
               this._lastDocBlockIndex = blockIndex;
               this._lastDocSelKey = selKey;
-              emitEditorSelectState({
+              canvasBus.editorSelectState.emit({
                 blockIndex,
                 proseIndex,
                 source: 'doc',

--- a/blocks/canvas/ew-editor-doc/prose.js
+++ b/blocks/canvas/ew-editor-doc/prose.js
@@ -41,6 +41,7 @@ import { getNx } from '../../../scripts/utils.js';
 import { getAuthToken } from '../../shared/utils.js';
 import { generateColor, getCollabIdentity } from './utils/collab.js';
 import { checkBlockLibraryConfigured } from '../editor-utils/block-slash.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 
 const { DA_ADMIN, DA_COLLAB, hashChange } = await import(`${getNx()}/utils/utils.js`);
 
@@ -191,7 +192,7 @@ export default async function initProse({
         return true;
       },
       'Mod-Alt-s': () => {
-        document.dispatchEvent(new CustomEvent('nx-canvas-new-version', { bubbles: true, composed: true }));
+        canvasBus.newVersionRequest.emit();
         return true;
       },
       ...getHeadingKeymap(schema),

--- a/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
+++ b/blocks/canvas/ew-editor-wysiwyg/ew-editor-wysiwyg.js
@@ -4,6 +4,7 @@ import { getPreviewOrigin, fetchWysiwygCookie, fetchWysiwygBranch } from '../edi
 import { initIms as loadIms } from '../../shared/utils.js';
 import { hideSelectionToolbar } from '../editor-utils/selection-toolbar.js';
 import { MESSAGE_TYPES } from '../utils/quick-edit-messages.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 
 const { loadStyle } = await import(`${getNx()}/utils/utils.js`);
 
@@ -56,16 +57,15 @@ export class EwEditorWysiwyg extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
-    this._onCanvasEditorActive = (e) => {
-      this._canvasActiveView = e.detail?.view;
+    this._unsubscribeEditorActive = canvasBus.editorViewState.subscribe(({ view }) => {
+      this._canvasActiveView = view;
       this._syncCanvasVisibility();
-    };
-    this.parentElement?.addEventListener('nx-canvas-editor-active', this._onCanvasEditorActive);
+    });
     this._syncCanvasVisibility();
   }
 
   disconnectedCallback() {
-    this.parentElement?.removeEventListener('nx-canvas-editor-active', this._onCanvasEditorActive);
+    this._unsubscribeEditorActive?.();
     this._clearQuickEditRetry();
     super.disconnectedCallback();
   }
@@ -142,11 +142,7 @@ export class EwEditorWysiwyg extends LitElement {
     this.setAttribute(WYSIWYG_PORT_READY_ATTR, '');
     this._syncCanvasVisibility();
     const iframe = this.shadowRoot?.querySelector('iframe');
-    this.dispatchEvent(new CustomEvent('nx-wysiwyg-port-ready', {
-      bubbles: true,
-      composed: true,
-      detail: { port, iframe },
-    }));
+    canvasBus.wysiwygPortReady.emit({ port, iframe });
   }
 
   _scheduleQuickEditInitRetries(send) {

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -5,6 +5,7 @@ import {
   NX_QUICK_EDIT_IFRAME_SELECTION_META,
   NX_QUICK_EDIT_CLEAR_IFRAME_SELECTION_ORIGIN_META,
 } from '../../editor-utils/selection-toolbar.js';
+import { canvasBus } from '../../utils/canvas-bus.js';
 
 export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
   const { view, wsProvider } = ctx;
@@ -57,9 +58,9 @@ export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
     }
 
     ctx.suppressRerender = true;
-    // dispatch() already triggers createTrackingPlugin's hook, which emits editorSelectChange
-    // with the full payload (incl. proseIndex) — a second, blockIndex-only emit here would
-    // clobber that and collapse the outline.
+    // dispatch() already triggers createTrackingPlugin's hook, which emits
+    // canvasBus.editorSelectState with the full payload (incl. proseIndex) — a second,
+    // blockIndex-only emit here would clobber that and collapse the outline.
     view.dispatch(tr.scrollIntoView());
     ctx.suppressRerender = false;
     const tb = getSelectionToolbar();
@@ -93,7 +94,7 @@ export function handleUndoRedo(data, ctx) {
 }
 
 export function handleNewVersion() {
-  document.dispatchEvent(new CustomEvent('nx-canvas-new-version', { bubbles: true, composed: true }));
+  canvasBus.newVersionRequest.emit();
 }
 
 export function handleStoredMarks({ marks }, ctx) {

--- a/blocks/canvas/ew-page-outline/ew-page-outline.js
+++ b/blocks/canvas/ew-page-outline/ew-page-outline.js
@@ -1,8 +1,9 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { getNx } from '../../../scripts/utils.js';
 import { treeKeydown } from '../utils/tree-nav.js';
-import { editorHtmlChange, editorSelectChange, editorProseSelectChange, parseSections } from '../editor-utils/editor-utils.js';
+import { emitEditorSelectState, parseSections } from '../editor-utils/editor-utils.js';
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 import {
   deleteBlock,
   deleteContentItem,
@@ -86,7 +87,7 @@ class EwPageOutline extends LitElement {
     this.shadowRoot.adoptedStyleSheets = [style];
     this._expandedContent = new Set();
     this._unsubHash = hashChange.subscribe((state) => { this._hashState = state; });
-    this._unsubscribeHtml = editorHtmlChange.subscribe((aemHtml) => {
+    this._unsubscribeHtml = canvasBus.editorHtmlState.subscribe((aemHtml) => {
       if (aemHtml.trim()) {
         const next = parseSections(aemHtml);
         if (!sectionsEqual(next, this._sections)) {
@@ -102,7 +103,7 @@ class EwPageOutline extends LitElement {
         this._selectedProseIndex = undefined;
       }
     });
-    this._unsubscribeSelect = editorSelectChange
+    this._unsubscribeSelect = canvasBus.editorSelectState
       .subscribe(({ blockIndex, proseIndex, source }) => {
         if (source === 'outline') return;
         this._selectedBlockIndex = blockIndex;
@@ -150,14 +151,14 @@ class EwPageOutline extends LitElement {
   _select(blockIndex) {
     this._selectedBlockIndex = blockIndex;
     this._selectedProseIndex = undefined;
-    editorSelectChange.emit({ blockIndex, source: 'outline' });
+    emitEditorSelectState({ blockIndex, source: 'outline' });
   }
 
   _selectProse(proseIndex, kind) {
     this._selectedProseIndex = proseIndex;
     this._selectedBlockIndex = undefined;
     this._expandRunForProse(proseIndex);
-    editorProseSelectChange.emit({ proseIndex, kind });
+    canvasBus.editorProseSelectState.emit({ proseIndex, kind });
   }
 
   _toggleContentGroup(key) {
@@ -169,7 +170,7 @@ class EwPageOutline extends LitElement {
 
   // Selection never collapses anything — it only ensures the run holding the new
   // selection is visible, adding it alongside whatever's already expanded. Expansion is
-  // only ever cleared wholesale on a reparse (see the editorHtmlChange subscription).
+  // only ever cleared wholesale on a reparse (see the canvasBus.editorHtmlState subscription).
   _expandRunForProse(proseIndex) {
     const runKey = this._findRunKeyForProseIndex(proseIndex);
     if (runKey == null) return;

--- a/blocks/canvas/ew-page-outline/ew-page-outline.js
+++ b/blocks/canvas/ew-page-outline/ew-page-outline.js
@@ -1,7 +1,7 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { getNx } from '../../../scripts/utils.js';
 import { treeKeydown } from '../utils/tree-nav.js';
-import { emitEditorSelectState, parseSections } from '../editor-utils/editor-utils.js';
+import { parseSections } from '../editor-utils/editor-utils.js';
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
 import { canvasBus } from '../utils/canvas-bus.js';
 import {
@@ -151,7 +151,7 @@ class EwPageOutline extends LitElement {
   _select(blockIndex) {
     this._selectedBlockIndex = blockIndex;
     this._selectedProseIndex = undefined;
-    emitEditorSelectState({ blockIndex, source: 'outline' });
+    canvasBus.editorSelectState.emit({ blockIndex, source: 'outline' });
   }
 
   _selectProse(proseIndex, kind) {

--- a/blocks/canvas/utils/canvas-bus.js
+++ b/blocks/canvas/utils/canvas-bus.js
@@ -1,0 +1,55 @@
+const target = new EventTarget();
+
+const CANVAS_EVENT = {
+  EDITOR_VIEW_STATE: 'canvas:editor-view-state',
+  UNDO_REQUEST: 'canvas:undo-request',
+  REDO_REQUEST: 'canvas:redo-request',
+  EDITOR_VIEW_REQUEST: 'canvas:editor-view-request',
+  UNDO_STATE: 'canvas:undo-state',
+  NEW_VERSION_REQUEST: 'canvas:new-version-request',
+  WYSIWYG_PORT_READY: 'canvas:wysiwyg-port-ready',
+  EDITOR_HTML_STATE: 'canvas:editor-html-state',
+  EDITOR_SELECT_STATE: 'canvas:editor-select-state',
+  EDITOR_PROSE_SELECT_STATE: 'canvas:editor-prose-select-state',
+};
+
+// Shared channel factory: one EventTarget backs every canvas-local, in-process
+// event instead of each call site picking its own dispatch target (mountRoot,
+// header element, document, a sibling...). `replay: true` re-delivers the last
+// truthy emitted value to a subscriber that joins later.
+function createChannel(type, { replay = false } = {}) {
+  let lastValue;
+  return {
+    emit(detail) {
+      lastValue = detail;
+      target.dispatchEvent(new CustomEvent(type, { detail }));
+    },
+    subscribe(fn) {
+      const handler = (e) => fn(e.detail);
+      target.addEventListener(type, handler);
+      if (replay && lastValue) fn(lastValue);
+      return () => target.removeEventListener(type, handler);
+    },
+  };
+}
+
+// Single namespaced entry point, and the only place `createChannel` is called:
+// `canvasBus.<name>.emit()` / `.subscribe()` is autocomplete-discoverable, and every
+// canvas-local event that exists is listed right here. Naming convention: `*Request` is
+// a command asking something to happen (emitted by the UI that wants the action);
+// `*State`/`*Ready` is a broadcast of something that already happened (emitted by
+// whatever resolved/owns that state).
+export const canvasBus = Object.freeze({
+  editorViewRequest: createChannel(CANVAS_EVENT.EDITOR_VIEW_REQUEST),
+  undoRequest: createChannel(CANVAS_EVENT.UNDO_REQUEST),
+  redoRequest: createChannel(CANVAS_EVENT.REDO_REQUEST),
+  newVersionRequest: createChannel(CANVAS_EVENT.NEW_VERSION_REQUEST),
+
+  undoState: createChannel(CANVAS_EVENT.UNDO_STATE),
+  editorViewState: createChannel(CANVAS_EVENT.EDITOR_VIEW_STATE),
+  editorHtmlState: createChannel(CANVAS_EVENT.EDITOR_HTML_STATE, { replay: true }),
+  editorSelectState: createChannel(CANVAS_EVENT.EDITOR_SELECT_STATE),
+  editorProseSelectState: createChannel(CANVAS_EVENT.EDITOR_PROSE_SELECT_STATE),
+
+  wysiwygPortReady: createChannel(CANVAS_EVENT.WYSIWYG_PORT_READY),
+});

--- a/blocks/canvas/utils/canvas-bus.js
+++ b/blocks/canvas/utils/canvas-bus.js
@@ -1,5 +1,9 @@
-// Plain pub/sub, no DOM dispatch target needed. `replay: true` re-delivers the last
-// truthy emitted value to a subscriber that joins later.
+// In-process pub/sub for canvas-local UI events (undo, selection, editor view, ...).
+// Not for panel or chat — those cross into da-nx and use its PANEL_EVENT/CHAT_EVENT
+// DOM CustomEvents instead, since components outside this block need to reach them too.
+
+// Each channel is a private listener Set — no DOM element involved. `replay: true`
+// re-delivers the last truthy emitted value to a subscriber that joins later.
 function createChannel({ replay = false } = {}) {
   const listeners = new Set();
   let lastValue;

--- a/blocks/canvas/utils/canvas-bus.js
+++ b/blocks/canvas/utils/canvas-bus.js
@@ -1,55 +1,50 @@
-const target = new EventTarget();
-
-const CANVAS_EVENT = {
-  EDITOR_VIEW_STATE: 'canvas:editor-view-state',
-  UNDO_REQUEST: 'canvas:undo-request',
-  REDO_REQUEST: 'canvas:redo-request',
-  EDITOR_VIEW_REQUEST: 'canvas:editor-view-request',
-  UNDO_STATE: 'canvas:undo-state',
-  NEW_VERSION_REQUEST: 'canvas:new-version-request',
-  WYSIWYG_PORT_READY: 'canvas:wysiwyg-port-ready',
-  EDITOR_HTML_STATE: 'canvas:editor-html-state',
-  EDITOR_SELECT_STATE: 'canvas:editor-select-state',
-  EDITOR_PROSE_SELECT_STATE: 'canvas:editor-prose-select-state',
-};
-
-// Shared channel factory: one EventTarget backs every canvas-local, in-process
-// event instead of each call site picking its own dispatch target (mountRoot,
-// header element, document, a sibling...). `replay: true` re-delivers the last
+// Plain pub/sub, no DOM dispatch target needed. `replay: true` re-delivers the last
 // truthy emitted value to a subscriber that joins later.
-function createChannel(type, { replay = false } = {}) {
+function createChannel({ replay = false } = {}) {
+  const listeners = new Set();
   let lastValue;
   return {
     emit(detail) {
       lastValue = detail;
-      target.dispatchEvent(new CustomEvent(type, { detail }));
+      listeners.forEach((fn) => fn(detail));
     },
     subscribe(fn) {
-      const handler = (e) => fn(e.detail);
-      target.addEventListener(type, handler);
+      listeners.add(fn);
       if (replay && lastValue) fn(lastValue);
-      return () => target.removeEventListener(type, handler);
+      return () => listeners.delete(fn);
     },
   };
 }
 
-// Single namespaced entry point, and the only place `createChannel` is called:
-// `canvasBus.<name>.emit()` / `.subscribe()` is autocomplete-discoverable, and every
-// canvas-local event that exists is listed right here. Naming convention: `*Request` is
-// a command asking something to happen (emitted by the UI that wants the action);
-// `*State`/`*Ready` is a broadcast of something that already happened (emitted by
-// whatever resolved/owns that state).
+// editor-utils.js owns selection enrichment (blockName/proseIndex/innerText lookup) and
+// registers it here — importing it directly would cycle back through this file.
+let enrichEditorSelect = (detail) => detail;
+let enricherRegistered = false;
+export function registerEditorSelectEnricher(fn) {
+  if (enricherRegistered) {
+    throw new Error('registerEditorSelectEnricher already called — extend the existing enricher instead of registering a second one.');
+  }
+  enricherRegistered = true;
+  enrichEditorSelect = fn;
+}
+const editorSelectChannel = createChannel();
+
+// Naming: `*Request` is a command (emitted by the UI that wants the action to happen);
+// `*State`/`*Ready` is a broadcast of something that already happened.
 export const canvasBus = Object.freeze({
-  editorViewRequest: createChannel(CANVAS_EVENT.EDITOR_VIEW_REQUEST),
-  undoRequest: createChannel(CANVAS_EVENT.UNDO_REQUEST),
-  redoRequest: createChannel(CANVAS_EVENT.REDO_REQUEST),
-  newVersionRequest: createChannel(CANVAS_EVENT.NEW_VERSION_REQUEST),
+  editorViewRequest: createChannel(),
+  undoRequest: createChannel(),
+  redoRequest: createChannel(),
+  newVersionRequest: createChannel(),
 
-  undoState: createChannel(CANVAS_EVENT.UNDO_STATE),
-  editorViewState: createChannel(CANVAS_EVENT.EDITOR_VIEW_STATE),
-  editorHtmlState: createChannel(CANVAS_EVENT.EDITOR_HTML_STATE, { replay: true }),
-  editorSelectState: createChannel(CANVAS_EVENT.EDITOR_SELECT_STATE),
-  editorProseSelectState: createChannel(CANVAS_EVENT.EDITOR_PROSE_SELECT_STATE),
+  undoState: createChannel(),
+  editorViewState: createChannel(),
+  editorHtmlState: createChannel({ replay: true }),
+  editorSelectState: {
+    subscribe: editorSelectChannel.subscribe,
+    emit: (detail) => editorSelectChannel.emit(enrichEditorSelect(detail)),
+  },
+  editorProseSelectState: createChannel(),
 
-  wysiwygPortReady: createChannel(CANVAS_EVENT.WYSIWYG_PORT_READY),
+  wysiwygPortReady: createChannel(),
 });

--- a/test/unit/blocks/canvas/ew-page-outline/ew-page-outline.test.js
+++ b/test/unit/blocks/canvas/ew-page-outline/ew-page-outline.test.js
@@ -5,12 +5,10 @@ import { getSchema } from 'da-parser';
 import { setNx } from '../../../../../scripts/utils.js';
 import { makeRealView } from '../test-helpers.js';
 import { createTrackingPlugin } from '../../../../../blocks/canvas/editor-utils/prose-diff.js';
+import { canvasBus } from '../../../../../blocks/canvas/utils/canvas-bus.js';
 
 setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
-let editorHtmlChange;
-let editorProseSelectChange;
-let editorSelectChange;
 let getExtensionsBridge;
 let getInstrumentedHTML;
 let parseSections;
@@ -18,7 +16,6 @@ let parseSections;
 before(async () => {
   await import('../../../../../blocks/canvas/ew-page-outline/ew-page-outline.js');
   const editorUtils = await import('../../../../../blocks/canvas/editor-utils/editor-utils.js');
-  ({ editorHtmlChange, editorProseSelectChange, editorSelectChange } = editorUtils);
   ({ getInstrumentedHTML, parseSections } = editorUtils);
   ({ getExtensionsBridge } = await import('../../../../../blocks/canvas/editor-utils/extensions-bridge.js'));
 });
@@ -37,7 +34,7 @@ function docSeq(doc) {
 }
 
 // Unlike makeRealView, wires the real tracking plugin so a delete/insert dispatched
-// through it auto-emits editorHtmlChange exactly like the production editor does —
+// through it auto-emits canvasBus.editorHtmlState exactly like the production editor does —
 // needed to test that a reparse-driven expansion reset/re-expand actually happens.
 function makeTrackedView(json) {
   const schema = getSchema();
@@ -45,7 +42,9 @@ function makeTrackedView(json) {
   const dom = document.createElement('div');
   document.body.appendChild(dom);
   let view;
-  const plugins = [createTrackingPlugin(() => editorHtmlChange.emit(getInstrumentedHTML(view)))];
+  const plugins = [
+    createTrackingPlugin(() => canvasBus.editorHtmlState.emit(getInstrumentedHTML(view))),
+  ];
   const state = EditorState.create({ schema, doc, plugins });
   view = new EditorView(dom, { state });
   return view;
@@ -123,12 +122,12 @@ describe('ew-page-outline — expandable default content', () => {
     expect(el.shadowRoot.querySelector('.content-children')).to.be.null;
   });
 
-  it('emits editorProseSelectChange with the child\'s own proseIndex and kind on click', async () => {
+  it('emits editorProseSelectState with the child\'s own proseIndex and kind on click', async () => {
     el.shadowRoot.querySelector('.content-item').click();
     await el.updateComplete;
 
     let received;
-    const unsub = editorProseSelectChange.subscribe((detail) => { received = detail; });
+    const unsub = canvasBus.editorProseSelectState.subscribe((detail) => { received = detail; });
     const paragraphChild = [...el.shadowRoot.querySelectorAll('.content-child')][1];
     paragraphChild.click();
     unsub();
@@ -141,7 +140,7 @@ describe('ew-page-outline — expandable default content', () => {
     await el.updateComplete;
 
     let received;
-    const unsub = editorProseSelectChange.subscribe((detail) => { received = detail; });
+    const unsub = canvasBus.editorProseSelectState.subscribe((detail) => { received = detail; });
     const imageChild = [...el.shadowRoot.querySelectorAll('.content-child')][2];
     imageChild.click();
     unsub();
@@ -172,7 +171,7 @@ describe('ew-page-outline — expandable default content', () => {
   });
 
   it('highlights a content child when the doc selection (not just an outline click) lands on it, and leaves it expanded on a later block selection', async () => {
-    editorSelectChange.emit({ blockIndex: -1, proseIndex: 5, source: 'doc' });
+    canvasBus.editorSelectState.emit({ blockIndex: -1, proseIndex: 5, source: 'doc' });
     await el.updateComplete;
 
     // A collapsed run expands additively to reveal a new selection, with no manual click needed.
@@ -180,7 +179,7 @@ describe('ew-page-outline — expandable default content', () => {
     const paragraphChild = [...el.shadowRoot.querySelectorAll('.content-child')][1];
     expect(paragraphChild.classList.contains('selected')).to.be.true;
 
-    editorSelectChange.emit({ blockIndex: 0, proseIndex: undefined, source: 'doc' });
+    canvasBus.editorSelectState.emit({ blockIndex: 0, proseIndex: undefined, source: 'doc' });
     await el.updateComplete;
 
     expect(el.shadowRoot.querySelector('.content-item').getAttribute('aria-expanded')).to.equal('true');
@@ -192,7 +191,7 @@ describe('ew-page-outline — expandable default content', () => {
     // Simulates pressing Enter mid-paragraph: the new empty node has no row of its own
     // (filtered out of parseSections), but its proseIndex (7) falls between the
     // surrounding real children (5 and 9), so it should still resolve to their run.
-    editorSelectChange.emit({ blockIndex: -1, proseIndex: 7, source: 'doc' });
+    canvasBus.editorSelectState.emit({ blockIndex: -1, proseIndex: 7, source: 'doc' });
     await el.updateComplete;
 
     expect(el.shadowRoot.querySelector('.content-item').getAttribute('aria-expanded')).to.equal('true');
@@ -223,35 +222,35 @@ describe('ew-page-outline — expandable default content', () => {
     // proseIndex 10 sits after section 0's only child (1) but well before section 1's
     // (20) — with no next item in section 0 to bound it, it's attributed to section 0's
     // run (the trailing/unbounded case a fresh Enter-created node at the end lands in).
-    editorSelectChange.emit({ blockIndex: -1, proseIndex: 10, source: 'doc' });
+    canvasBus.editorSelectState.emit({ blockIndex: -1, proseIndex: 10, source: 'doc' });
     await el.updateComplete;
 
     expect(headers()[0].getAttribute('aria-expanded')).to.equal('true');
     expect(headers()[1].getAttribute('aria-expanded')).to.equal('false');
 
     // proseIndex 25, past section 1's only child with nothing after it, resolves there.
-    editorSelectChange.emit({ blockIndex: -1, proseIndex: 25, source: 'doc' });
+    canvasBus.editorSelectState.emit({ blockIndex: -1, proseIndex: 25, source: 'doc' });
     await el.updateComplete;
 
     expect(headers()[1].getAttribute('aria-expanded')).to.equal('true');
   });
 
   it('resets expansion only when a structural edit actually changes the sections', async () => {
-    // Drives _sections through the real editorHtmlChange/parseSections pipeline (rather
+    // Drives _sections through the real canvasBus.editorHtmlState/parseSections pipeline (rather
     // than the manual fixture in beforeEach) so re-emitting identical HTML is guaranteed
     // to parse to a sectionsEqual result.
     const initialHtml = `<main><div>
       <h2 data-prose-index="1">Title</h2>
       <p data-prose-index="5">Para one</p>
     </div></main>`;
-    editorHtmlChange.emit(initialHtml);
+    canvasBus.editorHtmlState.emit(initialHtml);
     await el.updateComplete;
 
     el.shadowRoot.querySelector('.content-item').click();
     await el.updateComplete;
     expect(el.shadowRoot.querySelector('.content-item').getAttribute('aria-expanded')).to.equal('true');
 
-    editorHtmlChange.emit(initialHtml);
+    canvasBus.editorHtmlState.emit(initialHtml);
     await el.updateComplete;
 
     // Same HTML reparses to an equal section tree — sectionsEqual holds, expansion survives.
@@ -260,7 +259,7 @@ describe('ew-page-outline — expandable default content', () => {
     const changedHtml = `<main><div>
       <h2 data-prose-index="1">Title</h2>
     </div></main>`;
-    editorHtmlChange.emit(changedHtml);
+    canvasBus.editorHtmlState.emit(changedHtml);
     await el.updateComplete;
 
     // Structural change (a child removed) — sectionsEqual fails, expansion resets.
@@ -330,7 +329,7 @@ describe('ew-page-outline — content drag & delete', () => {
       ],
     });
 
-    editorHtmlChange.emit(getInstrumentedHTML(bridge.view));
+    canvasBus.editorHtmlState.emit(getInstrumentedHTML(bridge.view));
     await el.updateComplete;
 
     el.shadowRoot.querySelector('.content-item').click();

--- a/test/unit/blocks/canvas/utils/canvas-bus.test.js
+++ b/test/unit/blocks/canvas/utils/canvas-bus.test.js
@@ -1,0 +1,87 @@
+import { expect } from '@esm-bundle/chai';
+
+let canvasBus;
+let registerEditorSelectEnricher;
+
+before(async () => {
+  const mod = await import('../../../../../blocks/canvas/utils/canvas-bus.js');
+  canvasBus = mod.canvasBus;
+  registerEditorSelectEnricher = mod.registerEditorSelectEnricher;
+});
+
+// editorProseSelectState stands in for any plain (non-replay, non-enriched) channel —
+// they're all built by the same factory, so this exercises that shared contract once
+// rather than repeating it per channel name.
+describe('canvasBus plain channel (emit/subscribe)', () => {
+  it('delivers an emitted value to a subscriber', () => {
+    let received;
+    const unsub = canvasBus.editorProseSelectState.subscribe((d) => { received = d; });
+    canvasBus.editorProseSelectState.emit({ proseIndex: 3, kind: 'paragraph' });
+    unsub();
+    expect(received).to.deep.equal({ proseIndex: 3, kind: 'paragraph' });
+  });
+
+  it('delivers to every independent subscriber', () => {
+    const receivedA = [];
+    const receivedB = [];
+    const unsubA = canvasBus.editorProseSelectState.subscribe((d) => receivedA.push(d));
+    const unsubB = canvasBus.editorProseSelectState.subscribe((d) => receivedB.push(d));
+    canvasBus.editorProseSelectState.emit({ proseIndex: 1, kind: 'heading' });
+    unsubA();
+    unsubB();
+    expect(receivedA).to.deep.equal([{ proseIndex: 1, kind: 'heading' }]);
+    expect(receivedB).to.deep.equal([{ proseIndex: 1, kind: 'heading' }]);
+  });
+
+  it('stops delivering once unsubscribed', () => {
+    let calls = 0;
+    const unsub = canvasBus.editorProseSelectState.subscribe(() => { calls += 1; });
+    canvasBus.editorProseSelectState.emit({ proseIndex: 1, kind: 'heading' });
+    unsub();
+    canvasBus.editorProseSelectState.emit({ proseIndex: 2, kind: 'paragraph' });
+    expect(calls).to.equal(1);
+  });
+
+  it('does not replay a past emission to a subscriber that joins later', () => {
+    canvasBus.undoState.emit({ canUndo: true, canRedo: false });
+    let received = 'not-called';
+    canvasBus.undoState.subscribe((d) => { received = d; });
+    expect(received).to.equal('not-called');
+  });
+});
+
+describe('canvasBus.editorHtmlState replay', () => {
+  it('replays the last emitted value to a subscriber that joins later', () => {
+    canvasBus.editorHtmlState.emit('<main>hello</main>');
+    let received;
+    canvasBus.editorHtmlState.subscribe((html) => { received = html; });
+    expect(received).to.equal('<main>hello</main>');
+  });
+
+  it('does not replay an empty string, since it is falsy — matches ew-editor-doc.js emitting \'\' to mean "no doc"', () => {
+    canvasBus.editorHtmlState.emit('');
+    let received = 'not-called';
+    canvasBus.editorHtmlState.subscribe((html) => { received = html; });
+    expect(received).to.equal('not-called');
+  });
+});
+
+describe('canvasBus.editorSelectState enrichment', () => {
+  it('passes details through unchanged until an enricher is registered, applies it once registered, and rejects a second registration', () => {
+    let received;
+    const unsub = canvasBus.editorSelectState.subscribe((d) => { received = d; });
+
+    canvasBus.editorSelectState.emit({ blockIndex: 1, source: 'doc' });
+    expect(received).to.deep.equal({ blockIndex: 1, source: 'doc' });
+
+    registerEditorSelectEnricher((detail) => ({ ...detail, blockName: 'hero' }));
+    canvasBus.editorSelectState.emit({ blockIndex: 1, source: 'doc' });
+    expect(received).to.deep.equal({ blockIndex: 1, source: 'doc', blockName: 'hero' });
+
+    expect(() => registerEditorSelectEnricher((d) => d)).to.throw();
+    canvasBus.editorSelectState.emit({ blockIndex: 2, source: 'outline' });
+    expect(received).to.deep.equal({ blockIndex: 2, source: 'outline', blockName: 'hero' });
+
+    unsub();
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Consolidates canvas's in-process events (undo, redo, editor view, selection, wysiwyg-port-ready) into one `canvasBus` pub/sub (`blocks/canvas/utils/canvas-bus.js`), replacing scattered `CustomEvent`/hand-rolled observables with a single, consistent API.

Handled separately:
- Communication to shared nx blocks ie panel/chat via https://github.com/adobe/da-live/pull/1170
- Communication over postmessage for quickedit via https://github.com/adobe/da-live/pull/1120

Separation intentional since intent and usage is different across cases as are the consumers.


## Related Issue

Fixes #1116 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
