### PR TITLE
feat: let canvas extensions select a section

### DIFF
--- a/blocks/canvas/editor-utils/blocks.js
+++ b/blocks/canvas/editor-utils/blocks.js
@@ -1,4 +1,4 @@
-import { DOMParser as PMDOMParser, NodeSelection } from 'da-y-wrapper';
+import { DOMParser as PMDOMParser, NodeSelection, TextSelection } from 'da-y-wrapper';
 
 const NON_BLOCK_TABLE_NAMES = new Set(['metadata', 'section metadata', 'section-metadata']);
 
@@ -221,6 +221,36 @@ export function appendBlockRow(view, tablePos, rowDom) {
   const tr = state.tr.insert(tablePos + table.nodeSize - 1, rowNode);
   tr.setSelection(NodeSelection.create(tr.doc, tablePos));
   view.dispatch(tr.scrollIntoView());
+}
+
+/** Doc range of each section, split on horizontal rules (see deleteSection). */
+export function getSectionRanges(view) {
+  const { doc, schema } = view.state;
+  const ranges = [];
+  let current = null;
+  doc.forEach((node, offset) => {
+    if (node.type === schema.nodes.horizontal_rule) {
+      current = null;
+      return;
+    }
+    if (!current) {
+      current = { from: offset, to: offset };
+      ranges.push(current);
+    }
+    current.to = offset + node.nodeSize;
+  });
+  return ranges;
+}
+
+/** Select a whole section and scroll it into view. */
+export function selectSection(view, sectionIndex) {
+  if (!view) return false;
+  const range = getSectionRanges(view)[sectionIndex];
+  if (!range) return false;
+  const { tr, doc } = view.state;
+  view.dispatch(tr.setSelection(TextSelection.create(doc, range.from, range.to)).scrollIntoView());
+  view.focus();
+  return true;
 }
 
 export function deleteSection(view, sectionIndex) {

--- a/blocks/canvas/ew-panel-extensions/iframe-protocol.js
+++ b/blocks/canvas/ew-panel-extensions/iframe-protocol.js
@@ -1,4 +1,5 @@
 import { insertText, insertHTML, getEditorSelection } from './helpers.js';
+import { selectSection } from '../editor-utils/blocks.js';
 import { getNx } from '../../../scripts/utils.js';
 import { getPostMessageTargetOrigin, isValidHref } from '../../shared/utils.js';
 
@@ -59,6 +60,12 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
       document.dispatchEvent(
         new CustomEvent(PANEL_EVENT.OPEN, { detail: { section: 'chat', options: { text, autoSend } } }),
       );
+    }
+
+    if (action === 'selectSection') {
+      const ok = editorView ? selectSection(editorView, details?.index) : false;
+      channel.port1.postMessage({ action: 'selectSectionResult', details: { ok } });
+      return;
     }
 
     if (action === 'getSelection') {

--- a/blocks/canvas/ew-panel-extensions/iframe-protocol.js
+++ b/blocks/canvas/ew-panel-extensions/iframe-protocol.js
@@ -1,5 +1,6 @@
 import { insertText, insertHTML, getEditorSelection } from './helpers.js';
 import { selectSection } from '../editor-utils/blocks.js';
+import { canvasBus } from '../utils/canvas-bus.js';
 import { getNx } from '../../../scripts/utils.js';
 import { getPostMessageTargetOrigin, isValidHref } from '../../shared/utils.js';
 
@@ -62,6 +63,19 @@ export async function setupIframeChannel({ iframe, hashState, getView, onClose }
       );
     }
 
+    // Navigation reuses the outline's own path — same blockIndex address, same
+    // scroll — rather than driving the view directly, so the outline highlight
+    // and doc state stay in step.
+    if (action === 'scrollToBlock') {
+      const ok = Number.isInteger(details?.blockIndex) && details.blockIndex >= 0;
+      if (ok) canvasBus.editorSelectState.emit({ blockIndex: details.blockIndex, source: 'plugin' });
+      channel.port1.postMessage({ action: 'scrollToBlockResult', details: { ok } });
+      return;
+    }
+
+    // Separate from navigation: a section range is the only way to reach section
+    // metadata, which getBlockPositions deliberately excludes from blockIndex.
+    // Leaves a replaceable range under sendHTML.
     if (action === 'selectSection') {
       const ok = editorView ? selectSection(editorView, details?.index) : false;
       channel.port1.postMessage({ action: 'selectSectionResult', details: { ok } });


### PR DESCRIPTION
Closes #1281 — please read that first for the motivation. **Opening this as a draft: it is a concrete suggestion to argue about, not a merge request.** Happy for the team to take the idea and implement it their own way.

## What

Adds one action to the canvas extension channel, `selectSection`, backed by a `selectSection(view, sectionIndex)` helper in `editor-utils/blocks.js`.

## Why

A BYO panel extension can already **read** the document (the handshake hands it `{ org, repo, ref, path }` and the IMS token, so it can fetch page source from `admin.da.live`) and **insert** into it (`sendHTML` → `insertHTML`). What it cannot do is move the selection, and that blocks two things:

1. **Jumping the canvas to a section.** A plugin listing the page's sections cannot scroll the editor to one when clicked, the way `ew-page-outline` does.
2. **Editing an existing section.** `insertHTML` does `replaceRange(from, to, …)`, so the edit loop already works — it just needs something to put the selection on the right node first. Without that the only remaining route is writing source via `admin.da.live` underneath a live collab session, which we are deliberately not doing.

Selecting the whole section rather than only scrolling to it is the load-bearing choice: it delivers the jump **and** leaves a replaceable range under the existing `sendHTML`, so editing needs no second API.

## Implementation notes

- `getSectionRanges` reuses the same "split top-level nodes on `horizontal_rule`" walk that `deleteSection` and `moveSection` already use, rather than introducing a second notion of what a section is.
- Ends in `TextSelection` + `scrollIntoView()` + `view.focus()`, mirroring what the outline path does.
- Replies on the port with `{ action: 'selectSectionResult', details: { ok } }` so a plugin can feature-detect and degrade rather than fail silently — our prototype shows an explicit "this host does not support it yet" note on timeout.
- Nothing here lets a plugin mutate the document outside the editor. Edits still go through ProseMirror and collab.

## Open questions for the team

- **Address shape.** `sectionIndex` is what the existing block/section helpers already speak, but a prose-index or node address would be more general and would survive section reordering better. Happy to change.
- **Naming / placement.** `selectSection` sits alongside the other verbs in `iframe-protocol.js`; if extension capabilities are meant to be gated or declared per plugin, this should probably go through that instead.
- **Should a read-only variant exist** (`scrollToSection`) for plugins that want to navigate without disturbing the user's selection? We did not add one because the replaceable range is the point, but the two uses are separable.

## Testing

Verified against a real customer page in a local canvas: clicking a section in a plugin panel scrolls the editor to it, and a subsequent `getSelection` → edit → `sendHTML` round-trips the section's prose HTML — preserving block content and any non-audience `Style` tokens, and updating only what the plugin intended.

This is driven by an authoring plugin we built for section-scoped personalization; happy to share it if that helps evaluate the shape.
