### PR TITLE
fix(ew): inject ref, search & hash into iframe context for extensions

### DIFF
--- a/blocks/canvas/ew-panel-extensions/iframe-protocol.js
+++ b/blocks/canvas/ew-panel-extensions/iframe-protocol.js
@@ -78,12 +78,14 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
     }
   };
 
+  const ref = new URLSearchParams(window.location.search).get('ref') || 'main';
   const project = {
     org,
     repo: site,
-    ref: 'main',
+    ref,
     path: path ? `/${path}` : '/',
     view: view || 'edit',
+    hash: window.location.hash,
   };
 
   let token;

--- a/test/unit/blocks/canvas/ew-panel-extensions/iframe-protocol.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/iframe-protocol.test.js
@@ -1,0 +1,244 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setNx, getNx } from '../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { setupIframeChannel } = await import('../../../../../blocks/canvas/ew-panel-extensions/iframe-protocol.js');
+const { CHAT_EVENT } = await import(`${getNx()}/blocks/chat/constants.js`);
+const { PANEL_EVENT } = await import(`${getNx()}/utils/panel.js`);
+
+const wait = (ms = 50) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+function makeIframe(src = 'https://plugin.example.com/app') {
+  return { src, contentWindow: { postMessage: sinon.spy() } };
+}
+
+function setUrl(url) {
+  window.history.replaceState(null, '', url);
+}
+
+describe('setupIframeChannel', () => {
+  let originalUrl;
+
+  beforeEach(() => {
+    originalUrl = window.location.href;
+  });
+
+  afterEach(() => {
+    setUrl(originalUrl);
+  });
+
+  it('is a no-op when org is missing from hashState', async () => {
+    const iframe = makeIframe();
+    const result = await setupIframeChannel({
+      iframe,
+      hashState: { site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    expect(result.channel).to.equal(null);
+    expect(iframe.contentWindow.postMessage.called).to.be.false;
+  });
+
+  it('is a no-op when the iframe has no contentWindow', async () => {
+    const result = await setupIframeChannel({
+      iframe: { contentWindow: null },
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    expect(result.channel).to.equal(null);
+  });
+
+  it('posts a ready message with project details derived from hashState and the URL', async () => {
+    setUrl('/some/page?ref=feature123#/myorg/mysite/a/b');
+
+    const iframe = makeIframe();
+    const { destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite', path: 'a/b', view: 'split' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    await wait(800);
+
+    expect(iframe.contentWindow.postMessage.calledOnce).to.be.true;
+    const [message, targetOrigin, transfer] = iframe.contentWindow.postMessage.firstCall.args;
+
+    expect(message.ready).to.be.true;
+    expect(message.project).to.deep.equal({
+      org: 'myorg',
+      repo: 'mysite',
+      ref: 'feature123',
+      path: '/a/b',
+      view: 'split',
+      hash: '#/myorg/mysite/a/b',
+    });
+    expect(message.context).to.equal(message.project);
+    expect(targetOrigin).to.equal('https://plugin.example.com');
+    expect(transfer).to.have.lengthOf(1);
+
+    destroy();
+  });
+
+  it('defaults ref to main, path to / and view to edit when not provided', async () => {
+    setUrl('/some/page');
+
+    const iframe = makeIframe();
+    const { destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    await wait(800);
+
+    const [message] = iframe.contentWindow.postMessage.firstCall.args;
+    expect(message.project.ref).to.equal('main');
+    expect(message.project.path).to.equal('/');
+    expect(message.project.view).to.equal('edit');
+
+    destroy();
+  });
+
+  it('calls onClose for a closeLibrary action', async () => {
+    const iframe = makeIframe();
+    const onClose = sinon.spy();
+    const { channel, destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose,
+    });
+
+    channel.port2.postMessage({ action: 'closeLibrary' });
+    await wait();
+
+    expect(onClose.calledOnce).to.be.true;
+    destroy();
+  });
+
+  it('opens the tools panel for a showPanel action', async () => {
+    const iframe = makeIframe();
+    const { channel, destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    let received;
+    const onPanelOpen = (e) => { received = e.detail; };
+    document.addEventListener(PANEL_EVENT.OPEN, onPanelOpen);
+
+    channel.port2.postMessage({ action: 'showPanel', details: 'my-tool' });
+    await wait();
+
+    document.removeEventListener(PANEL_EVENT.OPEN, onPanelOpen);
+    expect(received).to.deep.equal({ section: 'tools', id: 'my-tool' });
+    destroy();
+  });
+
+  it('opens the chat panel with autoSend for an object-form setPrompt action', async () => {
+    const iframe = makeIframe();
+    const { channel, destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    let received;
+    const onPanelOpen = (e) => { received = e.detail; };
+    document.addEventListener(PANEL_EVENT.OPEN, onPanelOpen);
+
+    channel.port2.postMessage({ action: 'setPrompt', details: { text: 'hello', autoSend: true } });
+    await wait();
+
+    document.removeEventListener(PANEL_EVENT.OPEN, onPanelOpen);
+    expect(received).to.deep.equal({ section: 'chat', options: { text: 'hello', autoSend: true } });
+    destroy();
+  });
+
+  it('opens the chat panel without autoSend for a string-form setPrompt action', async () => {
+    const iframe = makeIframe();
+    const { channel, destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    let received;
+    const onPanelOpen = (e) => { received = e.detail; };
+    document.addEventListener(PANEL_EVENT.OPEN, onPanelOpen);
+
+    channel.port2.postMessage({ action: 'setPrompt', details: 'hello' });
+    await wait();
+
+    document.removeEventListener(PANEL_EVENT.OPEN, onPanelOpen);
+    expect(received).to.deep.equal({ section: 'chat', options: { text: 'hello', autoSend: false } });
+    destroy();
+  });
+
+  it('replies with an error over the channel when getSelection has no editor view', async () => {
+    const iframe = makeIframe();
+    const { channel, destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    const reply = new Promise((resolve) => {
+      channel.port2.onmessage = (e) => resolve(e.data);
+    });
+
+    channel.port2.postMessage({ action: 'getSelection' });
+    const data = await reply;
+
+    expect(data).to.deep.equal({ action: 'error', details: 'No editor view' });
+    destroy();
+  });
+
+  it('forwards agentChange events from the document to the iframe', async () => {
+    const iframe = makeIframe();
+    const { destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    document.dispatchEvent(new CustomEvent(CHAT_EVENT.AGENT_CHANGE, { detail: { agent: 'writer' } }));
+
+    expect(iframe.contentWindow.postMessage.calledWith(
+      { action: 'agentChange', detail: { agent: 'writer' } },
+      'https://plugin.example.com',
+    )).to.be.true;
+
+    destroy();
+  });
+
+  it('stops forwarding agentChange events after destroy', async () => {
+    const iframe = makeIframe();
+    const { destroy } = await setupIframeChannel({
+      iframe,
+      hashState: { org: 'myorg', site: 'mysite' },
+      getView: () => null,
+      onClose: () => {},
+    });
+
+    destroy();
+    iframe.contentWindow.postMessage.resetHistory();
+
+    document.dispatchEvent(new CustomEvent(CHAT_EVENT.AGENT_CHANGE, { detail: { agent: 'writer' } }));
+
+    expect(iframe.contentWindow.postMessage.called).to.be.false;
+  });
+});


### PR DESCRIPTION
... and add tests for iframe-protocol.js

This is needed to allow extensions access to current query parameters and hash, like for the developer extension I'm currently building, which needs the query parameter. 

URL:
- https://ctx--da-live--adobe.aem.live