### PR TITLE
feat: improve icon library

### DIFF
--- a/blocks/canvas/ew-block-library-modal/ew-block-library-modal.css
+++ b/blocks/canvas/ew-block-library-modal/ew-block-library-modal.css
@@ -17,7 +17,6 @@
   grid-template-rows: auto 1fr;
   min-height: 0;
   font-family: var(--s2-font-family);
-  color: light-dark(var(--s2-gray-900), var(--s2-gray-100));
 }
 
 .modal-header {
@@ -25,29 +24,12 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--s2-spacing-100) var(--s2-spacing-200);
-  border-bottom: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-700));
+  border-bottom: 1px solid var(--s2-gray-200);
 }
 
 .modal-title {
   font-weight: 600;
   font-size: var(--s2-body-size-m);
-}
-
-.modal-close {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: var(--s2-corner-radius-75);
-  background: transparent;
-  color: inherit;
-  font-family: inherit;
-  font-size: 16px;
-  cursor: pointer;
-}
-
-.modal-close:hover {
-  background: light-dark(var(--s2-gray-200), var(--s2-gray-700));
 }
 
 .modal-body {
@@ -59,9 +41,9 @@
 /* Left column — tree */
 
 .modal-tree-wrap {
-  border-right: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-700));
+  border-right: 1px solid var(--s2-gray-200);
   overflow-y: auto;
-  background: light-dark(var(--s2-gray-75), var(--s2-gray-800));
+  background: var(--s2-gray-75);
 }
 
 .modal-search {
@@ -70,72 +52,30 @@
   z-index: 1;
   padding: var(--s2-spacing-100);
   background: inherit;
-  border-bottom: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-700));
-}
-
-.modal-search-field {
-  position: relative;
-  display: flex;
-  align-items: center;
+  border-bottom: 1px solid var(--s2-gray-200);
 }
 
 .modal-search-icon {
   position: absolute;
-  inset-inline-start: 12px;
-  width: 18px;
-  height: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  width: 16px;
+  height: 16px;
   color: light-dark(var(--s2-gray-700), var(--s2-gray-400));
   pointer-events: none;
+  margin-left: 10px;
 }
 
