### PR TITLE
fix(target): strip .html before previewing so helix-admin accepts the path

### DIFF
--- a/blocks/edit/da-prepare/actions/target/utils.js
+++ b/blocks/edit/da-prepare/actions/target/utils.js
@@ -149,7 +149,7 @@ export const fetchTargetConfig = (() => {
 })();
 
 export async function savePreview(org, site, path) {
-  const fullpath = `/${org}/${site}${path}`;
+  const fullpath = `/${org}/${site}${path}`.replace(/\.html$/, '');
   const { aem } = await getNx2Api();
   const resp = await aem.preview(fullpath);
   if (!resp.ok) return { error: 'Couldn\'t preview.' };

--- a/test/unit/blocks/edit/da-prepare/actions/target/utils.test.js
+++ b/test/unit/blocks/edit/da-prepare/actions/target/utils.test.js
@@ -1,0 +1,58 @@
+import { expect } from '@esm-bundle/chai';
+import { setNx, getNx2Api } from '../../../../../../../scripts/utils.js';
+
+setNx('/test/fixtures/nx', { hostname: 'example.com' });
+
+const { savePreview } = await import('../../../../../../../blocks/edit/da-prepare/actions/target/utils.js');
+
+describe('target/utils savePreview', () => {
+  it('Strips the .html extension before previewing', async () => {
+    const { aem } = await getNx2Api();
+    const origPreview = aem.preview;
+    const previewed = [];
+    aem.preview = (path) => {
+      previewed.push(path);
+      return { ok: true, json: () => ({ preview: { url: 'https://main--site--org.aem.page/testpage' } }) };
+    };
+
+    try {
+      const result = await savePreview('org', 'site', '/testpage.html');
+
+      expect(previewed).to.deep.equal(['/org/site/testpage']);
+      expect(result.preview.url).to.equal('https://main--site--org.aem.page/testpage');
+    } finally {
+      aem.preview = origPreview;
+    }
+  });
+
+  it('Leaves extensionless paths untouched', async () => {
+    const { aem } = await getNx2Api();
+    const origPreview = aem.preview;
+    const previewed = [];
+    aem.preview = (path) => {
+      previewed.push(path);
+      return { ok: true, json: () => ({ preview: { url: 'https://main--site--org.aem.page/folder' } }) };
+    };
+
+    try {
+      await savePreview('org', 'site', '/folder');
+
+      expect(previewed).to.deep.equal(['/org/site/folder']);
+    } finally {
+      aem.preview = origPreview;
+    }
+  });
+
+  it('Returns an error when the preview fails', async () => {
+    const { aem } = await getNx2Api();
+    const origPreview = aem.preview;
+    aem.preview = () => ({ ok: false });
+
+    try {
+      const result = await savePreview('org', 'site', '/testpage.html');
+      expect(result).to.deep.equal({ error: 'Couldn\'t preview.' });
+    } finally {
+      aem.preview = origPreview;
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1268

## Problem

The Adobe Target integration ("send to Target") was broken because it sent a `.html`-suffixed path to helix-admin's preview API, which rejects it with a 400. `handleSend` calls `savePreview(org, site, path)` where `details.path` is `/mypage.html`; `savePreview` built `/org/site/mypage.html` and passed it straight to `aem.preview()`, so the preview call — and therefore the whole flow — failed with `Couldn't preview.`

This is the same root cause as the earlier unpublish fix (#1258).

## Fix

Strip the `.html` extension when building the path in `savePreview`, mirroring the `\.html$` regex from #1258. Done at the cause inside `savePreview` (rather than the call site) so any future caller is protected too, while keeping the `(org, site, path)` signature intact.

## Tests

Added `test/unit/blocks/edit/da-prepare/actions/target/utils.test.js` covering:
- `.html` is stripped before `aem.preview`
- extensionless paths are left untouched
- the error path on a failed preview

All target unit tests pass and lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)