### PR TITLE
fix(shared): show publish wording in permission error

### DIFF
--- a/blocks/shared/utils.js
+++ b/blocks/shared/utils.js
@@ -217,7 +217,10 @@ export async function aemAction(path, action, opts = {}) {
   }
 
   const liveJson = await saveToAem(path, 'live');
-  if (liveJson.error) return { ...liveJson, error: { ...liveJson.error, action: 'publish' } };
+  if (liveJson.error) {
+    const message = liveJson.error.message.replace(/ live$/, ' publish');
+    return { ...liveJson, error: { ...liveJson.error, action: 'publish', message } };
+  }
   return liveJson;
 }
 

--- a/test/unit/blocks/shared/utils.test.js
+++ b/test/unit/blocks/shared/utils.test.js
@@ -747,6 +747,23 @@ describe('aemAction', () => {
     expect(result.error.message).to.equal('Not authorized to preview');
   });
 
+  it('Returns a publish-worded error message when the live/publish fetch fails', async () => {
+    window.fetch = (url) => {
+      if (url.includes('/preview/')) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ preview: { url: 'https://x.hlx.page/' }, webPath: '/' }),
+          { status: 200 },
+        ));
+      }
+      return Promise.resolve(new Response('forbidden', { status: 403 }));
+    };
+
+    const result = await aemAction('/org/site/doc', 'publish', { skipSchedule: true });
+    expect(result.error).to.exist;
+    expect(result.error.action).to.equal('publish');
+    expect(result.error.message).to.equal('Not authorized to publish');
+  });
+
   it('Returns cancelled when publish is blocked by onScheduled returning false', async () => {
     const scheduleJson = { scheduled: true, scheduledPublish: new Date().toISOString() };
     window.fetch = (url) => {


### PR DESCRIPTION
## Summary
- The publish permission-denied popup showed "Not authorized to live" instead of "Not authorized to publish", because `aemAction()` renamed `error.action` to `publish` but left `error.message` built from the internal `live` action code.
- Now the message is rewritten alongside the action so it reads correctly for users (e.g. via the browse action bar and editor toolbar publish flows).

Fixes #1273

Test:
- https://pubauth--da-live--adobe.aem.live/#/exp-workspace/frescopa

For testing, you need an account which has preview permissions only but no public permissions. The dialog will now look like:
<img width="391" height="248" alt="Screenshot 2026-08-31 at 09 51 56" src="https://github.com/user-attachments/assets/41839f62-82a7-415f-bb45-6100d95d0f4e" />


## Test plan
- [x] Added a unit test in `test/unit/blocks/shared/utils.test.js` reproducing the bug (verified it failed before the fix)
- [x] `npx web-test-runner "test/unit/blocks/shared/utils.test.js"` — 76 passed
- [x] `npx web-test-runner "test/unit/blocks/edit/da-title/**/*.test.js" "test/unit/blocks/browse/**/*.test.js"` — 425 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)