-.modal-search-input {
-  box-sizing: border-box;
+.modal-search .nx-input {
   width: 100%;
-  height: 32px;
-  padding: 0 32px 0 34px;
-  border: 2px solid light-dark(var(--s2-gray-300), var(--s2-gray-600));
-  border-radius: var(--s2-corner-radius-800);
-  background: light-dark(#fff, var(--s2-gray-900));
-  color: inherit;
-  font-family: inherit;
-  font-size: var(--s2-body-size-s);
-}
-
-.modal-search-input::-webkit-search-cancel-button {
-  appearance: none;
-}
-
-.modal-search-clear {
-  position: absolute;
-  inset-inline-end: 8px;
-  width: 20px;
-  height: 20px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: light-dark(var(--s2-gray-800), var(--s2-gray-200));
-  font-family: inherit;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.modal-search-input::placeholder {
-  color: light-dark(var(--s2-gray-700), var(--s2-gray-400));
-}
-
-.modal-search-input:hover {
-  border-color: light-dark(var(--s2-gray-500), var(--s2-gray-400));
-}
-
-.modal-search-input:focus {
-  outline: none;
-  border-color: light-dark(var(--s2-gray-900), var(--s2-gray-100));
+  padding-left: 34px;
 }
 
 .modal-state {
   padding: var(--s2-spacing-200);
   font-size: var(--s2-body-size-s);
-  color: light-dark(var(--s2-gray-700), var(--s2-gray-300));
+  color: var(--s2-gray-700);
 }
 
 .modal-tree,
@@ -146,7 +86,7 @@
 }
 
 .modal-tree-block {
-  border-bottom: 1px solid light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  border-bottom: 1px solid var(--s2-gray-100);
 }
 
 .modal-tree-row {
@@ -165,12 +105,12 @@
 }
 
 .modal-tree-row:hover {
-  background: light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  background: var(--s2-gray-100);
 }
 
 .modal-tree-row.is-selected {
-  background: light-dark(var(--s2-blue-100), var(--s2-blue-900));
-  color: light-dark(var(--s2-blue-900), var(--s2-blue-100));
+  background: var(--s2-blue-100);
+  color: var(--s2-blue-900);
 }
 
 .modal-tree-row-variant {
@@ -194,23 +134,12 @@
 }
 
 .modal-tree-variant-row:hover {
-  background: light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  background: var(--s2-gray-100);
 }
 
 .modal-tree-info,
 .modal-tree-add {
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: var(--s2-corner-radius-75);
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
 }
 
 .modal-tree-info {
@@ -221,17 +150,6 @@
 .modal-tree-add {
   margin-inline-end: 8px;
   visibility: hidden;
-}
-
-.modal-tree-info svg,
-.modal-tree-add svg {
-  width: 18px;
-  height: 18px;
-}
-
-.modal-tree-info:hover,
-.modal-tree-add:hover {
-  background: light-dark(var(--s2-gray-200), var(--s2-gray-700));
 }
 
 .modal-tree-add:focus-visible,
@@ -245,7 +163,7 @@
 .modal-tree-description {
   padding: 6px 36px 10px;
   font-size: var(--s2-body-size-xs);
-  color: light-dark(var(--s2-gray-700), var(--s2-gray-300));
+  color: var(--s2-gray-700);
   line-height: 1.4;
 }
 
@@ -253,7 +171,7 @@
   flex-shrink: 0;
   width: 16px;
   height: 16px;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
   transition: transform 0.1s ease-out;
 }
 
@@ -270,14 +188,14 @@
 
 .modal-tree-subtitle {
   margin-left: 4px;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
   font-size: var(--s2-body-size-xs);
 }
 
 .modal-tree-loading {
   padding: 8px 36px;
   font-size: var(--s2-body-size-xs);
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
 }
 
 /* Right column — preview */
@@ -287,7 +205,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: light-dark(var(--s2-gray-50), var(--s2-gray-900));
+  background: var(--s2-gray-50);
 }
 
 .modal-preview-placeholder {
@@ -295,7 +213,7 @@
   align-items: center;
   justify-content: center;
   flex: 1;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
   font-size: var(--s2-body-size-s);
 }
 
@@ -312,8 +230,8 @@
 
 .modal-preview-error {
   padding: var(--s2-spacing-200);
-  background: light-dark(var(--s2-orange-100), var(--s2-orange-900));
-  color: light-dark(var(--s2-orange-900), var(--s2-orange-100));
+  background: var(--s2-orange-100);
+  color: var(--s2-orange-900);
   font-size: var(--s2-body-size-s);
 }
 

--- a/blocks/canvas/ew-block-library-modal/ew-block-library-modal.js
+++ b/blocks/canvas/ew-block-library-modal/ew-block-library-modal.js
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'da-lit';
-import { getNx } from '../../../scripts/utils.js';
+import { getNx, getNx2 } from '../../../scripts/utils.js';
+import getSheet from '../../shared/sheet.js';
 import {
   loadBlockLibrary,
   getItemPreviewUrl,
@@ -9,7 +10,11 @@ import {
 const nx = getNx();
 await import(`${nx}/blocks/shared/dialog/dialog.js`);
 const { loadStyle, hashChange } = await import(`${nx}/utils/utils.js`);
-const style = await loadStyle(import.meta.url);
+const [buttonsStyle, formStyle, style] = await Promise.all([
+  getSheet(`${getNx2()}/styles/buttons.css`),
+  getSheet(`${getNx2()}/styles/form.css`),
+  loadStyle(import.meta.url),
+]);
 
 const CHEVRON_ICON_SRC = '/img/icons/s2-icon-chevronright-20-n.svg';
 const SEARCH_ICON_SRC = '/img/icons/s2-icon-search-20-n.svg';
@@ -52,7 +57,7 @@ class EwBlockLibraryModal extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.shadowRoot.adoptedStyleSheets = [style];
+    this.shadowRoot.adoptedStyleSheets = [buttonsStyle, formStyle, style];
     this._variantsByPath = new Map();
     this._openDescriptions = new Set();
     this._unsubHash = hashChange.subscribe((state) => { this._hashState = state; });
@@ -113,11 +118,6 @@ class EwBlockLibraryModal extends LitElement {
 
   _onSearchInput = (e) => {
     this._search = e.target.value;
-  };
-
-  _clearSearch = () => {
-    this._search = '';
-    this.shadowRoot.querySelector('.modal-search-input')?.focus();
   };
 
   _onDialogClose = () => {
@@ -217,7 +217,7 @@ class EwBlockLibraryModal extends LitElement {
           </span>
           ${description ? html`
             <button type="button"
-                    class="modal-tree-info"
+                    class="nx-action-btn-icon nx-btn-sm modal-tree-info"
                     aria-label="Show description"
                     aria-expanded=${isOpen}
                     @click=${() => this._toggleDescription(v)}>
@@ -226,7 +226,7 @@ class EwBlockLibraryModal extends LitElement {
               </svg>
             </button>` : nothing}
           <button type="button"
-                  class="modal-tree-add"
+                  class="nx-action-btn-icon nx-btn-sm modal-tree-add"
                   aria-label="Add ${v.name} to page"
                   @click=${() => this._addVariant(v)}>
             <svg aria-hidden="true" viewBox="0 0 20 20">
@@ -257,25 +257,17 @@ class EwBlockLibraryModal extends LitElement {
   }
 
   _renderSearch() {
-    const hasValue = !!(this._search || '').length;
     return html`
       <div class="modal-search">
-        <div class="modal-search-field">
-          <svg aria-hidden="true" class="modal-search-icon" viewBox="0 0 20 20">
-            <use href="${SEARCH_ICON_SRC}#icon"></use>
-          </svg>
-          <input type="search"
-                 class="modal-search-input"
-                 placeholder="Search blocks"
-                 aria-label="Search blocks"
-                 .value=${this._search || ''}
-                 @input=${this._onSearchInput}>
-          ${hasValue ? html`
-            <button type="button"
-                    class="modal-search-clear"
-                    aria-label="Clear search"
-                    @click=${this._clearSearch}>✕</button>` : nothing}
-        </div>
+        <svg aria-hidden="true" class="modal-search-icon" viewBox="0 0 20 20">
+          <use href="${SEARCH_ICON_SRC}#icon"></use>
+        </svg>
+        <input type="search"
+               class="nx-input modal-search-input"
+               placeholder="Search blocks"
+               aria-label="Search blocks"
+               .value=${this._search || ''}
+               @input=${this._onSearchInput}>
       </div>`;
   }
 
@@ -301,7 +293,7 @@ class EwBlockLibraryModal extends LitElement {
         <div class="modal-content">
           <header class="modal-header">
             <span class="modal-title">${this.heading ?? 'Insert block'}</span>
-            <button type="button" class="modal-close"
+            <button type="button" class="nx-action-btn-icon nx-btn-sm"
                     aria-label="Close" @click=${() => this._close()}>✕</button>
           </header>
           <div class="modal-body">

--- a/blocks/canvas/ew-panel-extensions/ew-panel-library.css
+++ b/blocks/canvas/ew-panel-extensions/ew-panel-library.css
@@ -174,29 +174,70 @@
 }
 
 .ext-search {
-  position: sticky;
-  top: 0;
-  z-index: 1;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-100);
   padding: var(--s2-spacing-100);
-  background: var(--s2-gray-75);
   border-bottom: 1px solid var(--s2-gray-200);
 }
 
-.ext-search-icon {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
-  width: 16px;
-  height: 16px;
-  color: light-dark(var(--s2-gray-700), var(--s2-gray-400));
-  pointer-events: none;
-  margin-left: 8px;
+.ext-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
-.ext-search .nx-input {
-  width: 100%;
-  padding-left: 34px;
+.ext-search-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--s2-gray-600);
+}
+
+.ext-search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: none;
+  font-family: inherit;
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-900);
+  padding: 0;
+}
+
+.ext-search-input::placeholder {
+  color: var(--s2-gray-600);
+}
+
+.ext-search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.ext-search-clear {
+  display: none;
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--s2-gray-600);
+}
+
+.ext-search-clear svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
+.ext-search-clear:focus-visible {
+  outline: 2px solid var(--s2-blue-700);
+  outline-offset: 2px;
+}
+
+.ext-search-input:not(:placeholder-shown) + .ext-search-clear {
+  display: block;
 }
 
 .ext-item-value {

--- a/blocks/canvas/ew-panel-extensions/ew-panel-library.css
+++ b/blocks/canvas/ew-panel-extensions/ew-panel-library.css
@@ -4,12 +4,13 @@
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
+  font-family: var(--s2-font-family);
 }
 
 
 .ext-state {
   padding: 16px;
-  color: light-dark(var(--s2-gray-700), var(--s2-gray-300));
+  color: var(--s2-gray-700);
   font-size: 14px;
 }
 
@@ -20,7 +21,7 @@
 }
 
 .ext-group {
-  border-bottom: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-600));
+  border-bottom: 1px solid var(--s2-gray-200);
 }
 
 .ext-group-header {
@@ -45,77 +46,35 @@
 }
 
 .ext-group-title:hover {
-  background: light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  background: var(--s2-gray-100);
 }
 
 .ext-expand-icon {
   font-size: 12px;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
   flex-shrink: 0;
-}
-
-.ext-action-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  margin: 0;
-  border: none;
-  border-radius: 4px;
-  background: none;
-  cursor: pointer;
-  font-size: 14px;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
-  flex-shrink: 0;
-}
-
-.ext-action-btn:hover {
-  background: light-dark(var(--s2-gray-200), var(--s2-gray-600));
-  color: light-dark(var(--s2-gray-900), var(--s2-gray-100));
-}
-
-.ext-preview-btn {
-  margin-right: 4px;
-}
-
-.ext-add-btn {
-  margin-right: 8px;
-}
-
-.ext-icon {
-  width: 20px;
-  height: 20px;
-  flex: 0 0 auto;
-  display: block;
-  color: inherit;
-}
-
-.ext-action-btn .ext-icon {
-  pointer-events: none;
 }
 
 .ext-variant-list {
   list-style: none;
   margin: 0;
   padding: 0;
-  border-top: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-600));
+  border-top: 1px solid var(--s2-gray-200);
 }
 
 .ext-variants-loading {
   padding: 8px 24px;
   font-size: 13px;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
 }
 
 .ext-variant-item {
   padding: 8px 0 8px 24px;
-  border-bottom: 1px solid light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  border-bottom: 1px solid var(--s2-gray-100);
 }
 
 .ext-variant-item:hover {
-  background: light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  background: var(--s2-gray-100);
 }
 
 .ext-variant-header {
@@ -143,7 +102,7 @@
 
 .ext-variant-subtitle {
   font-size: 11px;
-  color: light-dark(var(--s2-gray-500), var(--s2-gray-400));
+  color: var(--s2-gray-500);
   margin-top: 2px;
 }
 
@@ -158,17 +117,18 @@
   padding: 6px 16px 6px 0;
   font-size: 12px;
   line-height: 1.4;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
 }
 
 .ext-item {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-600));
