### PR TITLE
fix(library): stop empty cells appearing when pasting blocks with uneven rows

### DIFF
--- a/blocks/canvas/ew-panel-extensions/helpers.js
+++ b/blocks/canvas/ew-panel-extensions/helpers.js
@@ -43,9 +43,16 @@ function getBlockTableHtml(block) {
 
   rows.forEach((row) => {
     const tr = document.createElement('tr');
-    [...row.children].forEach((col) => {
+    const cells = [...row.children];
+    cells.forEach((col, i) => {
       const td = document.createElement('td');
-      if (row.children.length < maxCols) td.setAttribute('colspan', String(maxCols));
+      // Pad only the last cell so the row's total width equals maxCols.
+      // Spanning every cell (the old behavior) made short multi-cell rows
+      // wider than maxCols, forcing ProseMirror to insert empty cells into
+      // every other row to keep the table rectangular.
+      if (cells.length < maxCols && i === cells.length - 1) {
+        td.setAttribute('colspan', String(maxCols - i));
+      }
       td.innerHTML = col.innerHTML;
       tr.append(td);
     });

--- a/blocks/edit/da-library/helpers/index.js
+++ b/blocks/edit/da-library/helpers/index.js
@@ -56,10 +56,15 @@ function getBlockTableHtml(block) {
   table.append(headerRow);
   rows.forEach((row) => {
     const tr = document.createElement('tr');
-    [...row.children].forEach((col) => {
+    const cells = [...row.children];
+    cells.forEach((col, i) => {
       const td = document.createElement('td');
-      if (row.children.length < maxCols) {
-        td.setAttribute('colspan', maxCols);
+      // Pad only the last cell so the row's total width equals maxCols.
+      // Spanning every cell (the old behavior) made short multi-cell rows
+      // wider than maxCols, forcing ProseMirror to insert empty cells into
+      // every other row to keep the table rectangular.
+      if (cells.length < maxCols && i === cells.length - 1) {
+        td.setAttribute('colspan', maxCols - i);
       }
       td.innerHTML = col.innerHTML;
       tr.append(td);

--- a/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
+++ b/test/unit/blocks/canvas/ew-panel-extensions/helpers.test.js
@@ -241,6 +241,32 @@ describe('EW panel helpers transformBlock', () => {
     expect(variants[0].dom.querySelector('.library-metadata')).to.be.null;
   });
 
+  it('Pads only the last cell of short rows so no row exceeds maxCols', async () => {
+    // A block with one wide row (5 cells) and shorter key/value rows.
+    // The old behavior spanned every cell of a short row to maxCols, making
+    // those rows wider than the grid and forcing ProseMirror to insert empty
+    // cells into every other row.
+    mockHtml(`
+      <body><div>
+        <div class="collection-carousel">
+          <div><div>categoryPath</div><div>a</div><div>b</div><div>c</div><div>d</div></div>
+          <div><div>maxItems</div><div>8</div></div>
+        </div>
+      </div></body>
+    `);
+    const variants = await getBlockVariants('/mock-path');
+    const rows = [...variants[0].dom.querySelectorAll('tr')];
+    const widths = rows.map((tr) => [...tr.children]
+      .reduce((n, td) => n + (parseInt(td.getAttribute('colspan'), 10) || 1), 0));
+    // header + wide row + short row, every one exactly maxCols (5) wide
+    expect(widths).to.deep.equal([5, 5, 5]);
+    // the wide row keeps its 5 cells, the short row keeps exactly 2 (no padding cells)
+    expect(rows[1].children).to.have.lengthOf(5);
+    expect(rows[2].children).to.have.lengthOf(2);
+    // the short row's last cell absorbs the remaining columns
+    expect(rows[2].children[1].getAttribute('colspan')).to.equal('4');
+  });
+
   it('Uses library-metadata Name to override the derived name', async () => {
     mockHtml(`
       <body><div>


### PR DESCRIPTION
## What

Fixes extra empty cells being inserted into the ProseMirror document when pasting a library block whose rows have uneven column counts (e.g. [collection-carousel](https://content.da.live/gsusa/gs-ecom-shop-eds/tools/library/blocks/collection-carousel), which has a 5-column `categoryPath` row alongside 2-column key/value rows).

## Why

`getBlockTableHtml` built the editing table by giving **every** cell in a short row `colspan=maxCols`. For a block whose widest row has 5 cells, each 2-cell config row (`maxItems | 8`, etc.) got two `colspan=5` cells → a 10-column-wide row. ProseMirror normalizes a table to a rectangular grid at the widest row, so it **inserted empty cells** into every 5-wide row. On save, `convertBlocks` (prose2aem) emits one `<div>` per `<td>`, so those inserted cells serialized to empty divs and corrupted the block.

## Fix

Pad only the **last** cell of a short row (`colspan = maxCols - i`) so each row totals exactly `maxCols`. Single-cell rows still span the full width (unchanged). Rows now stay rectangular, so ProseMirror inserts nothing.

## Notes for reviewers

- The same helper is duplicated in two places (the canvas copy is a fork noted as "ported from da-live"), so the identical bug was fixed in both:
  - `blocks/edit/da-library/helpers/index.js` — the reported library-paste path
  - `blocks/canvas/ew-panel-extensions/helpers.js` — canvas panel copy
- We discussed consolidating the two into one implementation but chose not to: their orchestration has genuinely diverged (ProseMirror-node vs raw-DOM output, metadata handling, and fetch/URL-rewrite behavior), so only the pure DOM builders overlap.
- Added a regression test asserting every row spans exactly `maxCols` and no padding cells are added.

## Testing

- `npx wtr` on the two affected suites: 75 passing.
- eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)