### PR TITLE
fix(edit): strip .html before unpublishing so helix-admin accepts the path

### DIFF
--- a/blocks/edit/da-prepare/actions/unpublish/unpublish.js
+++ b/blocks/edit/da-prepare/actions/unpublish/unpublish.js
@@ -28,8 +28,7 @@ class DaUnpublish extends LitElement {
     this._results = [];
     this._statusText = 'Removing preview';
 
-    const { org, site, path } = this.details;
-    const fullpath = `/${org}/${site}${path}`;
+    const fullpath = this.details.fullpath.replace(/\.html$/, '');
 
     const { aem } = await getNx2Api();
 

--- a/test/unit/blocks/edit/da-prepare/actions/unpublish/unpublish.test.js
+++ b/test/unit/blocks/edit/da-prepare/actions/unpublish/unpublish.test.js
@@ -1,0 +1,60 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx, getNx2Api } from '../../../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { default: renderUnpublish } = await import('../../../../../../../blocks/edit/da-prepare/actions/unpublish/unpublish.js');
+
+function makeUnpublish(details) {
+  const el = renderUnpublish(details);
+  // Avoid needing a real dialog ancestor for the close dispatch.
+  el.dispatchEvent = () => {};
+  return el;
+}
+
+describe('da-unpublish', () => {
+  it('Unpublishes HTML pages by their extensionless path', async () => {
+    const { aem } = await getNx2Api();
+    const origUnPreview = aem.unPreview;
+    const origUnPublish = aem.unPublish;
+    const unpublished = [];
+    aem.unPreview = (path) => {
+      unpublished.push(path);
+      return { ok: true };
+    };
+    aem.unPublish = (path) => {
+      unpublished.push(path);
+      return { ok: true };
+    };
+
+    try {
+      const el = makeUnpublish({ org: 'org', site: 'site', path: '/testpublishing.html', fullpath: '/org/site/testpublishing.html' });
+      await el.handleUnpublish();
+
+      expect(unpublished).to.deep.equal(['/org/site/testpublishing', '/org/site/testpublishing']);
+      expect(el._results).to.deep.equal([]);
+    } finally {
+      aem.unPreview = origUnPreview;
+      aem.unPublish = origUnPublish;
+    }
+  });
+
+  it('Records an error when unpublish fails', async () => {
+    const { aem } = await getNx2Api();
+    const origUnPreview = aem.unPreview;
+    const origUnPublish = aem.unPublish;
+    aem.unPreview = () => ({ ok: true });
+    aem.unPublish = () => ({ ok: false, status: 404 });
+
+    try {
+      const el = makeUnpublish({ org: 'org', site: 'site', path: '/testpublishing.html', fullpath: '/org/site/testpublishing.html' });
+      await el.handleUnpublish();
+
+      expect(el._results).to.deep.equal(['Couldn\'t unpublish from production.']);
+      expect(el._statusText).to.equal('There was an error');
+    } finally {
+      aem.unPreview = origUnPreview;
+      aem.unPublish = origUnPublish;
+    }
+  });
+});


### PR DESCRIPTION
## Description

The **Prepare → Unpublish** action now derives the admin path from the always-normalized `details.fullpath` and strips the trailing `.html`, instead of hand-assembling it from `details.path`. Previously it sent the `.html`-suffixed path straight to `aem.unPreview`/`aem.unPublish`, which the non-hlx6 unpublish (DELETE) endpoints reject with `AEM_BACKEND_HTML_PATH_UNSUPPORTED`.

This matches the sibling scheduler action and the browse-view unpublish, and sidesteps a latent trap: `details.path` is extensionless in edit mode but carries `.html` in canvas mode.

## Related Issue

Fixes #1257 

## Motivation and Context

Unpublishing a page in Canvas mode on a non-hlx6 site failed with:

```
x-error: [admin] .html paths are not supported, use the extensionless path instead: /testpublishing.html
x-error-code: AEM_BACKEND_HTML_PATH_UNSUPPORTED
```

Two things combined to cause this:

1. Possible **Regression from #1022** ("route DA operations through nx2 api.js and add hlx6 support"). Before it, unpublish called the local `aemAdmin` helper, which stripped `.html` implicitly. #1022 swapped the call to the remote nx2 `aem.unPreview`/`aem.unPublish` API — which leaves extension handling to the caller — but left the path construction unchanged, so the stripping was silently lost.

2. **Edit vs. Canvas pass a different `details` shape.** The action read `details.path`. In edit mode that field is extensionless (the `.html` only lives on `details.fullpath`), so the bug never surfaced. In canvas mode `details.path` includes `.html`, so it produced `/org/site/page.html` and broke. This is why the failure reproduces in **Canvas mode but not the regular edit-mode Prepare menu** — same code, differently-shaped data.

Publish/preview were unaffected because helix-admin tolerates `.html` on the POST endpoints; only the DELETE (unpublish) endpoints reject it. The browse-view unpublish already strips `.html`, leaving this prepare-menu call site as the only one missed.

Using `details.fullpath` (present and normalized in both edit and canvas) makes the fix robust across both entry points — the strip is a no-op when the extension isn't there and correct when it is.

## How Has This Been Tested?

- **Unit** — Added `test/unit/blocks/edit/da-prepare/actions/unpublish/unpublish.test.js` (2 tests): asserts `aem.unPreview`/`aem.unPublish` are called with the extensionless path when `details.fullpath` ends in `.html` (the exact canvas scenario), and that a failed DELETE surfaces the error message and status. All tests pass (`npm test`).
- **Lint** — `npm run lint` passes on the changed files.
- **Manual** — On a non-hlx6 site in **Canvas mode**, opened a published page, Prepare → Unpublish → typed `YES` → Unpublish. Confirmed no `AEM_BACKEND_HTML_PATH_UNSUPPORTED` error, the page is removed from preview + live, and the dialog closes. Re-verified edit-mode unpublish still works.
- Test url: https://unpubfix--da-live--adobe.aem.live/canvas#/aem-sandbox/block-collection/drafts/amol/shwblock

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.