### PR TITLE
fix(ew): resolve placeholder attribute/Playwright locator collision

### DIFF
--- a/blocks/browse/da-new/da-new.js
+++ b/blocks/browse/da-new/da-new.js
@@ -160,7 +160,7 @@ export default class DaNew extends LitElement {
     </da-link-dialog>
     <da-name-dialog
       dialog-title="${this._createDialogTitle}"
-      placeholder="${this._createType} name"
+      name-placeholder="${this._createType} name"
       saveLabel="Create"
       ?open=${this._createDialogOpen}
       ?saving=${this._loading}

--- a/blocks/canvas/ew-file-explorer/ew-file-explorer.js
+++ b/blocks/canvas/ew-file-explorer/ew-file-explorer.js
@@ -384,7 +384,7 @@ class EwFileExplorer extends LitElement {
       </ul>
       <da-name-dialog
         dialog-title="New page in ${this._createDialog?.folder?.split('/').pop() ?? ''}"
-        placeholder="page name"
+        name-placeholder="page name"
         ?open=${!!this._createDialog}
         ?saving=${this._createDialog?.saving}
         show-create-and-open

--- a/blocks/shared/da-name-dialog/da-name-dialog.js
+++ b/blocks/shared/da-name-dialog/da-name-dialog.js
@@ -11,7 +11,7 @@ class DaNameDialog extends LitElement {
   static properties = {
     open: { type: Boolean, reflect: true },
     title: { type: String, attribute: 'dialog-title' },
-    placeholder: { type: String },
+    namePlaceholder: { type: String, attribute: 'name-placeholder' },
     saveLabel: { type: String },
     saving: { type: Boolean },
     error: { type: String },
@@ -65,7 +65,7 @@ class DaNameDialog extends LitElement {
       <nx-dialog title="${this.title ?? 'New item'}" @close=${this._onClose}>
         <label class="nx-form-field ${this._nameError ? 'nx-field-error' : ''}">
           <span>Name</span>
-          <input autofocus type="text" class="nx-input" placeholder="${this.placeholder ?? 'name'}"
+          <input autofocus type="text" class="nx-input" placeholder="${this.namePlaceholder ?? 'name'}"
                  autocomplete="off"
                  @input=${this._onInput} @keydown=${this._onKeydown} />
           <span class="nx-input-error-msg" role="alert">

--- a/test/unit/blocks/shared/da-name-dialog/da-name-dialog.test.js
+++ b/test/unit/blocks/shared/da-name-dialog/da-name-dialog.test.js
@@ -36,7 +36,7 @@ describe('da-name-dialog', () => {
   });
 
   it('renders the name field when open is true', async () => {
-    await mount({ open: true, title: 'New page in a', placeholder: 'page name' });
+    await mount({ open: true, title: 'New page in a', namePlaceholder: 'page name' });
     const input = el.shadowRoot.querySelector('.nx-input');
     expect(input).to.exist;
     expect(input.placeholder).to.equal('page name');


### PR DESCRIPTION
## Summary
- Root cause of the e2e failures on #1234's last CI run: `<da-name-dialog placeholder="...">` set a literal `placeholder` HTML attribute on the custom element itself (via the parent's template), and Playwright's `getByPlaceholder` matches that attribute on any element, not just `<input>`. Every test filling the create-page/document/folder name field hit a strict-mode "resolved to 2 elements" violation between the wrapper and its shadow-DOM input.
- Renamed the component's prop/attribute to `namePlaceholder` / `name-placeholder` so it no longer shadows the native `placeholder` semantics (same pattern already used for `title` → `dialog-title` on this component).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 1882 passed, 0 failed
- [ ] Re-run the e2e workflow on this PR and confirm the previously-failing specs (`acl_browse`, `edit`, `copy_rename`, `regionaledits`, `preview_publish`) pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>