### PR TITLE
Prefer Iptc4xmpExt:ExtDescrAccessibility for asset alt text

### DIFF
--- a/blocks/edit/da-assets/README.md
+++ b/blocks/edit/da-assets/README.md
@@ -179,7 +179,7 @@ URL builder functions keyed to the mode:
 Plus:
 
 - `resolveRenditionType(mimetype, { mimeRenditionOverrides })` — determines the rendition type (`avif` / `play` / `original`) using override map and built-in defaults.
-- `getAssetAlt(asset)` — reads alt text from `_embedded` metadata (`dc:description` or `dc:title`).
+- `getAssetAlt(asset)` — reads alt text, preferring `Iptc4xmpExt:ExtDescrAccessibility` (the field the content supply chain agent maps alt text to), then `_embedded` metadata (`dc:description` or `dc:title`).
 - `getDmApprovalStatus(asset)` — reads `dam:assetStatus` and `dam:activationTarget` from `_embedded` metadata.
 
 ### `helpers/insert.js`

--- a/blocks/edit/da-assets/helpers/urls.js
+++ b/blocks/edit/da-assets/helpers/urls.js
@@ -153,7 +153,9 @@ export function buildSmartCropsListUrl(asset, dmOrigin, basePath = DEFAULT_ASSET
 /**
  * Returns the alt text for an asset.
  *
- * Handles both asset shapes returned by the selector:
+ * Prefers `Iptc4xmpExt:ExtDescrAccessibility` (the IPTC accessibility
+ * description) — this is the field the content supply chain agent maps alt
+ * text to by default. Then handles both asset shapes returned by the selector:
  *   - author tier: description/title live in `_embedded` metadata
  *   - delivery tier: title is a top-level `dc:title` (string, or a localized
  *     `{ 'o:default': ... }` object)
@@ -162,7 +164,9 @@ export function buildSmartCropsListUrl(asset, dmOrigin, basePath = DEFAULT_ASSET
 export function getAssetAlt(asset) {
   // eslint-disable-next-line no-underscore-dangle
   const meta = asset?._embedded?.['http://ns.adobe.com/adobecloud/rel/metadata/asset'];
-  return meta?.['dc:description']
+  return meta?.['Iptc4xmpExt:ExtDescrAccessibility']
+    || asset?.['Iptc4xmpExt:ExtDescrAccessibility']
+    || meta?.['dc:description']
     || meta?.['dc:title']
     || asset?.['dc:title']?.['o:default']
     || asset?.['dc:title']

--- a/test/unit/blocks/edit/da-assets/urls.test.js
+++ b/test/unit/blocks/edit/da-assets/urls.test.js
@@ -364,6 +364,26 @@ describe('buildSmartCropsListUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('getAssetAlt', () => {
+  it('prefers Iptc4xmpExt:ExtDescrAccessibility from _embedded metadata', () => {
+    const asset = {
+      _embedded: {
+        'http://ns.adobe.com/adobecloud/rel/metadata/asset': {
+          'Iptc4xmpExt:ExtDescrAccessibility': 'A rich mountain view with blue skies',
+          'dc:description': 'A mountain view',
+        },
+      },
+    };
+    expect(getAssetAlt(asset)).to.equal('A rich mountain view with blue skies');
+  });
+
+  it('prefers a top-level Iptc4xmpExt:ExtDescrAccessibility (delivery-tier shape)', () => {
+    const asset = {
+      'Iptc4xmpExt:ExtDescrAccessibility': 'A rich mountain view with blue skies',
+      'dc:title': 'Sunset',
+    };
+    expect(getAssetAlt(asset)).to.equal('A rich mountain view with blue skies');
+  });
+
   it('returns dc:description when available', () => {
     expect(getAssetAlt(AUTHOR_IMAGE)).to.equal('A mountain view');
   });


### PR DESCRIPTION
## Summary

The content supply chain agent (optel gateway) maps alt text to the IPTC accessibility description field `Iptc4xmpExt:ExtDescrAccessibility` by default, but `getAssetAlt()` in `blocks/edit/da-assets/helpers/urls.js` didn't read it.

## Changes

- **`blocks/edit/da-assets/helpers/urls.js`** — `getAssetAlt()` now prefers `Iptc4xmpExt:ExtDescrAccessibility` (from `_embedded` metadata first, then top-level for the delivery-tier shape), before falling back to `dc:description` / `dc:title` / asset name.
- **`test/unit/blocks/edit/da-assets/urls.test.js`** — added tests covering both the author-tier (`_embedded`) and delivery-tier (top-level) shapes.
- **`blocks/edit/da-assets/README.md`** — updated the `getAssetAlt` description.

## Testing

All 53 tests in `test/unit/blocks/edit/da-assets/urls.test.js` pass.