### PR TITLE
chore(e2e): pin nx to the playwfix branch

### DIFF
--- a/test/e2e/utils/page.js
+++ b/test/e2e/utils/page.js
@@ -19,7 +19,7 @@ export function getQuery() {
   if (branch === 'local' || branch === 'local-https') {
     return '?da-admin=local&da-collab=local';
   }
-  return '';
+  return '?nx=playwfix';
 }
 
 const QUERY = getQuery();


### PR DESCRIPTION

points the e2e suite at `playwfix--da-nx`, the branch that fixes the hlx6 permissions drop. the Helix job then runs against the fix.

do not merge. the fix belongs in adobe/da-nx and this branch only exists to watch that job.
