### PR TITLE
HLX6 cleanup: saveToDa, saveDaVersion, getSidekickConfig, aemAdmin

### DIFF
--- a/blocks/browse/da-list/da-list.js
+++ b/blocks/browse/da-list/da-list.js
@@ -3,12 +3,12 @@ import { isFavorite, toggleFavorite } from '../shared/favorites.js';
 import { getNx, getNx2Api, sanitizePathParts } from '../../../scripts/utils.js';
 import {
   aemAction,
-  saveDaVersion,
   getExistingSchedule,
   fetchDaConfigs,
   getFirstSheet,
   initIms,
 } from '../../shared/utils.js';
+import { createVersion } from '../../shared/version/version-actions.js';
 
 import '../da-list-item/da-list-item.js';
 
@@ -665,7 +665,7 @@ export default class DaList extends LitElement {
       } else if (json.error) {
         this._itemErrors.push({ ...item, message: json.error?.message || `Couldn't ${action} item` });
       } else {
-        if (!MEDIA_EXTS.has(item.ext)) saveDaVersion(item.path, `${verb}ed`);
+        if (!MEDIA_EXTS.has(item.ext)) createVersion(item.path, `${verb}ed`);
         results.push({ name: item.name, url: json[urlKey]?.url });
       }
       remaining -= 1;

--- a/blocks/edit/da-title/da-title.js
+++ b/blocks/edit/da-title/da-title.js
@@ -5,7 +5,8 @@ import {
   saveDaConfig,
   getAemHrefs,
 } from '../utils/helpers.js';
-import { delay, fetchDaConfigs, getFirstSheet, aemAction, saveDaVersion } from '../../shared/utils.js';
+import { delay, fetchDaConfigs, getFirstSheet, aemAction } from '../../shared/utils.js';
+import { createVersion } from '../../shared/version/version-actions.js';
 import inlinesvg from '../../shared/inlinesvg.js';
 import getSheet from '../../shared/sheet.js';
 
@@ -323,8 +324,8 @@ export default class DaTitle extends LitElement {
     }
 
     if (view === 'edit' || view === 'sheet' || view === 'form') {
-      if (action === 'publish') saveDaVersion(fullpath, 'Published');
-      else if (action === 'preview') saveDaVersion(fullpath, 'Previewed');
+      if (action === 'publish') createVersion(fullpath, 'Published');
+      else if (action === 'preview') createVersion(fullpath, 'Previewed');
     }
     this._isSending = false;
   }

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -204,23 +204,6 @@ export async function getExistingSchedule(org, site, path) {
 }
 
 /**
- * Creates a version snapshot for a path. Failures are swallowed and logged
- * since versioning is a best-effort side effect of saving, not a save blocker.
- * @param {string} pathname - The path to version.
- * @param {string} [label] - The version comment/label.
- * @returns {Promise<void>}
- */
-export async function saveDaVersion(pathname, label = 'Published') {
-  try {
-    const { versions } = await getNx2Api();
-    await versions.create(pathname, { comment: label });
-  } catch {
-    // eslint-disable-next-line no-console
-    console.log(`Error creating auto version (${label}).`);
-  }
-}
-
-/**
  * Runs the preview-then-publish flow for a path. Always previews first;
  * when publishing, checks for an existing snapshot schedule unless skipped
  * and lets the caller decide whether to proceed via `opts.onScheduled`.

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -129,21 +129,6 @@ export function etcFetch(href, api, options) {
   return fetch(url, opts);
 }
 
-export async function aemAdmin(path, api, method = 'POST') {
-  const [owner, repo, ...parts] = path.slice(1).split('/');
-  const name = parts.pop() || repo || owner;
-  parts.push(name.replace('.html', ''));
-  const aemUrl = `https://admin.hlx.page/${api}/${owner}/${repo}/main/${parts.join('/')}`;
-  const resp = await daFetch(aemUrl, { method });
-  if (method === 'DELETE' && resp.status === 204) return {};
-  if (!resp.ok) return undefined;
-  try {
-    return resp.json();
-  } catch {
-    return undefined;
-  }
-}
-
 /* eslint-disable max-len */
 /**
  * [admin] Unable to preview '.../page.md': source contains large image: error fetching resource at http.../hello: Image 1 exceeds allowed limit of 10.00MB

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -168,9 +168,12 @@ export function parseAemError(xError) {
   return xError.replace('[admin] ', '');
 }
 
-// `action` is the admin API namespace: 'preview' or 'live' (the latter is the
-// admin API's name for publish). Routes through nx's `aem` API, which detects
-// HLX6 vs legacy (via isHlx6) and calls the correct endpoint for the org/site.
+/**
+ * Publishes or previews a path via AEM.
+ * @param {string} path - The path to save.
+ * @param {'live'|'preview'} action - 'live' publishes, anything else previews.
+ * @returns {Promise<object>} The AEM response body, or an { error } object on failure.
+ */
 export async function saveToAem(path, action) {
   const { aem } = await getNx2Api();
   const aemPath = path.toLowerCase();
@@ -200,6 +203,13 @@ export async function getExistingSchedule(org, site, path) {
   }
 }
 