+  border-bottom: 1px solid var(--s2-gray-200);
+  padding-right: 4px;
 }
 
 .ext-item:hover {
-  background: light-dark(var(--s2-gray-100), var(--s2-gray-700));
+  background: var(--s2-gray-75);
 }
 
 .ext-item-title {
@@ -199,13 +159,51 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-family: var(--s2-font-family);
+}
+
+.ext-item-icon {
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  object-fit: contain;
+  background: var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-75);
+}
+
+.ext-search {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: var(--s2-spacing-100);
+  background: var(--s2-gray-75);
+  border-bottom: 1px solid var(--s2-gray-200);
+}
+
+.ext-search-icon {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+  color: light-dark(var(--s2-gray-700), var(--s2-gray-400));
+  pointer-events: none;
+  margin-left: 8px;
+}
+
+.ext-search .nx-input {
+  width: 100%;
+  padding-left: 34px;
 }
 
 .ext-item-value {
   flex-shrink: 0;
   margin-left: 8px;
   font-size: 12px;
-  color: light-dark(var(--s2-gray-600), var(--s2-gray-400));
+  color: var(--s2-gray-600);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -220,9 +218,9 @@
   height: 80vh;
   margin: auto;
   padding: 0;
-  border: 1px solid light-dark(var(--s2-gray-300), var(--s2-gray-600));
+  border: 1px solid var(--s2-gray-300);
   border-radius: 8px;
-  background: light-dark(var(--s2-gray-50), var(--s2-gray-800));
+  background: var(--s2-gray-50);
   color: inherit;
   display: flex;
   flex-direction: column;
@@ -238,32 +236,13 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid light-dark(var(--s2-gray-200), var(--s2-gray-600));
+  border-bottom: 1px solid var(--s2-gray-200);
 }
 
 .ext-preview-title {
   margin: 0;
   font-size: 14px;
   font-weight: 600;
-}
-
-.ext-preview-close {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: 4px;
-  background: none;
-  cursor: pointer;
-  font-size: 16px;
-  color: inherit;
-}
-
-.ext-preview-close:hover {
-  background: light-dark(var(--s2-gray-200), var(--s2-gray-600));
 }
 
 .ext-preview-body {
@@ -290,7 +269,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: light-dark(var(--s2-gray-50), var(--s2-gray-800));
+  background: var(--s2-gray-50);
   font-size: 14px;
-  color: light-dark(var(--s2-gray-700), var(--s2-gray-300));
+  color: var(--s2-gray-700);
 }

