### PR TITLE
fix(ew): don't surface library metadata in outline panel

### DIFF
--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -198,7 +198,8 @@ export function getInstrumentedHTML(view) {
     const firstRow = table.querySelector('tr');
     const firstCellText = firstRow?.cells?.[0]?.textContent?.trim().toLowerCase();
     const isPageOrSectionMetadata = firstCellText === 'metadata' || firstCellText === 'section metadata' || firstCellText === 'section-metadata';
-    if (isPageOrSectionMetadata) return;
+    const isLibraryMetadata = firstCellText === 'library metadata' || firstCellText === 'library-metadata';
+    if (isPageOrSectionMetadata || isLibraryMetadata) return;
     const div = table.parentElement;
     const blockMarker = document.createElement('div');
     blockMarker.className = 'block-marker';
@@ -256,7 +257,7 @@ export function getInstrumentedHTML(view) {
   return htmlString;
 }
 
-const SKIP_BLOCK_CLASSES = new Set(['default-content-wrapper', 'metadata', 'block-marker']);
+const SKIP_BLOCK_CLASSES = new Set(['default-content-wrapper', 'metadata', 'section-metadata', 'library-metadata', 'block-marker']);
 
 function hasDefaultContent(el) {
   if (el.textContent?.trim()) return true;


### PR DESCRIPTION
When editing block library pages, Library metadata is surfaced as a block in the outline panel. Remove it like others (metadata, section-metadata).

BEFORE
<img width="408" height="489" alt="image" src="https://github.com/user-attachments/assets/c5df537c-b62c-4b34-9db4-e0788fdae564" />

AFTER
<img width="413" height="686" alt="image" src="https://github.com/user-attachments/assets/7b005e6a-7a8c-448f-9f99-38836bfd94b0" />
