### PR TITLE
fix: add WYSIWYG branch support via query parameter

### DIFF
--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -410,7 +410,7 @@ export function getPreviewOrigin(org, repo, branch = 'main') {
 
 export async function fetchWysiwygBranch({ org, site, path }) {
   if (!org || !site) return 'main';
-  const branchParam = new URLSearchParams(window.location.search).get('branch');
+  const branchParam = new URLSearchParams(window.location.search).get('ref');
   if (branchParam) return branchParam;
 
   try {

--- a/blocks/canvas/editor-utils/editor-utils.js
+++ b/blocks/canvas/editor-utils/editor-utils.js
@@ -410,6 +410,9 @@ export function getPreviewOrigin(org, repo, branch = 'main') {
 
 export async function fetchWysiwygBranch({ org, site, path }) {
   if (!org || !site) return 'main';
+  const branchParam = new URLSearchParams(window.location.search).get('branch');
+  if (branchParam) return branchParam;
+
   try {
     const configs = await Promise.all(fetchDaConfigs({ org, site }));
     const rows = configs.filter(Boolean).reverse().flatMap((c) => getFirstSheet(c) || []);

--- a/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
+++ b/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
@@ -33,15 +33,24 @@ describe('getPreviewOrigin', () => {
 
 describe('fetchWysiwygBranch', () => {
   let savedFetch;
+  let savedSearch;
   let testIndex = 0;
+
+  function setSearch(search) {
+    const url = new URL(window.location.href);
+    url.search = search;
+    window.history.replaceState(null, '', url);
+  }
 
   beforeEach(() => {
     savedFetch = window.fetch;
+    savedSearch = window.location.search;
     testIndex += 1;
   });
 
   afterEach(() => {
     window.fetch = savedFetch;
+    setSearch(savedSearch);
   });
 
   function ctx(extra = {}) {
@@ -119,6 +128,31 @@ describe('fetchWysiwygBranch', () => {
     ]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-10/site-wbr-10/page' }));
     expect(branch).to.equal('valid');
+  });
+
+  it('uses the branch query param when present, skipping config lookup', async () => {
+    setSearch('?branch=from-query');
+    let fetchCalled = false;
+    window.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+    };
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-11/site-wbr-11/page' }));
+    expect(branch).to.equal('from-query');
+    expect(fetchCalled).to.equal(false);
+  });
+
+  it('uses the branch query param even when org/site are missing', async () => {
+    setSearch('?branch=from-query');
+    const branch = await fetchWysiwygBranch({});
+    expect(branch).to.equal('from-query');
+  });
+
+  it('falls back to config when the branch query param is empty', async () => {
+    setSearch('?branch=');
+    mockConfig([{ key: 'ew.wysiwygBranch', value: '/org-wbr-12/site-wbr-12=feature' }]);
+    const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-12/site-wbr-12/page' }));
+    expect(branch).to.equal('feature');
   });
 });
 

--- a/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
+++ b/test/unit/blocks/canvas/editor-utils/editor-utils.test.js
@@ -130,8 +130,8 @@ describe('fetchWysiwygBranch', () => {
     expect(branch).to.equal('valid');
   });
 
-  it('uses the branch query param when present, skipping config lookup', async () => {
-    setSearch('?branch=from-query');
+  it('uses the ref query param when present, skipping config lookup', async () => {
+    setSearch('?ref=from-query');
     let fetchCalled = false;
     window.fetch = () => {
       fetchCalled = true;
@@ -142,14 +142,8 @@ describe('fetchWysiwygBranch', () => {
     expect(fetchCalled).to.equal(false);
   });
 
-  it('uses the branch query param even when org/site are missing', async () => {
-    setSearch('?branch=from-query');
-    const branch = await fetchWysiwygBranch({});
-    expect(branch).to.equal('from-query');
-  });
-
-  it('falls back to config when the branch query param is empty', async () => {
-    setSearch('?branch=');
+  it('falls back to config when the ref query param is empty', async () => {
+    setSearch('?ref=');
     mockConfig([{ key: 'ew.wysiwygBranch', value: '/org-wbr-12/site-wbr-12=feature' }]);
     const branch = await fetchWysiwygBranch(ctx({ path: 'org-wbr-12/site-wbr-12/page' }));
     expect(branch).to.equal('feature');


### PR DESCRIPTION
## Description

Using a project branch like `?ref=testing` will load the WYSIWYG using that branch.

fixes #1235 

Url:
- https://da.live/canvas?ref=testing#/exp-workspace/frescopa/coffee

