### PR TITLE
fix(e2e): stream stale-resource listing/deletion, raise cleanup timeout

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -6,7 +6,7 @@
     "test:install": "playwright install",
     "test:all": "playwright test --project=chromium --project=firefox --project=webkit --grep-invert \"Delete multiple old pages\"",
     "test:nonauth": "SKIP_AUTH=true playwright test --project=chromium tests/*.spec.js --grep-invert \"Delete multiple old pages\"",
-    "test:cleanup": "playwright test --project=chromium tests/delete.spec.js --grep \"Delete multiple old pages\"",
+    "test:cleanup": "playwright test --project=chromium tests/delete.spec.js --grep \"Delete multiple old pages\" --retries=1",
     "test:ui": "playwright test --project=chromium --ui",
     "test:debug": "playwright test --project=chromium --debug",
     "test:report": "playwright show-report"

--- a/test/e2e/tests/delete.spec.js
+++ b/test/e2e/tests/delete.spec.js
@@ -25,6 +25,7 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
     // only execute this test on chromium
     return;
   }
+  test.setTimeout(5 * 60 * 1000);
 
   let authHeader;
   page.on('request', (request) => {
@@ -40,17 +41,16 @@ test('Delete multiple old pages', async ({ page }, workerInfo) => {
   await expect(page.getByText('pingtest'), 'Precondition').toBeVisible();
   await dismissAlertBanner(page);
 
-  const stale = await listOldTestResources(page, authHeader, TEST_ORG, TEST_SITE, '/tests', MIN_HOURS);
-  if (!stale.length) {
-    console.log('No items to delete');
-    return;
+  const stale = listOldTestResources(page, authHeader, TEST_ORG, TEST_SITE, '/tests', MIN_HOURS);
+  let deletedCount = 0;
+  try {
+    await mapWithConcurrency(stale, DELETE_CONCURRENCY, async ({ path, isFolder }) => {
+      await deleteResource(page, authHeader, TEST_ORG, TEST_SITE, path, { isFolder });
+      deletedCount += 1;
+    });
+  } finally {
+    console.log(deletedCount ? `Deleted ${deletedCount} test files` : 'No items to delete');
   }
-
-  await mapWithConcurrency(stale, DELETE_CONCURRENCY, ({ path, isFolder }) => (
-    deleteResource(page, authHeader, TEST_ORG, TEST_SITE, path, { isFolder })
-  ));
-
-  console.log('Deleted', stale.length, 'test files');
 });
 
 test('Empty out open editors on deleted documents', async ({ browser, page }, workerInfo) => {

--- a/test/e2e/utils/cleanup.js
+++ b/test/e2e/utils/cleanup.js
@@ -26,19 +26,21 @@ export function parseTestUrl(url) {
 
 export const DELETE_CONCURRENCY = 5;
 
-export async function mapWithConcurrency(items, limit, fn) {
-  const results = new Array(items.length);
-  let next = 0;
+export async function mapWithConcurrency(iterable, limit, fn) {
+  const iterator = iterable[Symbol.asyncIterator]();
+  let count = 0;
   async function worker() {
-    while (next < items.length) {
-      const i = next;
-      next += 1;
+    for (;;) {
       // eslint-disable-next-line no-await-in-loop
-      results[i] = await fn(items[i], i);
+      const { value, done } = await iterator.next();
+      if (done) return;
+      count += 1;
+      // eslint-disable-next-line no-await-in-loop
+      await fn(value);
     }
   }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return results;
+  await Promise.all(Array.from({ length: limit }, worker));
+  return count;
 }
 
 function buildSourceUrl(org, site, path) {
@@ -67,13 +69,10 @@ export async function deleteResource(page, authHeader, org, site, path, opts = {
   return page.request.delete(url, { headers, failOnStatusCode: false });
 }
 
-export async function listOldTestResources(page, authHeader, org, site, path, minHours) {
+export async function* listOldTestResources(page, authHeader, org, site, path, minHours) {
   const cutoff = Date.now() - (1000 * 60 * 60 * minHours);
-  const stale = [];
   const listUrl = buildListUrl(org, site, path);
   let token;
-  // Same 500-iteration safety cap as da-list.js's loadAllPages(), so a runaway
-  // continuation token can't spin forever.
   for (let i = 0; i < 500; i += 1) {
     const headers = { Authorization: authHeader };
     if (IS_HLX6_SITE) headers['x-content-source-authorization'] = authHeader;
@@ -85,24 +84,25 @@ export async function listOldTestResources(page, authHeader, org, site, path, mi
       // Surface this instead of quietly returning no stragglers - a failed list
       // call and an empty folder look identical to the caller otherwise.
       if (i === 0) console.warn(`listOldTestResources: list failed (${resp.status()}) for ${listUrl}`);
-      break;
+      return;
     }
 
     // eslint-disable-next-line no-await-in-loop
     const items = await resp.json().catch(() => []);
     if (Array.isArray(items)) {
-      items.forEach((item) => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const item of items) {
         const rawName = item.name ?? item.path?.split('/').pop();
-        if (!rawName) return;
-        const isFolder = IS_HLX6_SITE ? rawName.endsWith('/') : !item.ext;
-        const name = isFolder ? rawName.replace(/\/$/, '') : rawName;
-        const age = getTestResourceAge(name);
-        if (age && age < cutoff) stale.push({ path: `${path}/${name}`, isFolder });
-      });
+        if (rawName) {
+          const isFolder = IS_HLX6_SITE ? rawName.endsWith('/') : !item.ext;
+          const name = isFolder ? rawName.replace(/\/$/, '') : rawName;
+          const age = getTestResourceAge(name);
+          if (age && age < cutoff) yield { path: `${path}/${name}`, isFolder };
+        }
+      }
     }
 
     token = resp.headers()['da-continuation-token'];
-    if (!token) break;
+    if (!token) return;
   }
-  return stale;
 }


### PR DESCRIPTION
Cleanup job consistently timed out because listOldTestResources listed every page before any deletes ran, all inside the default 30s test timeout. It's now an async generator that yields items as pages are fetched, so deletes overlap with listing; test timeout raised to 5min and retries scoped down to 1 for this test.

<!--- Provide a general summary of your changes in the Title above -->

## Description

noticed this job was consistently failing and backlog was growing

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

also seems like this may impact the frequent and consistent failures with PR playright tests timing out. cautiously hoping this better cleanup will help with that.

## How Has This Been Tested?

ran https://github.com/adobe/da-live/actions/runs/33434325504 which deleted many files.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