--- a/blocks/canvas/ew-panel-extensions/ew-panel-library.js
+++ b/blocks/canvas/ew-panel-extensions/ew-panel-library.js
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'da-lit';
-import { getNx } from '../../../scripts/utils.js';
+import { getNx, getNx2 } from '../../../scripts/utils.js';
+import getSheet from '../../shared/sheet.js';
 import {
   fetchBlocks,
   fetchItems,
@@ -12,10 +13,19 @@ import {
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
 
 const { loadStyle, hashChange } = await import(`${getNx()}/utils/utils.js`);
-const style = await loadStyle(import.meta.url);
+const [buttonsStyle, formStyle, style] = await Promise.all([
+  getSheet(`${getNx2()}/styles/buttons.css`),
+  getSheet(`${getNx2()}/styles/form.css`),
+  loadStyle(import.meta.url),
+]);
 
-const iconAdd = () => html`<svg aria-hidden="true" class="icon ext-icon" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-experienceadd-20-n.svg#icon"></use></svg>`;
-const iconPreview = () => html`<svg aria-hidden="true" class="icon ext-icon" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-experiencepreview-20-n.svg#icon"></use></svg>`;
+const iconAdd = () => html`<svg aria-hidden="true" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-experienceadd-20-n.svg#icon"></use></svg>`;
+const iconPreview = () => html`<svg aria-hidden="true" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-experiencepreview-20-n.svg#icon"></use></svg>`;
+
+function andMatch(query, target) {
+  const terms = query.split(/\s+/).filter(Boolean);
+  return terms.every((term) => target.includes(term));
+}
 
 /**
  * First-party library panel: blocks, templates, icons, placeholders (OOTB sheet-driven tools).
@@ -29,11 +39,12 @@ class EwPanelLibrary extends LitElement {
     _preview: { state: true },
     _tooltipOpen: { state: true },
     _hashState: { state: true },
+    _search: { state: true },
   };
 
   connectedCallback() {
     super.connectedCallback();
-    this.shadowRoot.adoptedStyleSheets = [style];
+    this.shadowRoot.adoptedStyleSheets = [buttonsStyle, formStyle, style];
     this._unsubHash = hashChange.subscribe((state) => { this._hashState = state; });
   }
 
@@ -49,6 +60,7 @@ class EwPanelLibrary extends LitElement {
       this._expandedBlock = null;
       this._preview = undefined;
       this._tooltipOpen = null;
+      this._search = '';
       this._loadItems();
     }
   }
@@ -133,6 +145,19 @@ class EwPanelLibrary extends LitElement {
     this._tooltipOpen = this._tooltipOpen === key ? null : key;
   }
 
+  _onSearchInput = (e) => {
+    this._search = e.target.value;
+  };
+
+  _filteredItems() {
+    const q = (this._search || '').trim().toLowerCase();
+    if (!q) return this._items || [];
+    return (this._items || []).filter((item) => {
+      const text = [item.key, item.name, item.value].filter(Boolean).join(' ').toLowerCase();
+      return andMatch(q, text);
+    });
+  }
+
   _renderVariants(block) {
     if (this._expandedBlock !== block.path) return nothing;
     const variants = this._blockVariants.get(block.path);
@@ -153,9 +178,9 @@ class EwPanelLibrary extends LitElement {
               </button>
               <div class="ext-variant-actions">
                 ${v.description ? html`
-                  <button class="ext-action-btn" aria-label="Info"
+                  <button class="nx-action-btn-icon nx-btn-sm" aria-label="Info"
                     @click=${() => this._toggleTooltip(v.name)}>ℹ</button>` : nothing}
-                <button class="ext-action-btn ext-add-btn" aria-label="Add"
+                <button class="nx-action-btn-icon nx-btn-sm" aria-label="Add"
                   @click=${() => this._insertBlock(v)}>${iconAdd()}</button>
               </div>
             </div>
@@ -179,7 +204,7 @@ class EwPanelLibrary extends LitElement {
                 <span class="ext-item-name">${block.name}</span>
                 <span class="ext-expand-icon">${this._expandedBlock === block.path ? '▾' : '▸'}</span>
               </button>
-              <button class="ext-action-btn ext-preview-btn" aria-label="Preview"
+              <button class="nx-action-btn-icon nx-btn-sm" aria-label="Preview"
                 @click=${() => this._openPreview(block)}>${iconPreview()}</button>
             </div>
             ${this._renderVariants(block)}
@@ -200,9 +225,9 @@ class EwPanelLibrary extends LitElement {
               <span class="ext-item-name">${item.name ?? item.key ?? item.title ?? item.value}</span>
             </button>
             <div class="ext-item-actions">
-              <button class="ext-action-btn ext-preview-btn" aria-label="Preview"
+              <button class="nx-action-btn-icon nx-btn-sm" aria-label="Preview"
                 @click=${() => this._openPreview(item)}>${iconPreview()}</button>
-              <button class="ext-action-btn ext-add-btn" aria-label="Add"
+              <button class="nx-action-btn-icon nx-btn-sm" aria-label="Add"
                 @click=${() => this._insertTemplate(item)}>${iconAdd()}</button>
             </div>
           </li>
@@ -211,25 +236,53 @@ class EwPanelLibrary extends LitElement {
     `;
   }
 
+  _renderSearchInput(label) {
+    return html`
+      <div class="ext-search">
+        <svg aria-hidden="true" class="ext-search-icon" viewBox="0 0 20 20">
+          <use href="/img/icons/s2-icon-search-20-n.svg#icon"></use>
+        </svg>
+        <input type="search" class="nx-input ext-search-input"
+          placeholder="Search ${label}"
+          aria-label="Search ${label}"
+          .value=${this._search || ''}
+          @input=${this._onSearchInput}>
+      </div>
+    `;
+  }
+
   _renderKeyValueItems(label) {
     if (this._items === undefined) return html`<div class="ext-state">Loading…</div>`;
     if (!this._items.length) return html`<div class="ext-state">No ${label} found.</div>`;
+
+    const isIcons = this.extension.name === 'icons';
+    const items = this._filteredItems();
+
     return html`
-      <ul class="ext-list">
-        ${this._items.map((item) => html`
-          <li class="ext-item">
-            <button class="ext-item-title" @click=${() => this._insertText(item)}>
-              <span class="ext-item-name">${item.key || item.name || item.value}</span>
-              ${item.value && item.value !== item.key
-                ? html`<span class="ext-item-value">${item.value}</span>` : nothing}
-            </button>
-            <div class="ext-item-actions">
-              <button class="ext-action-btn ext-add-btn" aria-label="Add"
-                @click=${() => this._insertText(item)}>${iconAdd()}</button>
-            </div>
-          </li>
-        `)}
-      </ul>
+      ${this._renderSearchInput(label)}
+      ${items.length ? html`
+        <ul class="ext-list">
+          ${items.map((item) => {
+            const iconSrc = isIcons ? item.icon : null;
+            return html`
+              <li class="ext-item">
+                <button class="ext-item-title" @click=${() => this._insertText(item)}>
+                  ${iconSrc ? html`
+                    <img class="ext-item-icon" src=${iconSrc} alt=""
+                      @error=${(e) => { e.target.style.display = 'none'; }} />` : nothing}
+                  <span class="ext-item-name">${item.key || item.name || item.value}</span>
+                  ${item.value && item.value !== item.key
+                    ? html`<span class="ext-item-value">${item.value}</span>` : nothing}
+                </button>
+                <div class="ext-item-actions">
+                  <button class="nx-action-btn-icon nx-btn-sm" aria-label="Add"
+                    @click=${() => this._insertText(item)}>${iconAdd()}</button>
+                </div>
+              </li>
+            `;
+          })}
+        </ul>
+      ` : html`<div class="ext-state">No ${label} match “${this._search}”.</div>`}
     `;
   }
 
@@ -245,7 +298,7 @@ class EwPanelLibrary extends LitElement {
       <dialog class="ext-preview-dialog" @close=${() => this._closePreview()}>
         <div class="ext-preview-header">
           <p class="ext-preview-title">${name} preview</p>
-          <button class="ext-preview-close" @click=${() => this._closePreview()}>✕</button>
+          <button class="nx-action-btn-icon nx-btn-sm" aria-label="Close" @click=${() => this._closePreview()}>✕</button>
         </div>
         <div class="ext-preview-body">
           ${error ? html`<div class="ext-preview-error"><p>${error}</p></div>` : nothing}

--- a/blocks/canvas/ew-panel-extensions/ew-panel-library.js
+++ b/blocks/canvas/ew-panel-extensions/ew-panel-library.js
@@ -13,11 +13,13 @@ import {
 import { getExtensionsBridge } from '../editor-utils/extensions-bridge.js';
 
 const { loadStyle, hashChange } = await import(`${getNx()}/utils/utils.js`);
-const [buttonsStyle, formStyle, style] = await Promise.all([
+const [buttonsStyle, style] = await Promise.all([
   getSheet(`${getNx2()}/styles/buttons.css`),
-  getSheet(`${getNx2()}/styles/form.css`),
   loadStyle(import.meta.url),
 ]);
+
+const SEARCH_ICON_SRC = '/img/icons/s2-icon-search-20-n.svg';
+const CLEAR_ICON_SRC = '/img/icons/s2-icon-close-20-n.svg';
 
 const iconAdd = () => html`<svg aria-hidden="true" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-experienceadd-20-n.svg#icon"></use></svg>`;
 const iconPreview = () => html`<svg aria-hidden="true" viewBox="0 0 20 20"><use href="/img/icons/s2-icon-experiencepreview-20-n.svg#icon"></use></svg>`;
@@ -44,7 +46,7 @@ class EwPanelLibrary extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.shadowRoot.adoptedStyleSheets = [buttonsStyle, formStyle, style];
+    this.shadowRoot.adoptedStyleSheets = [buttonsStyle, style];
     this._unsubHash = hashChange.subscribe((state) => { this._hashState = state; });
   }
 
@@ -149,6 +151,12 @@ class EwPanelLibrary extends LitElement {
     this._search = e.target.value;
   };
 
+  _onSearchClear = () => {
+    const input = this.shadowRoot.querySelector('.ext-search-input');
+    if (input) input.value = '';
+    this._search = '';
+  };
+
   _filteredItems() {
     const q = (this._search || '').trim().toLowerCase();
     if (!q) return this._items || [];
@@ -239,14 +247,15 @@ class EwPanelLibrary extends LitElement {
   _renderSearchInput(label) {
     return html`
       <div class="ext-search">
-        <svg aria-hidden="true" class="ext-search-icon" viewBox="0 0 20 20">
-          <use href="/img/icons/s2-icon-search-20-n.svg#icon"></use>
-        </svg>
-        <input type="search" class="nx-input ext-search-input"
-          placeholder="Search ${label}"
+        <svg class="ext-search-icon" viewBox="0 0 20 20" aria-hidden="true"><use href="${SEARCH_ICON_SRC}#icon"></use></svg>
+        <input type="search" class="ext-search-input"
+          placeholder="Search"
           aria-label="Search ${label}"
           .value=${this._search || ''}
           @input=${this._onSearchInput}>
+        <button type="button" class="ext-search-clear" aria-label="Clear search" @click=${this._onSearchClear}>
+          <svg viewBox="0 0 20 20" aria-hidden="true"><use href="${CLEAR_ICON_SRC}#icon"></use></svg>
+        </button>
       </div>
     `;
   }
@@ -260,29 +269,31 @@ class EwPanelLibrary extends LitElement {
 
     return html`
       ${this._renderSearchInput(label)}
-      ${items.length ? html`
-        <ul class="ext-list">
-          ${items.map((item) => {
-            const iconSrc = isIcons ? item.icon : null;
-            return html`
-              <li class="ext-item">
-                <button class="ext-item-title" @click=${() => this._insertText(item)}>
-                  ${iconSrc ? html`
-                    <img class="ext-item-icon" src=${iconSrc} alt=""
-                      @error=${(e) => { e.target.style.display = 'none'; }} />` : nothing}
-                  <span class="ext-item-name">${item.key || item.name || item.value}</span>
-                  ${item.value && item.value !== item.key
-                    ? html`<span class="ext-item-value">${item.value}</span>` : nothing}
-                </button>
-                <div class="ext-item-actions">
-                  <button class="nx-action-btn-icon nx-btn-sm" aria-label="Add"
-                    @click=${() => this._insertText(item)}>${iconAdd()}</button>
-                </div>
-              </li>
-            `;
-          })}
-        </ul>
-      ` : html`<div class="ext-state">No ${label} match “${this._search}”.</div>`}
+      <div class="ext-scroll">
+        ${items.length ? html`
+          <ul class="ext-list">
+            ${items.map((item) => {
+              const iconSrc = isIcons ? item.icon : null;
+              return html`
+                <li class="ext-item">
+                  <button class="ext-item-title" @click=${() => this._insertText(item)}>
+                    ${iconSrc ? html`
+                      <img class="ext-item-icon" src=${iconSrc} alt=""
+                        @error=${(e) => { e.target.style.display = 'none'; }} />` : nothing}
+                    <span class="ext-item-name">${item.key || item.name || item.value}</span>
+                    ${item.value && item.value !== item.key
+                      ? html`<span class="ext-item-value">${item.value}</span>` : nothing}
+                  </button>
+                  <div class="ext-item-actions">
+                    <button class="nx-action-btn-icon nx-btn-sm" aria-label="Add"
+                      @click=${() => this._insertText(item)}>${iconAdd()}</button>
+                  </div>
+                </li>
+              `;
+            })}
+          </ul>
+        ` : html`<div class="ext-state">No ${label} match “${this._search}”.</div>`}
+      </div>
     `;
   }
 

--- a/test/unit/blocks/canvas/ew-panel-extensions/ew-panel-library.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/ew-panel-library.test.js
@@ -48,3 +48,50 @@ describe('Ew panel library _insertTemplate', () => {
     expect(fetchedUrl).to.equal('https://content.da.live/org/site/home');
   });
 });
+
+describe('Ew panel library icons: preview + search', () => {
+  let el;
+
+  beforeEach(async () => {
+    el = document.createElement('ew-panel-library');
+    document.body.append(el);
+    el.extension = { name: 'icons', ootb: true, sources: [] };
+    await el.updateComplete;
+    await el._loadItems();
+    el._items = [
+      { key: 'search', icon: 'https://content.da.live/adobe/da-live/icons/search.svg', text: ':search:' },
+      {
+        key: 'financial-services',
+        icon: 'https://content.da.live/adobe/da-live/icons/financial-services.svg',
+        text: ':financial-services:',
+      },
+    ];
+    await el.updateComplete;
+  });
+
+  afterEach(() => el.remove());
+
+  it('renders an icon preview image per item using the sheet-configured icon URL', () => {
+    const imgs = el.shadowRoot.querySelectorAll('.ext-item-icon');
+    expect(imgs.length).to.equal(2);
+    expect(imgs[0].src).to.equal('https://content.da.live/adobe/da-live/icons/search.svg');
+  });
+
+  it('filters items by the search box', async () => {
+    const input = el.shadowRoot.querySelector('.ext-search input');
+    input.value = 'financial';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const names = [...el.shadowRoot.querySelectorAll('.ext-item-name')].map((n) => n.textContent);
+    expect(names).to.deep.equal(['financial-services']);
+  });
+
+  it('hides a broken icon image on load error', async () => {
+    const img = el.shadowRoot.querySelector('.ext-item-icon');
+    img.dispatchEvent(new Event('error'));
+    await el.updateComplete;
+
+    expect(img.style.display).to.equal('none');
+  });
+});


### PR DESCRIPTION
Improves icon library to add:
- icon previews
- search

**Additional Updates:**
While I was in here:
- Used shared `nx-input` (for icons panel + the block library modal) where possible
- Updated icon only buttons with `nx-action-btn-icon`
- Fixed dark mode for the block library modal

Fixes #1248

<img width="400" alt="2026-08-20 17 01 46" src="https://github.com/user-attachments/assets/597db772-be90-4b12-b177-34eb7ad108e7" />


### Block Library Dark Mode

**BEFORE**
<img width="1006" height="670" alt="image" src="https://github.com/user-attachments/assets/8c3afb12-24a6-4ce6-8a91-d1b9cb4e59dd" />

**AFTER**
<img width="970" height="646" alt="image" src="https://github.com/user-attachments/assets/66b15875-e298-487b-b787-dea63b58e0ad" />