+/**
+ * Creates a version snapshot for a path. Failures are swallowed and logged
+ * since versioning is a best-effort side effect of saving, not a save blocker.
+ * @param {string} pathname - The path to version.
+ * @param {string} [label] - The version comment/label.
+ * @returns {Promise<void>}
+ */
 export async function saveDaVersion(pathname, label = 'Published') {
   try {
     const { versions } = await getNx2Api();
@@ -210,6 +220,18 @@ export async function saveDaVersion(pathname, label = 'Published') {
   }
 }
 
+/**
+ * Runs the preview-then-publish flow for a path. Always previews first;
+ * when publishing, checks for an existing snapshot schedule unless skipped
+ * and lets the caller decide whether to proceed via `opts.onScheduled`.
+ * @param {string} path - The path to act on.
+ * @param {'preview'|'live'} action - 'preview' stops after preview; 'live' also publishes.
+ * @param {object} [opts]
+ * @param {boolean} [opts.skipSchedule] - Skip the existing-schedule check before publishing.
+ * @param {(schedule: object) => Promise<boolean>|boolean} [opts.onScheduled] - Called with the
+ *   existing schedule when one is found; return true to proceed with publish anyway.
+ * @returns {Promise<object>} The AEM response, `{ cancelled: true }`, or an `{ error }` object.
+ */
 export async function aemAction(path, action, opts = {}) {
   const previewJson = await saveToAem(path, 'preview');
   if (previewJson.error) return previewJson;
@@ -339,11 +361,19 @@ export async function checkLockdownImages(owner) {
   }
 }
 
+/**
+ * Fetches org and (optionally) site configs, caching the in-flight/resolved
+ * promises by path so repeated calls for the same org/site reuse one request
+ * instead of firing duplicate fetches.
+ * @param {object} params
+ * @param {string} params.org - The org to fetch config for.
+ * @param {string} [params.site] - The site to also fetch config for.
+ * @returns {Promise[]} `[orgConfigPromise]`, or `[orgConfigPromise, siteConfigPromise]`
+ *   when `site` is given; `[Promise.resolve(null)]` when `org` is missing.
+ */
 export const fetchDaConfigs = (() => {
   const configCache = {};
 
-  // getNx2Api's config.get is isHlx6-aware: it reads from api.aem.live for a
-  // migrated org/site, and falls back to admin.da.live otherwise.
   const fetchConfig = async (org, site) => {
     const { config: configApi } = await getNx2Api();
     const resp = await configApi.get({ org, site });

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -2,7 +2,8 @@ import { DA_ORIGIN, CON_ORIGIN, DA_ETC_ORIGIN, getLivePreviewUrl, AEM_ORIGIN } f
 import { getNx, getNx2Api } from '../../scripts/utils.js';
 
 const DA_ORIGINS = ['https://da.live', 'https://da.page', 'https://admin.da.live', 'https://admin.da.page', 'https://stage-admin.da.live', 'https://content.da.live', 'http://localhost:8787'];
-const AEM_ORIGINS = ['https://admin.hlx.page', 'https://admin.aem.live'];
+const AEM_API_ORIGIN = 'https://api.aem.live';
+const AEM_ORIGINS = ['https://admin.hlx.page', 'https://admin.aem.live', AEM_API_ORIGIN];
 const ETC_ORIGINS = ['https://stage-content.da.live', 'https://helix-snapshot-scheduler-ci.adobeaem.workers.dev', 'https://helix-snapshot-scheduler-prod.adobeaem.workers.dev'];
 const ALLOWED_TOKEN = [...DA_ORIGINS, ...AEM_ORIGINS, ...ETC_ORIGINS];
 
@@ -387,10 +388,16 @@ export const fetchDaConfigs = (() => {
 export const getSidekickConfig = (() => {
   const configCache = {};
 
+  // Sidekick config now lives on api.aem.live for every site (legacy DA and
+  // HLX6 alike) — no isHlx6 branch needed here.
   const fetchConfig = async (org, site) => {
-    const aemPath = `/${org}/${site}/config.json`;
-
-    return aemAdmin(aemPath, 'sidekick', 'GET');
+    const resp = await daFetch(`${AEM_API_ORIGIN}/${org}/sites/${site}/sidekick`, { method: 'GET' });
+    if (!resp.ok) return undefined;
+    try {
+      return await resp.json();
+    } catch {
+      return undefined;
+    }
   };
 
   return ({ org, site }) => {

--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -267,7 +267,7 @@ export async function saveToDa({ path, formData, blob, props, preview = false })
   const daResp = await daFetch(`${DA_ORIGIN}/source${path}`, opts);
   if (!daResp.ok) return undefined;
   if (!preview) return undefined;
-  return aemAdmin(path, 'preview');
+  return aemAction(path, 'preview');
 }
 
 export const getSheetByIndex = (json, index = 0) => {

--- a/test/unit/blocks/browse/da-list/da-list.test.js
+++ b/test/unit/blocks/browse/da-list/da-list.test.js
@@ -814,10 +814,10 @@ describe('DaList helpers', () => {
       return versioned;
     }
 
-    // flush fire-and-forget saveDaVersion (not awaited in callback)
+    // flush fire-and-forget createVersion (not awaited in callback)
     const flush = () => new Promise((r) => { setTimeout(r, 0); });
 
-    it('Calls saveDaVersion for html items', async () => {
+    it('Calls createVersion for html items', async () => {
       const versioned = stubVersionCreate();
       const el = makeList();
       el._selectedItems = [{ name: 'page', ext: 'html', path: '/org/site/page.html' }];
@@ -827,7 +827,7 @@ describe('DaList helpers', () => {
       expect(versioned.length).to.equal(1);
     });
 
-    it('Calls saveDaVersion for json items', async () => {
+    it('Calls createVersion for json items', async () => {
       const versioned = stubVersionCreate();
       const el = makeList();
       el._selectedItems = [{ name: 'data', ext: 'json', path: '/org/site/data.json' }];
@@ -837,7 +837,7 @@ describe('DaList helpers', () => {
       expect(versioned.length).to.equal(1);
     });
 
-    it('Skips saveDaVersion for svg items', async () => {
+    it('Skips createVersion for svg items', async () => {
       const versioned = stubVersionCreate();
       const el = makeList();
       el._selectedItems = [{ name: 'icon', ext: 'svg', path: '/org/site/icon.svg' }];
@@ -847,7 +847,7 @@ describe('DaList helpers', () => {
       expect(versioned.length).to.equal(0);
     });
 
-    it('Skips saveDaVersion for pdf items', async () => {
+    it('Skips createVersion for pdf items', async () => {
       const versioned = stubVersionCreate();
       const el = makeList();
       el._selectedItems = [{ name: 'doc', ext: 'pdf', path: '/org/site/doc.pdf' }];
@@ -857,7 +857,7 @@ describe('DaList helpers', () => {
       expect(versioned.length).to.equal(0);
     });
 
-    it('Skips saveDaVersion for image items (png, jpg, gif, webp)', async () => {
+    it('Skips createVersion for image items (png, jpg, gif, webp)', async () => {
       const versioned = stubVersionCreate();
       const el = makeList();
       el._selectedItems = [

--- a/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
@@ -211,9 +211,6 @@ describe('extensionToPanelView', () => {
   });
 });
 
-// getPreviewStatus now goes through getNx2Api's isHlx6-aware status.get, not the legacy
-// admin.hlx.page-only aemAdmin() helper. A real Response keeps isHlx6's ping (which fires
-// before the actual status call) safe regardless of route.
 describe('getPreviewStatus', () => {
   let savedFetch;
 

--- a/test/unit/blocks/edit/utils/helpers.test.js
+++ b/test/unit/blocks/edit/utils/helpers.test.js
@@ -24,10 +24,7 @@ const {
   htmlToProse,
 } = await import('../../../../../blocks/edit/utils/helpers.js');
 
-const {
-  saveToAem,
-  saveDaVersion,
-} = await import('../../../../../blocks/shared/utils.js');
+const { saveToAem } = await import('../../../../../blocks/shared/utils.js');
 
 // Skip the api.js hlx6 upgrade probe so source/config URLs stay on DA_ADMIN.
 const skipPing = (handler) => async (url, opts) => {
@@ -741,59 +738,6 @@ describe('saveDaConfig', () => {
     expect(typeof config).to.equal('string');
     const parsed = JSON.parse(config);
     expect(parsed.data).to.deep.equal([{ k: 'a', v: '1' }]);
-  });
-});
-
-describe('saveDaVersion', () => {
-  let savedFetch;
-  beforeEach(() => { savedFetch = window.fetch; });
-  afterEach(() => { window.fetch = savedFetch; });
-
-  it('POSTs the label as a JSON body and swallows errors', async () => {
-    let captured;
-    window.fetch = (url, opts) => {
-      captured = { url, opts };
-      return Promise.resolve(new Response('', { status: 200 }));
-    };
-    await saveDaVersion('/org/site/page', 'My Label');
-    expect(captured.url).to.contain('/versionsource/org/site/page');
-    expect(captured.opts.method).to.equal('POST');
-    expect(captured.opts.body).to.equal(JSON.stringify({ label: 'My Label' }));
-  });
-
-  it('Defaults the label to "Published"', async () => {
-    let captured;
-    window.fetch = (url, opts) => {
-      captured = { url, opts };
-      return Promise.resolve(new Response('', { status: 200 }));
-    };
-    await saveDaVersion('/org/site/page');
-    expect(captured.opts.body).to.equal(JSON.stringify({ label: 'Published' }));
-  });
-
-  it('Sends comment as a query param with no body on hlx6', async () => {
-    let captured;
-    window.fetch = (url, opts) => {
-      const u = String(url);
-      // The hlx6 upgrade probe — advertise the upgrade so the call routes to AEM.
-      if (u.startsWith('https://admin.hlx.page/ping')) {
-        return Promise.resolve(new Response('', {
-          status: 200,
-          headers: { 'x-api-upgrade-available': 'da-admin' },
-        }));
-      }
-      captured = { url: u, opts };
-      return Promise.resolve(new Response('', { status: 201 }));
-    };
-    try {
-      await saveDaVersion('/hlx6org/hlx6site/page', 'My Label');
-      expect(captured.url).to.contain('/hlx6org/sites/hlx6site/source/page/.versions');
-      expect(captured.url).to.contain('comment=My+Label');
-      expect(captured.opts.method).to.equal('POST');
-      expect(captured.opts.body).to.equal(undefined);
-    } finally {
-      window.localStorage.removeItem('hlx6-upgrade');
-    }
   });
 });
 

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -564,7 +564,7 @@ describe('getSidekickConfig', () => {
   it('Returns preview and prod when both hosts are available', async () => {
     const org = 'org1';
     const site = 'site1';
-    const configUrl = `https://admin.hlx.page/sidekick/${org}/${site}/main/config.json`;
+    const configUrl = `https://api.aem.live/${org}/sites/${site}/sidekick`;
 
     const mockFetch = (url) => {
       if (url === configUrl) {
@@ -592,7 +592,7 @@ describe('getSidekickConfig', () => {
   it('Returns object when only previewHost is available', async () => {
     const org = 'org2';
     const site = 'site2';
-    const configUrl = `https://admin.hlx.page/sidekick/${org}/${site}/main/config.json`;
+    const configUrl = `https://api.aem.live/${org}/sites/${site}/sidekick`;
 
     const mockFetch = (url) => {
       if (url === configUrl) {
@@ -614,7 +614,7 @@ describe('getSidekickConfig', () => {
   it('Returns object when only host is available', async () => {
     const org = 'org3';
     const site = 'site3';
-    const configUrl = `https://admin.hlx.page/sidekick/${org}/${site}/main/config.json`;
+    const configUrl = `https://api.aem.live/${org}/sites/${site}/sidekick`;
 
     const mockFetch = (url) => {
       if (url === configUrl) {
@@ -636,7 +636,7 @@ describe('getSidekickConfig', () => {
   it('Returns empty object when neither previewHost nor host is available', async () => {
     const org = 'org4';
     const site = 'site4';
-    const configUrl = `https://admin.hlx.page/sidekick/${org}/${site}/main/config.json`;
+    const configUrl = `https://api.aem.live/${org}/sites/${site}/sidekick`;
 
     const mockFetch = (url) => {
       if (url === configUrl) {
@@ -658,7 +658,7 @@ describe('getSidekickConfig', () => {
   it('Returns undefined when fetch fails', async () => {
     const org = 'org5';
     const site = 'site5';
-    const configUrl = `https://admin.hlx.page/sidekick/${org}/${site}/main/config.json`;
+    const configUrl = `https://api.aem.live/${org}/sites/${site}/sidekick`;
 
     const mockFetch = (url) => {
       if (url === configUrl) {

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -4,7 +4,6 @@ import { DA_ORIGIN } from '../../../../blocks/shared/constants.js';
 import {
   daFetch,
   etcFetch,
-  aemAdmin,
   aemAction,
   saveToDa,
   getSheetByIndex,
@@ -400,63 +399,6 @@ describe('etcFetch', () => {
     } finally {
       window.fetch = savedFetch;
     }
-  });
-});
-
-describe('aemAdmin', () => {
-  let savedFetch;
-  let savedLocalStorage;
-
-  beforeEach(() => {
-    savedFetch = window.fetch;
-    savedLocalStorage = window.localStorage.getItem('nx-ims');
-    window.localStorage.removeItem('nx-ims');
-  });
-
-  afterEach(() => {
-    window.fetch = savedFetch;
-    if (savedLocalStorage) {
-      window.localStorage.setItem('nx-ims', savedLocalStorage);
-    } else {
-      window.localStorage.removeItem('nx-ims');
-    }
-  });
-
-  it('Constructs correct AEM admin URL from path', async () => {
-    let capturedUrl;
-    window.fetch = (url) => {
-      capturedUrl = url;
-      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
-    };
-
-    await aemAdmin('/owner/repo/folder/page.html', 'preview');
-    expect(capturedUrl).to.equal('https://admin.hlx.page/preview/owner/repo/main/folder/page');
-  });
-
-  it('Strips .html extension from name', async () => {
-    let capturedUrl;
-    window.fetch = (url) => {
-      capturedUrl = url;
-      return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }));
-    };
-
-    await aemAdmin('/owner/repo/test.html', 'preview');
-    expect(capturedUrl).to.include('/test');
-    expect(capturedUrl).not.to.include('.html');
-  });
-
-  it('Returns empty object for DELETE with 204', async () => {
-    window.fetch = () => Promise.resolve(new Response(null, { status: 204 }));
-
-    const result = await aemAdmin('/owner/repo/page', 'preview', 'DELETE');
-    expect(result).to.deep.equal({});
-  });
-
-  it('Returns undefined when response is not ok', async () => {
-    window.fetch = () => Promise.resolve(new Response('error', { status: 500 }));
-
-    const result = await aemAdmin('/owner/repo/page', 'preview');
-    expect(result).to.equal(undefined);
   });
 });
 

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -7,7 +7,6 @@ import {
   aemAdmin,
   aemAction,
   saveToDa,
-  saveDaVersion,
   getSheetByIndex,
   getSheetByName,
   getFirstSheet,
@@ -753,32 +752,6 @@ describe('fetchDaConfigs', () => {
 
     const [orgConfig] = await Promise.all(fetchDaConfigs({ org: 'cfgfail' }));
     expect(orgConfig).to.deep.equal({ error: 'Error loading /cfgfail', status: 500 });
-  });
-});
-
-describe('saveDaVersion', () => {
-  let savedFetch;
-  beforeEach(() => { savedFetch = window.fetch; });
-  afterEach(() => { window.fetch = savedFetch; });
-
-  it('POSTs to the versionsource endpoint with the correct path and label', async () => {
-    let capturedUrl;
-    let capturedOpts;
-    window.fetch = (url, opts) => {
-      capturedUrl = url;
-      capturedOpts = opts;
-      return Promise.resolve(new Response('ok', { status: 200 }));
-    };
-
-    await saveDaVersion('/org/site/doc', 'Previewed');
-    expect(capturedUrl).to.include('/versionsource/org/site/doc');
-    expect(capturedOpts.method).to.equal('POST');
-    expect(JSON.parse(capturedOpts.body)).to.deep.equal({ label: 'Previewed' });
-  });
-
-  it('Silently swallows fetch errors', async () => {
-    window.fetch = () => Promise.reject(new Error('network error'));
-    await saveDaVersion('/org/site/doc', 'Published');
   });
 });
 

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { setNx } from '../../../../scripts/utils.js';
+import { DA_ORIGIN } from '../../../../blocks/shared/constants.js';
 import {
   daFetch,
   etcFetch,
@@ -517,6 +518,46 @@ describe('saveToDa', () => {
     expect(capturedBody).to.be.instanceOf(FormData);
     expect(capturedBody.get('data')).to.be.instanceOf(Blob);
     expect(capturedBody.get('props')).to.equal(JSON.stringify(props));
+  });
+
+  // preview:true now goes through aemAction (getNx2Api's isHlx6-aware aem.preview),
+  // not the legacy aemAdmin() helper.
+  it('Runs the AEM preview via aemAction when preview is true', async () => {
+    const org = 'savetodaorg';
+    const site = 'savetodasite';
+    const calls = [];
+    window.fetch = async (url, opts) => {
+      const href = String(url);
+      calls.push({ url: href, opts });
+      if (href.includes(`${DA_ORIGIN}/source/`)) return new Response('ok', { status: 200 });
+      if (href.includes('/ping/')) return new Response('', { status: 200 });
+      if (href.includes(`/preview/${org}/${site}/`)) {
+        return new Response(JSON.stringify({ preview: { status: 200 } }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    };
+
+    const result = await saveToDa({ path: `/${org}/${site}/page`, preview: true });
+
+    expect(result).to.deep.equal({ preview: { status: 200 } });
+    const previewCall = calls.find((c) => c.url.includes(`/preview/${org}/${site}/`));
+    expect(previewCall, 'AEM preview was not called').to.exist;
+    expect(previewCall.opts.method).to.equal('POST');
+  });
+
+  it('Returns an error object when the AEM preview fails', async () => {
+    const org = 'savetodaerr';
+    const site = 'savetodaerr';
+    window.fetch = async (url) => {
+      const href = String(url);
+      if (href.includes(`${DA_ORIGIN}/source/`)) return new Response('ok', { status: 200 });
+      if (href.includes('/ping/')) return new Response('', { status: 200 });
+      return new Response('', { status: 500 });
+    };
+
+    const result = await saveToDa({ path: `/${org}/${site}/page`, preview: true });
+    expect(result.error).to.be.an('object');
+    expect(result.error.action).to.equal('preview');
   });
 });
 


### PR DESCRIPTION
Follow-up cleanup for the HLX6 migration in `blocks/shared/utils.js`:

- `saveToDa` now previews via `aemAction` instead of legacy `aemAdmin`
- Removed `saveDaVersion`, duplicate of `createVersion` (shared/version/version-actions.js) — callers switched to `createVersion`
- `getSidekickConfig` now fetches `https://api.aem.live/{org}/sites/{site}/sidekick` directly (same endpoint for legacy DA and HLX6)
- Removed now-dead `aemAdmin` helper

Test:
- https://h6clean--da-live--adobe.aem.live/#/exp-workspace/frescopa