### PR TITLE
fix: stop appending .html to config paths

### DIFF
--- a/blocks/shared/pathDetails.js
+++ b/blocks/shared/pathDetails.js
@@ -91,7 +91,9 @@ function getFullDetails({ editor, pathParts, ext }) {
 function getExtension(editor, name, isFolder) {
   const nameSplit = name.split('.');
   if (nameSplit.length >= 2) return nameSplit.pop();
-  if (isFolder || editor === 'browse') return null;
+  // a config path names an org or a site, not a document, and admin.da.live answers
+  // /config/{org}/{site}.html with a 404
+  if (isFolder || editor === 'browse' || editor === 'config') return null;
   if (editor === 'sheet' && nameSplit.slice(-1)[0] !== 'json') return 'json';
   return 'html';
 }

--- a/blocks/shared/pathDetails.js
+++ b/blocks/shared/pathDetails.js
@@ -91,8 +91,6 @@ function getFullDetails({ editor, pathParts, ext }) {
 function getExtension(editor, name, isFolder) {
   const nameSplit = name.split('.');
   if (nameSplit.length >= 2) return nameSplit.pop();
-  // a config path names an org or a site, not a document, and admin.da.live answers
-  // /config/{org}/{site}.html with a 404
   if (isFolder || editor === 'browse' || editor === 'config') return null;
   if (editor === 'sheet' && nameSplit.slice(-1)[0] !== 'json') return 'json';
   return 'html';

--- a/test/unit/blocks/shared/pathDetails.test.js
+++ b/test/unit/blocks/shared/pathDetails.test.js
@@ -84,11 +84,14 @@ describe('Path details', () => {
         expect(details.parentName).to.equal('Root');
       });
 
-      it('Handles HTML config ()', () => {
+      // a config path names a config, not a document, so it gets no extension. the slashed and
+      // slashless forms have to agree: only the slash was hiding the .html
+      it('Handles config without a trailing slash ()', () => {
         const loc = { pathname: '/config', hash: '#/adobe' };
         const details = getPathDetails(loc);
-        expect(details.fullpath).to.equal('/adobe.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe.html');
+        expect(details.fullpath).to.equal('/adobe');
+        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe');
+        expect(details.name).to.equal('config');
       });
     });
 
@@ -143,11 +146,13 @@ describe('Path details', () => {
         expect(details.parentName).to.equal('adobe');
       });
 
-      it('Handles HTML config ()', () => {
+      // admin.da.live answers /config/{org}/{site}.html with a 404, so the .html was never right
+      it('Handles config without a trailing slash ()', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx' };
         const details = getPathDetails(loc);
-        expect(details.fullpath).to.equal('/adobe/geometrixx.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx.html');
+        expect(details.fullpath).to.equal('/adobe/geometrixx');
+        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx');
+        expect(details.name).to.equal('geometrixx config');
       });
     });
 
@@ -192,11 +197,11 @@ describe('Path details', () => {
         expect(details.parentName).to.equal('geometrixx');
       });
 
-      it('Handles HTML config ()', () => {
+      it('Handles config without a trailing slash ()', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx/testing-123' };
         const details = getPathDetails(loc);
-        expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123.html');
-        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx/testing-123.html');
+        expect(details.fullpath).to.equal('/adobe/geometrixx/testing-123');
+        expect(details.sourceUrl).to.equal('https://admin.da.live/config/adobe/geometrixx/testing-123');
       });
     });
 

--- a/test/unit/blocks/shared/pathDetails.test.js
+++ b/test/unit/blocks/shared/pathDetails.test.js
@@ -84,8 +84,6 @@ describe('Path details', () => {
         expect(details.parentName).to.equal('Root');
       });
 
-      // a config path names a config, not a document, so it gets no extension. the slashed and
-      // slashless forms have to agree: only the slash was hiding the .html
       it('Handles config without a trailing slash ()', () => {
         const loc = { pathname: '/config', hash: '#/adobe' };
         const details = getPathDetails(loc);
@@ -146,7 +144,6 @@ describe('Path details', () => {
         expect(details.parentName).to.equal('adobe');
       });
 
-      // admin.da.live answers /config/{org}/{site}.html with a 404, so the .html was never right
       it('Handles config without a trailing slash ()', () => {
         const loc = { pathname: '/config', hash: '#/adobe/geometrixx' };
         const details = getPathDetails(loc);


### PR DESCRIPTION
`/config#/{org}/{site}` sent `/config/{org}/{site}.html` on save. That 404s, and it made nx2 probe `/ping/{org}/{site}.html`, which fails CORS.

`getExtension` had no branch for the config view, so a config path fell through to the document default and gained a `.html`. A trailing slash hid it: `/config#/{org}/{site}/` short-circuits the extension, `/config#/{org}/{site}` does not.

Three tests asserted the broken URL. The trailing-slash tests beside them already expected no extension, so the two forms disagreed.

## Testing

1805 unit tests pass, 1804 before. Reverting the one line fails exactly those three.

Against the served module, both config forms now give `https://admin.da.live/config/{org}/{site}`. `/config#/{org}/{site}.json` keeps its extension. Edit and sheet are unchanged: `/edit#/{org}/{site}/index` still gives `index.html`, `/sheet#/{org}/{site}/data` still gives `data.json`.

Not verified: a save against a live config sheet, which needs a signed-in local session.
