### PR TITLE
fix: redirect /edit to /canvas when Experience Workspace is enabled

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -1,6 +1,6 @@
 import getPathDetails from '../shared/pathDetails.js';
 import { contentLogin, livePreviewLogin } from '../shared/utils.js';
-import { getNx, getNx2Api } from '../../scripts/utils.js';
+import { getNx, getNx2Api, getNxEWFlags } from '../../scripts/utils.js';
 
 import './da-title/da-title.js';
 import './da-content/da-content.js';
@@ -40,6 +40,12 @@ function initArea(areaName, details, el) {
 async function setUI(el) {
   const details = getPathDetails();
   if (!details) return;
+
+  const { isEWEnabled } = await getNxEWFlags();
+  if (await isEWEnabled({ org: details.org, site: details.site })) {
+    window.location.href = `/canvas#${details.fullpath}`;
+    return;
+  }
 
   // Warm the hlx6 probe cache up front so createConnection's `await isHlx6(...)`
   // resolves from cache instead of gating the WebSocket on a network round-trip.

--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -41,10 +41,14 @@ async function setUI(el) {
   const details = getPathDetails();
   if (!details) return;
 
-  const { isEWEnabled } = await getNxEWFlags();
-  if (await isEWEnabled({ org: details.org, site: details.site })) {
-    window.location.href = `/canvas#${details.fullpath}`;
-    return;
+  try {
+    const { isEWEnabled } = await getNxEWFlags();
+    if (await isEWEnabled({ org: details.org, site: details.site })) {
+      window.location.href = `/canvas#${details.fullpath}`;
+      return;
+    }
+  } catch {
+    // Flag check unavailable — fall through to the normal editor.
   }
 
   // Warm the hlx6 probe cache up front so createConnection's `await isHlx6(...)`


### PR DESCRIPTION
## Summary
`/edit` now always checks whether Experience Workspace is enabled — either via the user's personal opt-in (the `nx2:ew-user-enabled` localStorage flag) or the site-level `ew.enabled` config flag — and if either is set, redirects straight to `/canvas` instead of loading the old editor.

This closes the gap where landing on `/edit` (e.g. via a Sidekick "Edit" click, which targets `/edit` regardless of the user's preference) would silently show the old editor even though the user had opted into the new one.

Implementation: `setUI()` in `blocks/edit/edit.js` awaits `isEWEnabled({ org, site })` (from da-nx's `nx2/utils/ewFlags.js`, which itself checks the user flag first and falls back to the site flag) right after resolving path details, and redirects before any old-editor doc-fetch/websocket work starts.

Pairs with adobe/da-nx#714, which stops the toggle from clearing the user's localStorage flag when Sidekick lands you on `/edit` — without that fix, this redirect would rarely fire since the flag would already be cleared by the time you got here.

Fixes #1289

## How Has This Been Tested?
Combine this branch with the companion da-nx branch via the `?nx=togglefix` override:

https://ewredir--da-live--adobe.aem.live/edit?nx=togglefix#/aem-sandbox/block-collection/index

1. Toggle "New Authoring" on (nav switch on `/edit`, or profile menu on `/canvas`) — you land on `/canvas`.
2. Re-visit the `/edit#...` URL above directly (simulating Sidekick bouncing you back to `/edit`) — you're redirected straight back to `/canvas` instead of seeing the old editor.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [x] I have read the CONTRIBUTING document.