### PR TITLE
test: move e2e cleanup to scheduled 6h workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,48 @@
+name: Cleanup stale test resources
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: da-admin
+            env: {}
+          - name: helix
+            env:
+              TEST_ORG: da-testautomation
+              TEST_SITE: da-e2e-tests
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: cd test/e2e && npm ci
+    - name: Install Playwright Browsers
+      run: cd test/e2e && npx playwright install --with-deps chromium
+    - name: Run stale-resource cleanup
+      env:
+        TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+        TEST_ORG: ${{ matrix.env.TEST_ORG }}
+        TEST_SITE: ${{ matrix.env.TEST_SITE }}
+      run: cd test/e2e && npm run test:cleanup
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: cleanup-report-${{ matrix.name }}
+        path: test/e2e/playwright-report/
+        retention-days: 7

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -2,10 +2,11 @@
   "name": "da-live_e2e_test",
   "version": "1.0.0",
   "scripts": {
-    "test": "playwright test --project=chromium",
+    "test": "playwright test --project=chromium --grep-invert \"Delete multiple old pages\"",
     "test:install": "playwright install",
-    "test:all": "playwright test --project=chromium --project=firefox --project=webkit",
-    "test:nonauth": "SKIP_AUTH=true playwright test --project=chromium tests/*.spec.js",
+    "test:all": "playwright test --project=chromium --project=firefox --project=webkit --grep-invert \"Delete multiple old pages\"",
+    "test:nonauth": "SKIP_AUTH=true playwright test --project=chromium tests/*.spec.js --grep-invert \"Delete multiple old pages\"",
+    "test:cleanup": "playwright test --project=chromium tests/delete.spec.js --grep \"Delete multiple old pages\"",
     "test:ui": "playwright test --project=chromium --ui",
     "test:debug": "playwright test --project=chromium --debug",
     "test:report": "playwright show-report"

--- a/test/e2e/tests/authenticated/acl_browse.spec.js
+++ b/test/e2e/tests/authenticated/acl_browse.spec.js
@@ -35,11 +35,10 @@ test('Read-only directory', async ({ page }) => {
   await expect(page.locator('button.delete-button').filter({ visible: true })).toHaveCount(0);
 });
 
-test('Read-write directory', async ({ browser, page, trackCleanup }, workerInfo) => {
+test('Read-write directory', async ({ browser, page }, workerInfo) => {
   test.skip(TEST_SITE !== 'da-status', 'ACLs are not yet supported for Helix 6');
   test.setTimeout(60000);
   const pageURL = getTestPageURL('acl-browse-edt', workerInfo, '/da-testautomation/acltest/testdocs/subdir/subdir1');
-  trackCleanup(pageURL);
   const pageName = pageURL.split('/').pop();
   const browseURL = pageURL.replace(`/${pageName}`, '').replace('/edit#/', '/#/');
 

--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -40,7 +40,7 @@ async function waitForRemoteCursor(watcherPage, sourcePage) {
   }
 }
 
-test('Collab cursors in multiple editors', async ({ browser, page, browserName, trackCleanup }, workerInfo) => {
+test('Collab cursors in multiple editors', async ({ browser, page, browserName }, workerInfo) => {
   // Open 2 editors on the same page and edit in both of them.
   // Ensure that the edits are visible to both and that the collab cursors are there
   // Also check that the cloud icon is visible for the collaborator
@@ -48,7 +48,6 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName, 
   test.setTimeout(60000);
 
   const pageURL = getTestPageURL('collab', workerInfo);
-  trackCleanup(pageURL);
 
   // Capture the Bearer token that da-live's daFetch attaches to its backend
   // requests, so we can reuse the exact same Authorization header below.

--- a/test/e2e/tests/copy_rename.spec.js
+++ b/test/e2e/tests/copy_rename.spec.js
@@ -16,7 +16,7 @@ import {
 } from '../utils/page.js';
 import { dismissAlertBanner } from '../utils/utils.js';
 
-test('Copy and Rename with Versioned document', async ({ page, trackCleanup }, workerInfo) => {
+test('Copy and Rename with Versioned document', async ({ page }, workerInfo) => {
   test.skip(
     TEST_SITE !== 'da-status',
     `
@@ -31,8 +31,6 @@ const link = await page.getByRole('link', { name: orgPageName });
 
   const pageURL = getTestPageURL('copyrename', workerInfo);
   const orgPageName = pageURL.split('/').pop();
-  // Safety net for a failure before the rename below actually happens.
-  trackCleanup(pageURL);
   await page.goto(pageURL);
   await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();
@@ -68,7 +66,6 @@ const link = await page.getByRole('link', { name: orgPageName });
 
   const copyFolderURL = getTestFolderURL('copy', workerInfo);
   const copyFolderName = copyFolderURL.split('/').pop();
-  trackCleanup(copyFolderURL, { isFolder: true });
   await expect(page.getByRole('button', { name: 'New' })).toBeEnabled();
   await page.getByRole('button', { name: 'New' }).click({ force: true });
   await page.getByRole('menuitem', { name: 'Folder' }).click();
@@ -108,8 +105,6 @@ const link = await page.getByRole('link', { name: orgPageName });
   await page.getByRole('button', { name: 'Rename' }).click();
   await page.locator(`input[value=${orgPageName}]`).fill(renPageName);
   await page.keyboard.press('Enter');
-  // The document now lives under its renamed path instead of pageURL.
-  trackCleanup(`${pageURL}ren`);
 
   // Open the renamed page
   await page.waitForTimeout(3000);

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -53,14 +53,11 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   console.log('Deleted', stale.length, 'test files');
 });
 
-test('Empty out open editors on deleted documents', async ({ browser, page, trackCleanup }, workerInfo) => {
+test('Empty out open editors on deleted documents', async ({ browser, page }, workerInfo) => {
   test.skip(TEST_SITE !== 'da-status', 'Empty out open editors on deleted documents doesn\'t work yet in Helix 6');
   test.setTimeout(60000);
 
   const url = getTestPageURL('delete', workerInfo);
-  // Safety net: this test deletes the document via the UI already, but track it
-  // too in case that assertion fails partway through.
-  trackCleanup(url);
   const pageName = url.split('/').pop();
 
   await page.goto(url);

--- a/test/e2e/tests/edit.spec.js
+++ b/test/e2e/tests/edit.spec.js
@@ -16,11 +16,10 @@ import {
 } from '../utils/page.js';
 import { dismissAlertBanner } from '../utils/utils.js';
 
-test('Update Document', async ({ browser, page, trackCleanup }, workerInfo) => {
+test('Update Document', async ({ browser, page }, workerInfo) => {
   test.setTimeout(30000);
 
   const url = getTestPageURL('edit1', workerInfo);
-  trackCleanup(url);
   await page.goto(url);
   await page.waitForTimeout(2000);
   await page.getByText('Create document', { exact: true }).click();
@@ -41,13 +40,10 @@ test('Update Document', async ({ browser, page, trackCleanup }, workerInfo) => {
   await expect(newPage.locator('div.ProseMirror')).toContainText(enteredText);
 });
 
-test('Create Delete Document', async ({ browser, page, trackCleanup }, workerInfo) => {
+test('Create Delete Document', async ({ browser, page }, workerInfo) => {
   test.setTimeout(30000);
 
   const url = getTestPageURL('edit2', workerInfo);
-  // Safety net: the test below deletes this via the UI already, but track it too
-  // in case that assertion fails partway through.
-  trackCleanup(url);
   const pageName = url.split('/').pop();
 
   await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);
@@ -87,14 +83,12 @@ test('Create Delete Document', async ({ browser, page, trackCleanup }, workerInf
   await expect(newPage.locator(`a[href="/edit#/${TEST_ORG}/${TEST_SITE}/tests/${pageName}"]`)).not.toBeVisible();
 });
 
-test('Change document by switching anchors', async ({ page, trackCleanup }, workerInfo) => {
+test('Change document by switching anchors', async ({ page }, workerInfo) => {
   test.setTimeout(60000);
 
   const url = getTestPageURL('edit3', workerInfo);
   const urlA = `${url}A`;
   const urlB = `${url}B`;
-  trackCleanup(urlA);
-  trackCleanup(urlB);
 
   await page.goto(urlA);
   await page.getByText('Create document', { exact: true }).click();
@@ -179,10 +173,9 @@ async function pressKeyUntil(page, key, times, check) {
   throw new Error(`Cursor didn't land as expected after ${times} "${key}" presses: ${JSON.stringify(last)}`);
 }
 
-test('Add code mark', async ({ page, trackCleanup }, workerInfo) => {
+test('Add code mark', async ({ page }, workerInfo) => {
   test.setTimeout(30000);
   const url = getTestPageURL('edit5', workerInfo);
-  trackCleanup(url);
   await page.goto(url);
   await page.getByText('Create document', { exact: true }).click();
   const proseMirror = page.locator('div.ProseMirror');

--- a/test/e2e/tests/formatting.spec.js
+++ b/test/e2e/tests/formatting.spec.js
@@ -65,11 +65,10 @@ async function selectRange(page, from, to) {
   }, { from, to });
 }
 
-test('Text formatting and links persist after reload', async ({ page, trackCleanup }, workerInfo) => {
+test('Text formatting and links persist after reload', async ({ page }, workerInfo) => {
   test.setTimeout(60000);
 
   const url = getTestPageURL('formatting', workerInfo);
-  trackCleanup(url);
   console.log(url);
   await page.goto(url);
   await page.getByText('Create document', { exact: true }).click();

--- a/test/e2e/tests/preview_publish.spec.js
+++ b/test/e2e/tests/preview_publish.spec.js
@@ -86,11 +86,10 @@ test('Clicking Preview opens a confirmation dialog', async ({ page }) => {
   await expect(page.locator('da-dialog')).toContainText('Preview the');
 });
 
-test('Preview the selected page', async ({ page, context, trackCleanup }, workerInfo) => {
+test('Preview the selected page', async ({ page, context }, workerInfo) => {
   test.setTimeout(60000);
 
   const url = getTestPageURL('preview', workerInfo);
-  trackCleanup(url);
   const pageName = url.split('/').pop();
   await createDocument(page, url);
 
@@ -127,11 +126,10 @@ test('Preview the selected page', async ({ page, context, trackCleanup }, worker
   await previewTab.close();
 });
 
-test('Publish the selected page', async ({ page, context, trackCleanup }, workerInfo) => {
+test('Publish the selected page', async ({ page, context }, workerInfo) => {
   test.setTimeout(60000);
 
   const url = getTestPageURL('publish', workerInfo);
-  trackCleanup(url);
   const pageName = url.split('/').pop();
   await createDocument(page, url);
 

--- a/test/e2e/tests/regionaledits.spec.js
+++ b/test/e2e/tests/regionaledits.spec.js
@@ -28,11 +28,10 @@ const sendUndo = async (page) => {
   await expect(page.locator('div.diff-tabbed-actions.loc-floating-overlay')).toBeVisible();
 };
 
-test('Regional Edit Document', async ({ page, context, trackCleanup }, workerInfo) => {
+test('Regional Edit Document', async ({ page, context }, workerInfo) => {
   test.setTimeout(30000);
 
   const folderURL = getTestFolderURL('regionaledit', workerInfo);
-  trackCleanup(folderURL, { isFolder: true });
 
   /* */ // Added this to make it work in Helix 6
   await page.goto(`${ENV}/${getQuery()}#/${TEST_ORG}/${TEST_SITE}/tests`);

--- a/test/e2e/tests/sheet.spec.js
+++ b/test/e2e/tests/sheet.spec.js
@@ -1,11 +1,10 @@
 import { test, expect } from '../utils/fixtures.js';
 import { getTestSheetURL, waitForSave } from '../utils/page.js';
 
-test('New sheet', async ({ page, trackCleanup }, workerInfo) => {
+test('New sheet', async ({ page }, workerInfo) => {
   test.setTimeout(30000);
 
   const url = getTestSheetURL('sheet1', workerInfo);
-  trackCleanup(url, { ext: '.json' });
   await page.goto(url);
 
   // DA title
@@ -27,11 +26,10 @@ test('New sheet', async ({ page, trackCleanup }, workerInfo) => {
   await page.close();
 });
 
-test('Deleting rows persists after reload', async ({ page, trackCleanup }, workerInfo) => {
+test('Deleting rows persists after reload', async ({ page }, workerInfo) => {
   test.setTimeout(30000);
 
   const url = getTestSheetURL('sheetdel', workerInfo);
-  trackCleanup(url, { ext: '.json' });
   await page.goto(url);
 
   await expect(page.locator('da-sheet-tabs')).toBeVisible();
@@ -73,11 +71,10 @@ test('Deleting rows persists after reload', async ({ page, trackCleanup }, worke
   await page.close();
 });
 
-test('Deleting columns persists after reload', async ({ page, trackCleanup }, workerInfo) => {
+test('Deleting columns persists after reload', async ({ page }, workerInfo) => {
   test.setTimeout(30000);
 
   const url = getTestSheetURL('sheetdelc', workerInfo);
-  trackCleanup(url, { ext: '.json' });
   await page.goto(url);
 
   await expect(page.locator('da-sheet-tabs')).toBeVisible();
@@ -117,11 +114,10 @@ test('Deleting columns persists after reload', async ({ page, trackCleanup }, wo
   await page.close();
 });
 
-test('Moving a row persists after reload', async ({ page, trackCleanup }, workerInfo) => {
+test('Moving a row persists after reload', async ({ page }, workerInfo) => {
   test.setTimeout(30000);
 
   const url = getTestSheetURL('sheetmove', workerInfo);
-  trackCleanup(url, { ext: '.json' });
   await page.goto(url);
 
   await expect(page.locator('da-sheet-tabs')).toBeVisible();

--- a/test/e2e/tests/versions.spec.js
+++ b/test/e2e/tests/versions.spec.js
@@ -12,13 +12,12 @@
 import { test, expect } from '../utils/fixtures.js';
 import { getTestPageURL, fill, TEST_SITE } from '../utils/page.js';
 
-test('Create Version and Restore from it', async ({ page, trackCleanup }, workerInfo) => {
+test('Create Version and Restore from it', async ({ page }, workerInfo) => {
   // This test has a fairly high timeout because it waits for the document to be saved
   // a number of times
   test.setTimeout(60000);
 
   const url = getTestPageURL('versions', workerInfo);
-  trackCleanup(url);
   await page.goto(url);
   await page.getByText('Create document', { exact: true }).click();
   await expect(page.locator('div.ProseMirror')).toBeVisible();

--- a/test/e2e/utils/fixtures.js
+++ b/test/e2e/utils/fixtures.js
@@ -9,43 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { test as base, expect } from '@playwright/test';
-import { parseTestUrl, deleteResource, mapWithConcurrency, DELETE_CONCURRENCY } from './cleanup.js';
 
-/**
- * Extends the base test with a `trackCleanup` fixture. Call
- * `trackCleanup(url)` (or `trackCleanup(url, { isFolder: true })`) right after
- * creating a test document/folder, and it will be deleted directly via the
- * admin API once the test finishes - regardless of whether it passed or
- * failed, since this teardown code runs after `use()` the same way a finally
- * block would.
- */
-export const test = base.extend({
-  trackCleanup: async ({ page }, use, testInfo) => {
-    let authHeader;
-    page.on('request', (request) => {
-      const auth = request.headers().authorization;
-      if (auth?.startsWith('Bearer ') && !authHeader) authHeader = auth;
-    });
-
-    const registered = [];
-    await use((url, opts) => registered.push({ url, opts }));
-
-    await mapWithConcurrency(registered, DELETE_CONCURRENCY, async ({ url, opts }) => {
-      const { org, site, path } = parseTestUrl(url);
-      const label = `[cleanup] ${testInfo.title} -> ${org}/${site}${path}`;
-      if (!authHeader) {
-        console.warn(`${label}: skipped (no auth header captured)`);
-        return;
-      }
-      try {
-        const resp = await deleteResource(page, authHeader, org, site, path, opts);
-        console.log(`${label}: ${resp.ok() ? 'deleted' : `failed (${resp.status()})`}`);
-      } catch (err) {
-        console.warn(`${label}: error (${err.message})`);
-      }
-    });
-  },
-});
-
-export { expect };
+// Test-created documents/folders are no longer deleted per-test (that added a
+// request-header capture + admin-API round trip to every test's teardown).
+// Stale resources are instead swept up by the scheduled cleanup workflow, which
+// runs the "Delete multiple old pages" test in delete.spec.js every 6h - see
+// .github/workflows/cleanup.yml.
+export { test, expect } from '@playwright/test';


### PR DESCRIPTION
## Summary
- Remove per-test `trackCleanup` fixture/calls (admin-API delete in every test's teardown) to speed up suite execution
- Add `.github/workflows/cleanup.yml`: cron `0 */6 * * *` + manual dispatch, runs the existing stale-resource sweep (`Delete multiple old pages` in delete.spec.js) against both da-admin and helix site configs
- Exclude that sweep test from regular `test`/`test:all`/`test:nonauth` runs via `--grep-invert`; add `test:cleanup` script for it

## Test plan
- [ ] `npm run lint` clean (done locally)
- [ ] Regular Playwright CI run (playwright.yml / playwright-hlx.yml) green, faster without per-test deletes
- [ ] Manually trigger `Cleanup stale test resources` workflow via workflow_dispatch, confirm it deletes stale `/tests` resources on both da-admin and helix sites
- [ ] Confirm scheduled run fires on the 6h cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)