### PR TITLE
fix(ew): add scroll buffer for selection toolbar in canvas

### DIFF
--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.css
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.css
@@ -27,7 +27,7 @@
   background: light-dark(#fff, var(--s2-gray-75, #2c2c2c));
   color: light-dark(#222, var(--s2-gray-900, #f5f5f5));
   position: relative;
-  padding: 1rem;
+  padding: 1rem 1rem 130px;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary                                                                   
  - Add bottom padding to the canvas editor doc sized to the selection toolbar's worst case (bottom offset + up to two wrapped button rows + margin), so it never covers the last block when scrolled to the end of the doc.                                                                         
                                                                               
 - Fixes #1143                                                                  
                                                                               
  ## Test plan                                                                 
  - [ ] Scroll to the end of a long doc and confirm the last block is fully visible above the selection toolbar                                          
  - [ ] Select text near the end of the doc and confirm the toolbar (including wrapped rows) doesn't overlap content          