### PR TITLE
feat: support multiple items for block options via slash menu, add swatch identifier

### DIFF
--- a/blocks/canvas/ew-editor-doc/slash-menu/block-options.js
+++ b/blocks/canvas/ew-editor-doc/slash-menu/block-options.js
@@ -14,6 +14,12 @@ export function normalizeForSlashMenu(str) {
   return str?.toLowerCase().trim().replace(/\s+/g, '-');
 }
 
+function isColorCode(str) {
+  const hexColorRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+  const rgbColorRegex = /^rgba?\(\s*(\d{1,3}\s*,\s*){2}\d{1,3}(\s*,\s*(0|1|0?\.\d+))?\s*\)$/;
+  return hexColorRegex.test(str) || rgbColorRegex.test(str) || str?.includes('-gradient(');
+}
+
 function buildBlockMap(data) {
   const blockMap = new Map();
   data?.forEach((item) => {
@@ -127,7 +133,7 @@ export function blockOptionItems(state, query, blockMap = store.blockMap) {
       if (!q || v.title.toLowerCase().includes(q)) {
         const id = `blockopt-val:${i}`;
         actions.set(id, { text: v.value, moveNext: false });
-        items.push({ id, label: v.title });
+        items.push({ id, label: v.title, ...(isColorCode(v.value) ? { swatch: v.value } : {}) });
       }
     });
   }

--- a/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js
+++ b/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js
@@ -42,12 +42,13 @@ export function getSlashContext(state) {
   if (head <= paraStart) return null;
 
   const prefix = state.doc.textBetween(paraStart, head, '\ufffc', '\ufffc');
-  if (!prefix.startsWith('/')) return null;
+  const slashIndex = prefix.lastIndexOf('/');
+  if (slashIndex === -1) return null;
 
-  const query = prefix.slice(1);
+  const query = prefix.slice(slashIndex + 1);
   if (query.length > 50) return null;
 
-  return { query, anchorPos: paraStart, mode };
+  return { query, anchorPos: paraStart + slashIndex, mode };
 }
 
 // A CellSelection (one or more selected table cells) carries `$anchorCell`;

--- a/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js
+++ b/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.js
@@ -45,6 +45,11 @@ export function getSlashContext(state) {
   const slashIndex = prefix.lastIndexOf('/');
   if (slashIndex === -1) return null;
 
+  if (slashIndex > 0) {
+    if (mode !== 'cell') return null;
+    if (!prefix.slice(0, slashIndex).trimEnd().endsWith(',')) return null;
+  }
+
   const query = prefix.slice(slashIndex + 1);
   if (query.length > 50) return null;
 

--- a/test/unit/blocks/canvas/ew-editor-doc/block-options.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/block-options.test.js
@@ -13,7 +13,7 @@ const {
 } = await import('../../../../../blocks/canvas/ew-editor-doc/slash-menu/block-options.js');
 
 const OPTIONS = [
-  { blocks: 'myblock', key: 'color', values: 'Red=red|Blue=blue' },
+  { blocks: 'myblock', key: 'color', values: 'Red=red|Blue=blue|Sky=#1a2b3c' },
   { blocks: 'myblock', key: 'size', values: 'Large=lg|Small=sm' },
 ];
 
@@ -54,6 +54,7 @@ describe('processBlockOptions', () => {
     expect(keyData.get('color')).to.deep.equal([
       { title: 'Red', value: 'red' },
       { title: 'Blue', value: 'blue' },
+      { title: 'Sky', value: '#1a2b3c' },
     ]);
   });
 
@@ -96,7 +97,15 @@ describe('blockOptionItems', () => {
     const { valuePos } = buildBlock(editor);
     selectAt(editor, valuePos);
     const items = blockOptionItems(editor.view.state, '', map);
-    expect(items.slice(1).map((i) => i.label)).to.deep.equal(['Red', 'Blue']);
+    expect(items.slice(1).map((i) => i.label)).to.deep.equal(['Red', 'Blue', 'Sky']);
+  });
+
+  it('flags hex-color values with a swatch, leaving non-colors alone', () => {
+    const { valuePos } = buildBlock(editor);
+    selectAt(editor, valuePos);
+    const items = blockOptionItems(editor.view.state, '', map);
+    expect(items.find((i) => i.label === 'Sky').swatch).to.equal('#1a2b3c');
+    expect(items.find((i) => i.label === 'Red').swatch).to.equal(undefined);
   });
 
   it('returns null when the cursor is not in a block cell', () => {

--- a/test/unit/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.test.js
@@ -25,6 +25,18 @@ function stateWithParagraph(text) {
   return EditorState.create({ schema, doc, selection: sel });
 }
 
+function stateWithCellParagraph(text) {
+  const para = schema.nodes.paragraph.create(null, text ? schema.text(text) : null);
+  const cell = schema.nodes.table_cell.create(null, para);
+  const row = schema.nodes.table_row.create(null, cell);
+  const table = schema.nodes.table.create(null, row);
+  const doc = schema.nodes.doc.create(null, table);
+  // doc -> table -> table_row -> table_cell -> paragraph: 4 open tokens before the
+  // text, 4 close tokens after it, so end-of-text is content.size - 4.
+  const sel = TextSelection.create(doc, doc.content.size - 4);
+  return EditorState.create({ schema, doc, selection: sel });
+}
+
 describe('getSlashContext', () => {
   it('returns the query for a single-word slash command', () => {
     const ctx = getSlashContext(stateWithParagraph('/banner'));
@@ -46,11 +58,19 @@ describe('getSlashContext', () => {
     expect(getSlashContext(stateWithParagraph(`/${'x'.repeat(60)}`))).to.be.null;
   });
 
-  it('opens on the last "/" so a prior comma-separated value does not block it', () => {
-    const ctx = getSlashContext(stateWithParagraph('red, /bl'));
+  it('ignores a mid-line "/" outside a block-options cell (legit "/" in text)', () => {
+    expect(getSlashContext(stateWithParagraph('1/2 cup sugar'))).to.be.null;
+  });
+
+  it('in a block-options cell, opens on "/" right after a comma-separated value', () => {
+    const ctx = getSlashContext(stateWithCellParagraph('red, /bl'));
     expect(ctx).to.not.be.null;
     expect(ctx.query).to.equal('bl');
-    expect(ctx.anchorPos).to.equal(6); // position of the second "/"
+    expect(ctx.anchorPos).to.equal(9); // position of the second "/"
+  });
+
+  it('in a block-options cell, ignores a mid-line "/" not preceded by a comma', () => {
+    expect(getSlashContext(stateWithCellParagraph('red /bl'))).to.be.null;
   });
 });
 

--- a/test/unit/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/slash-menu/slash-menu.test.js
@@ -45,6 +45,13 @@ describe('getSlashContext', () => {
   it('returns null for an over-long query (cap)', () => {
     expect(getSlashContext(stateWithParagraph(`/${'x'.repeat(60)}`))).to.be.null;
   });
+
+  it('opens on the last "/" so a prior comma-separated value does not block it', () => {
+    const ctx = getSlashContext(stateWithParagraph('red, /bl'));
+    expect(ctx).to.not.be.null;
+    expect(ctx.query).to.equal('bl');
+    expect(ctx.anchorPos).to.equal(6); // position of the second "/"
+  });
 });
 
 describe('hasCellSelection', () => {


### PR DESCRIPTION
**Must land with https://github.com/adobe/da-nx/pull/682**

- Adds support for https://github.com/adobe/da-live/pull/1171#issuecomment-5346523947
- Adds a `swatch` identifier for color options so that they can be rendered with a swatch preview in the options menu.

Test URL: https://slash--da-live--adobe.aem.live/canvas?nx=swatch#/aemsites/intuit-erp/drafts/ukhalid/account-management

DEMO:
<img width="2620" height="1690" alt="2026-08-20 08 49 07" src="https://github.com/user-attachments/assets/154185cb-a42c-4446-8ea1-0abfc80f1083" />
