### PR TITLE
fix(target): send AEM site token when fetching previewed content

### DIFF
--- a/blocks/edit/da-prepare/actions/target/utils.js
+++ b/blocks/edit/da-prepare/actions/target/utils.js
@@ -1,5 +1,5 @@
 import { DOMParser as ProseParser } from 'da-y-wrapper';
-import { etcFetch, getFirstSheet } from '../../../../shared/utils.js';
+import { etcFetch, getAemSiteToken, getFirstSheet } from '../../../../shared/utils.js';
 import { getNx2Api } from '../../../../../scripts/utils.js';
 import { deleteOffer, getAccessToken, getOffer, saveOffer } from './api.js';
 
@@ -157,7 +157,12 @@ export async function savePreview(org, site, path) {
 }
 
 export async function sendToTarget(org, site, name, aemPath, displayName, existingOfferId) {
-  const aemResp = await etcFetch(`${aemPath}?nocache=${Date.now()}`, 'cors');
+  const opts = {};
+  try {
+    const { siteToken } = await getAemSiteToken({ org, site });
+    if (siteToken) opts.headers = { Authorization: `token ${siteToken}` };
+  } catch { /* fall back to an unauthenticated fetch */ }
+  const aemResp = await etcFetch(`${aemPath}?nocache=${Date.now()}`, 'cors', opts);
   if (!aemResp.ok) return { error: 'Could not fetch from AEM.' };
   const html = await aemResp.text();
   const dom = new DOMParser().parseFromString(html, 'text/html');

--- a/test/unit/blocks/edit/da-prepare/actions/target/utils.test.js
+++ b/test/unit/blocks/edit/da-prepare/actions/target/utils.test.js
@@ -3,7 +3,7 @@ import { setNx, getNx2Api } from '../../../../../../../scripts/utils.js';
 
 setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
-const { savePreview } = await import('../../../../../../../blocks/edit/da-prepare/actions/target/utils.js');
+const { savePreview, sendToTarget } = await import('../../../../../../../blocks/edit/da-prepare/actions/target/utils.js');
 
 describe('target/utils savePreview', () => {
   it('Strips the .html extension before previewing', async () => {
@@ -54,5 +54,46 @@ describe('target/utils savePreview', () => {
     } finally {
       aem.preview = origPreview;
     }
+  });
+});
+
+describe('target/utils sendToTarget', () => {
+  let savedFetch;
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  it('Fetches the previewed content through the da-etc cors proxy with a cache-buster', async () => {
+    let captured;
+    window.fetch = (url, opts) => {
+      captured = { url, opts };
+      // A locked-down preview host returns 401; the proxy relays it through.
+      return Promise.resolve(new Response('access-not-allowed', { status: 401 }));
+    };
+
+    const aemPath = 'https://main--site--org.aem.page/demo';
+    const result = await sendToTarget('org', 'send1', 'name', aemPath, 'Joe');
+
+    expect(captured.url).to.contain('/cors?url=');
+    expect(captured.url).to.contain(encodeURIComponent(aemPath));
+    expect(captured.url).to.contain(encodeURIComponent('nocache='));
+    // A 401 from the delivery host surfaces as a clean error, not a hang/throw.
+    expect(result).to.deep.equal({ error: 'Could not fetch from AEM.' });
+  });
+
+  it('Falls back to an unauthenticated fetch when the site-token exchange fails', async () => {
+    // In this test env initIms() resolves to undefined, so getAemSiteToken
+    // rejects. sendToTarget must swallow that and still attempt the fetch
+    // rather than throwing (which would leave the dialog hung).
+    let captured;
+    window.fetch = (url, opts) => {
+      captured = { url, opts };
+      return Promise.resolve(new Response('nope', { status: 401 }));
+    };
+
+    const result = await sendToTarget('org', 'send2', 'name', 'https://main--site--org.aem.page/p', 'Joe');
+
+    // No Authorization header was attached (token exchange failed → fallback).
+    expect(captured.opts?.headers?.Authorization).to.equal(undefined);
+    expect(result).to.deep.equal({ error: 'Could not fetch from AEM.' });
   });
 });


### PR DESCRIPTION
## Problem

"Send to Adobe Target" (Prepare menu) previews the page, then reads the rendered content back from the delivery preview host (`*.aem.page`) through the `da-etc` `/cors` proxy so it can extract `main` and create the Target offer.

That read went out with **no authentication**. For access-controlled sites the preview host returns `401 access-not-allowed`, the proxy relays the 401, and the send fails with `Could not fetch from AEM.` — even though the preview step itself succeeds (preview goes through `admin.hlx.page`/`admin.aem.live` with a Bearer token; reading `.aem.page` back does not).

Verified against a locked-down site:

```
GET https://main--da-author-test--elilillyco.aem.page/demo
HTTP/2 401
x-error: access-not-allowed
```

…and the same 401 comes back through `da-etc.adobeaem.workers.dev/cors?url=…`.

## Fix

Attach an AEM **site token** to the content fetch in `sendToTarget`:

```js
const { siteToken } = await getAemSiteToken({ org, site });
if (siteToken) opts.headers = { Authorization: `token ${siteToken}` };
```

This mirrors the already-shipped **preflight link checker** ([`preflight/views/link.js`](https://github.com/adobe/da-live/blob/main/blocks/edit/da-prepare/actions/preflight/views/link.js)), which hits the same `da-etc` proxy against preview URLs and authorizes because it sends this exact header. The `da-etc` worker forwards `Authorization` upstream and the locked-down `.aem.page` host accepts the site token.

The token exchange is wrapped in a `try/catch`: on failure it falls back to an unauthenticated fetch, so public sites keep working and locked sites surface the clean `Could not fetch from AEM.` error instead of throwing and leaving the dialog stuck on "Sending to Target…".

## Testing

- `npm run lint` — clean.
- Added a `sendToTarget` unit suite (`test/unit/.../target/utils.test.js`): asserts the fetch goes through the `/cors` proxy with a cache-buster and that a 401 yields a clean error, plus that a site-token exchange failure falls back without throwing. All 17 target unit tests pass.

> [!NOTE]
> The *positive* auth-header case isn't unit-asserted: the nx test fixture's `loadIms()` resolves to `undefined`, so `getAemSiteToken` always rejects in the test env, and named ESM imports can't be stubbed here without touching shared fixtures. The header format is copied verbatim from the proven preflight path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)