### PR TITLE
fix: hide chat on browse if disabled

### DIFF
--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -24,6 +24,7 @@ export default class DaBrowse extends LitElement {
     details: { attribute: false },
     _tabItems: { state: true },
     _searchItems: { state: true },
+    _ewEnabled: { state: true },
     _chatEnabled: { state: true },
   };
 
@@ -124,8 +125,13 @@ export default class DaBrowse extends LitElement {
       // and do this before getEditor so the default editor reflects EW state
       if (orgChanged || prevDetails?.site !== this.details.site) {
         const { org, site } = this.details;
-        const { isEWEnabled } = await getNxEWFlags();
-        this._chatEnabled = await isEWEnabled({ org, site });
+        const { isEWEnabled, isEwChatDisabled } = await getNxEWFlags();
+        const [ewEnabled, chatDisabled] = await Promise.all([
+          isEWEnabled({ org, site }),
+          isEwChatDisabled({ org, site }),
+        ]);
+        this._ewEnabled = ewEnabled;
+        this._chatEnabled = ewEnabled && !chatDisabled;
         if (this._chatEnabled) {
           registerPanelSection('chat', {
             position: 'before',
@@ -144,7 +150,7 @@ export default class DaBrowse extends LitElement {
   }
 
   async getEditor(reFetch) {
-    const DEF_EDIT = this._chatEnabled ? '/canvas#' : '/edit#';
+    const DEF_EDIT = this._ewEnabled ? '/canvas#' : '/edit#';
 
     if (reFetch) {
       const { org, site } = this.details;

--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -19,6 +19,10 @@ function openChatPanel() {
   document.dispatchEvent(new CustomEvent(PANEL_EVENT.OPEN, { detail: { section: 'chat' } }));
 }
 
+function closeChatPanel() {
+  document.dispatchEvent(new CustomEvent(PANEL_EVENT.CLOSE, { detail: { section: 'chat' } }));
+}
+
 export default class DaBrowse extends LitElement {
   static properties = {
     details: { attribute: false },
@@ -139,6 +143,8 @@ export default class DaBrowse extends LitElement {
             getContent: getChatPanelContent(),
           });
           if (wasPanelOpen('chat')) openChatPanel();
+        } else {
+          closeChatPanel();
         }
       }
 

--- a/test/e2e/tests/authenticated/ew_browse.spec.js
+++ b/test/e2e/tests/authenticated/ew_browse.spec.js
@@ -7,9 +7,14 @@ import { getQuery } from '../../utils/page.js';
  *   path                    groups                      actions
  *   /ewtest/+**             907136ED5D35CBF50A495CD4    read
  * And a document at /da-testautomation/ewtest/demo with EW enabled on the site.
+ *
+ * The disableChat case additionally requires a site with EW enabled and
+ * `ew.disableChat` set to `true` at /da-testautomation/ewtest-nochat, with a
+ * document at /da-testautomation/ewtest-nochat/demo.
  */
 
 const EW_SITE = `${ENV}/${getQuery()}#/da-testautomation/ewtest`;
+const EW_SITE_NO_CHAT = `${ENV}/${getQuery()}#/da-testautomation/ewtest-nochat`;
 const NON_EW_SITE = `${ENV}/${getQuery()}#/da-testautomation/acltest/testdocs/subdir`;
 
 test('Chat button is visible on EW-enabled site', async ({ page }) => {
@@ -27,4 +32,15 @@ test('Chat button is absent on non-EW site', async ({ page }) => {
   // Wait for the list to render before asserting absence
   await expect(page.locator('da-list-item').first()).toBeVisible();
   await expect(page.locator('button.chat-btn')).toHaveCount(0);
+});
+
+test('Chat button is absent when ew.disableChat is set, even with EW enabled', async ({ page }) => {
+  await page.goto(EW_SITE_NO_CHAT);
+  await expect(page.locator('da-list-item').first()).toBeVisible();
+  await expect(page.locator('button.chat-btn')).toHaveCount(0);
+});
+
+test('Document links still use canvas editor when chat is disabled', async ({ page }) => {
+  await page.goto(EW_SITE_NO_CHAT);
+  await expect(page.locator('a[href="/canvas#/da-testautomation/ewtest-nochat/demo"]')).toBeVisible();
 });

--- a/test/unit/blocks/browse/da-browse/da-browse.test.js
+++ b/test/unit/blocks/browse/da-browse/da-browse.test.js
@@ -563,7 +563,7 @@ describe('DaBrowse Component', () => {
     });
 
     it('Returns /canvas# as default when EW is enabled and no explicit config', async () => {
-      daBrowseComp._chatEnabled = true;
+      daBrowseComp._ewEnabled = true;
       window.fetch = () => Promise.resolve(
         new Response(JSON.stringify({ data: [] }), { status: 200 }),
       );
@@ -572,8 +572,19 @@ describe('DaBrowse Component', () => {
       expect(editor).to.equal('/canvas#');
     });
 
+    it('Returns /canvas# default even when chat is disabled, since EW alone drives the editor', async () => {
+      daBrowseComp._ewEnabled = true;
+      daBrowseComp._chatEnabled = false;
+      window.fetch = () => Promise.resolve(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      );
+      daBrowseComp.details = { owner: 'canvas-org3', org: 'canvas-org3', site: 'canvas-site3', fullpath: '/canvas-org3/canvas-site3/folder' };
+      const editor = await daBrowseComp.getEditor(true);
+      expect(editor).to.equal('/canvas#');
+    });
+
     it('Explicit editor.path config takes precedence over EW canvas default', async () => {
-      daBrowseComp._chatEnabled = true;
+      daBrowseComp._ewEnabled = true;
       const body = JSON.stringify({ data: [{ key: 'editor.path', value: '/canvas-org2/canvas-site2=https://custom-editor' }] });
       window.fetch = () => Promise.resolve(new Response(body, { status: 200 }));
       daBrowseComp.details = { owner: 'canvas-org2', org: 'canvas-org2', site: 'canvas-site2', fullpath: '/canvas-org2/canvas-site2/page' };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Chat should also be disabled on browse if `ew.disableChat` is true

- Ew enabled with chat: https://ewbchat--da-live--adobe.aem.live/#/da-testautomation/ewtest
- Ew enabled without chat: https://ewbchat--da-live--adobe.aem.live/#/da-testautomation/ewtest-nochat
- No ew enabled: https://ewbchat--da-live--adobe.aem.live/#/da-testautomation

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
