### PR TITLE
fix(canvas): suppress controller rerender while editing in block modal

### DIFF
--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.js
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.js
@@ -391,6 +391,11 @@ export class EwEditorDoc extends LitElement {
     setBlockFocus(view, pos);
     this._blockEditName = getTableBlockName(node);
     this._blockEditMode = true;
+    // A full controller redecoration (SET_BODY) tears down and rebuilds the iframe DOM
+    // this modal is live-editing — suppress it for the duration of block edit so it can't
+    // race the target site's own (possibly async) block decoration mid-edit; flushed once
+    // on exit below.
+    if (this._controllerCtx) this._controllerCtx.suppressRerender = true;
     // Un-hide the (layout-hidden) host, but collapse its box via `:host(.block-edit)`
     // so the top-layer dialog doesn't claim a flex slot and shrink the preview.
     this.hidden = false;
@@ -433,6 +438,11 @@ export class EwEditorDoc extends LitElement {
     }
     const view = this._proseContext?.view;
     if (view) clearBlockFocus(view);
+    if (this._controllerCtx) {
+      this._controllerCtx.suppressRerender = false;
+      const body = updateDocument(this._controllerCtx);
+      if (body) canvasBus.editorHtmlState.emit(body);
+    }
     canvasBus.blockEditState.emit({ open: false });
   }
 

--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.js
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.js
@@ -391,10 +391,7 @@ export class EwEditorDoc extends LitElement {
     setBlockFocus(view, pos);
     this._blockEditName = getTableBlockName(node);
     this._blockEditMode = true;
-    // A full controller redecoration (SET_BODY) tears down and rebuilds the iframe DOM
-    // this modal is live-editing — suppress it for the duration of block edit so it can't
-    // race the target site's own (possibly async) block decoration mid-edit; flushed once
-    // on exit below.
+    // Suppress controller redecoration so it can't rebuild the iframe DOM mid-edit.
     if (this._controllerCtx) this._controllerCtx.suppressRerender = true;
     // Un-hide the (layout-hidden) host, but collapse its box via `:host(.block-edit)`
     // so the top-layer dialog doesn't claim a flex slot and shrink the preview.

--- a/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
@@ -57,9 +57,7 @@ function tableJSON(name, ...contentTexts) {
   };
 }
 
-// Replaces the default doc with a single block table, mirroring a page with one authored block.
-// Also returns a position inside the second cell's paragraph text, suitable for tr.split —
-// mirroring what pressing Enter mid-cell does.
+// Like buildDoc but a single block table; also returns a cell text position for tr.split.
 function buildTableDoc(view) {
   const { schema } = view.state;
   const table = schema.nodeFromJSON(tableJSON('grid', 'content'));
@@ -165,13 +163,9 @@ describe('EwEditorDoc — _scrollDocToProseIndex', () => {
   });
 });
 
-// Reproduces the actual bug: opening block-edit hands the live view to a modal, but the
-// controller's tracking plugin (editor-utils/prose-diff.js) still watches every dispatch
-// on that view. A doc change whose common ancestor isn't a single heading/paragraph/list —
-// e.g. Enter splitting a table-cell paragraph into two — fails findCommonEditableAncestor
-// and falls back to a full SET_BODY redecoration. That tears down and rebuilds the iframe
-// DOM the block-edit modal is live-editing, racing the target site's own (possibly async)
-// block decoration against the user's still-in-flight edit.
+// Splitting a table-cell paragraph (e.g. Enter mid-cell) fails findCommonEditableAncestor
+// and falls back to a full SET_BODY redecoration, which races the block-edit modal's
+// live-editing of that same iframe DOM.
 describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
   let editor;
   let el;
@@ -188,8 +182,7 @@ describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
     editor = await createTestEditor({ additionalPlugins: [trackingPlugin] });
     ctx.view = editor.view;
     ({ tablePos, cellTextPos } = buildTableDoc(editor.view));
-    // buildTableDoc's own setup dispatch (a whole-doc replace) also trips the tracking
-    // plugin — clear that noise so counts below reflect only the split under test.
+    // Discard the setup dispatch's own trip through the tracking plugin.
     postMessageCalls.length = 0;
 
     el = document.createElement('ew-editor-doc');
@@ -201,9 +194,6 @@ describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
     destroyEditor(editor);
   });
 
-  // Confirms the premise: splitting a table-cell paragraph (what Enter does) really does
-  // produce a doc change findCommonEditableAncestor rejects, which fires a rerender —
-  // this is the trigger the fix has to suppress.
   it('splitting a table-cell paragraph triggers a rerender outside block edit', () => {
     editor.view.dispatch(editor.view.state.tr.split(cellTextPos));
 
@@ -221,12 +211,8 @@ describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
   });
 });
 
-// A fake iframe controller that models SET_BODY's asynchronous cost — the real target site's
-// loadPage() rebuilds the DOM and awaits its own (possibly slow/async) block decoration
-// before settling. Each postMessage call opens a "redecoration in flight" that only closes
-// when the test explicitly settles it, so a second SET_BODY arriving before that lets us
-// directly observe the overlap — the actual "overlapping loadPage() calls" shape, not just
-// whether postMessage fired.
+// Models SET_BODY's async cost: each postMessage opens a "redecoration in flight" that
+// stays open until settleOldest(), so overlapping calls are directly observable.
 function createFakeIframePort() {
   const calls = [];
   let active = 0;
@@ -251,9 +237,8 @@ function createFakeIframePort() {
   };
 }
 
-// Builds a doc with one table containing two independently-splittable paragraphs, so two
-// separate "Enter" edits can be simulated without reusing a position invalidated by the
-// first split.
+// Two independently-splittable cells, so two "Enter" edits can be simulated without
+// reusing a position invalidated by the first split.
 function buildTwoCellTableDoc(view) {
   const { schema } = view.state;
   const table = schema.nodeFromJSON(tableJSON('grid', 'first cell', 'second cell'));
@@ -302,15 +287,12 @@ describe('EwEditorDoc — block-edit prevents overlapping SET_BODY redecorations
   });
 
   it('two edits in quick succession overlap outside block edit', () => {
-    // First "Enter" starts a redecoration that hasn't settled yet (loadPage still running).
-    // (Yjs's sync plugin can echo more than one tracking-plugin trip per dispatch, so assert
-    // on overlap growth rather than a pinned call count.)
     editor.view.dispatch(editor.view.state.tr.split(cellTextPos.first));
     const activeAfterFirst = port.active;
     expect(activeAfterFirst).to.be.above(0, 'first edit should start a redecoration');
 
-    // A second "Enter" arrives before the first redecoration settles — exactly the shape
-    // of the live bug (Enter, then more edits, while the iframe is mid-rebuild).
+    // Yjs's sync plugin can echo more than one tracking-plugin trip per dispatch, so
+    // assert on overlap growth rather than a pinned call count.
     editor.view.dispatch(editor.view.state.tr.split(cellTextPos.second));
     expect(port.active).to.be.above(activeAfterFirst, 'a second SET_BODY fired while the first was still in flight');
   });

--- a/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
@@ -37,6 +37,35 @@ function buildDoc(view) {
   return { imagePos };
 }
 
+// Mirrors blocks.test.js's tableJSON helper — a minimal authored block table.
+function tableJSON(name, contentText = 'content') {
+  const cell = (text) => ({
+    type: 'table_cell',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  });
+  return {
+    type: 'table',
+    content: [
+      { type: 'table_row', content: [cell(name)] },
+      { type: 'table_row', content: [cell(contentText)] },
+    ],
+  };
+}
+
+// Replaces the default doc with a single block table, mirroring a page with one authored block.
+function buildTableDoc(view) {
+  const { schema } = view.state;
+  const table = schema.nodeFromJSON(tableJSON('grid'));
+  const { content } = schema.nodes.doc.create(null, [table]);
+  view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, content));
+
+  let tablePos = -1;
+  view.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'table') tablePos = pos;
+  });
+  return { tablePos };
+}
+
 describe('EwEditorDoc — _scrollDocToProseIndex', () => {
   let editor;
   let el;
@@ -122,5 +151,50 @@ describe('EwEditorDoc — _scrollDocToProseIndex', () => {
 
       expect(dispatchCalls).to.have.lengthOf(0);
     });
+  });
+});
+
+// Reproduces: opening block-edit hands the live view to a modal while the controller's
+// tracking plugin can still fire a full SET_BODY redecoration mid-edit (e.g. on any doc
+// change whose common ancestor isn't a single heading/paragraph/list — such as an Enter
+// that splits a table-cell paragraph in two). That full redecoration tears down and
+// rebuilds the iframe DOM the block-edit modal is live-editing, racing the target site's
+// own async block decoration against the user's still-in-flight edit.
+describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
+  let editor;
+  let el;
+  let tablePos;
+  let ctx;
+
+  beforeEach(async () => {
+    editor = await createTestEditor();
+    ({ tablePos } = buildTableDoc(editor.view));
+    el = document.createElement('ew-editor-doc');
+    el._proseContext = { view: editor.view };
+    ctx = { view: editor.view, suppressRerender: false, port: { postMessage: () => {} } };
+    el._controllerCtx = ctx;
+  });
+
+  afterEach(() => {
+    destroyEditor(editor);
+  });
+
+  it('suppresses the controller rerender for the duration of block edit', () => {
+    el.enterBlockEdit(tablePos);
+
+    expect(ctx.suppressRerender).to.equal(true);
+  });
+
+  it('flushes exactly one rerender when block edit exits', () => {
+    const postMessageCalls = [];
+    ctx.port.postMessage = (msg) => postMessageCalls.push(msg);
+
+    el.enterBlockEdit(tablePos);
+    expect(ctx.suppressRerender).to.equal(true);
+
+    el.exitBlockEdit();
+
+    expect(ctx.suppressRerender).to.equal(false);
+    expect(postMessageCalls).to.have.lengthOf(1);
   });
 });

--- a/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
@@ -184,9 +184,8 @@ describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
     postMessageCalls = [];
     ctx = { suppressRerender: false, port: { postMessage: (msg) => postMessageCalls.push(msg) } };
 
-    editor = await createTestEditor({
-      additionalPlugins: [createTrackingPlugin(() => updateDocument(ctx))],
-    });
+    const trackingPlugin = createTrackingPlugin(() => updateDocument(ctx));
+    editor = await createTestEditor({ additionalPlugins: [trackingPlugin] });
     ctx.view = editor.view;
     ({ tablePos, cellTextPos } = buildTableDoc(editor.view));
     // buildTableDoc's own setup dispatch (a whole-doc replace) also trips the tracking
@@ -287,9 +286,8 @@ describe('EwEditorDoc — block-edit prevents overlapping SET_BODY redecorations
     port = createFakeIframePort();
     ctx = { suppressRerender: false, port };
 
-    editor = await createTestEditor({
-      additionalPlugins: [createTrackingPlugin(() => updateDocument(ctx))],
-    });
+    const trackingPlugin = createTrackingPlugin(() => updateDocument(ctx));
+    editor = await createTestEditor({ additionalPlugins: [trackingPlugin] });
     ctx.view = editor.view;
     ({ tablePos, cellTextPos } = buildTwoCellTableDoc(editor.view));
     port.reset(); // discard the setup dispatch's own trip through the tracking plugin

--- a/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
@@ -6,8 +6,13 @@ import { createTestEditor, destroyEditor } from '../../edit/prose/test-helpers.j
 
 setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
+let createTrackingPlugin;
+let updateDocument;
+
 before(async () => {
   await import('../../../../../blocks/canvas/ew-editor-doc/ew-editor-doc.js');
+  ({ createTrackingPlugin } = await import('../../../../../blocks/canvas/editor-utils/prose-diff.js'));
+  ({ updateDocument } = await import('../../../../../blocks/canvas/editor-utils/editor-utils.js'));
 });
 
 // Wraps view.dispatch so tests can assert the guarded early-returns in
@@ -53,6 +58,8 @@ function tableJSON(name, contentText = 'content') {
 }
 
 // Replaces the default doc with a single block table, mirroring a page with one authored block.
+// Also returns a position inside the second cell's paragraph text, suitable for tr.split —
+// mirroring what pressing Enter mid-cell does.
 function buildTableDoc(view) {
   const { schema } = view.state;
   const table = schema.nodeFromJSON(tableJSON('grid'));
@@ -60,10 +67,14 @@ function buildTableDoc(view) {
   view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, content));
 
   let tablePos = -1;
+  let cellTextPos = -1;
   view.state.doc.descendants((node, pos) => {
-    if (node.type.name === 'table') tablePos = pos;
+    if (node.type.name === 'table' && tablePos === -1) tablePos = pos;
+    if (node.type.name === 'paragraph' && node.textContent === 'content') {
+      cellTextPos = pos + 1 + Math.floor(node.textContent.length / 2);
+    }
   });
-  return { tablePos };
+  return { tablePos, cellTextPos };
 }
 
 describe('EwEditorDoc — _scrollDocToProseIndex', () => {
@@ -154,24 +165,36 @@ describe('EwEditorDoc — _scrollDocToProseIndex', () => {
   });
 });
 
-// Reproduces: opening block-edit hands the live view to a modal while the controller's
-// tracking plugin can still fire a full SET_BODY redecoration mid-edit (e.g. on any doc
-// change whose common ancestor isn't a single heading/paragraph/list — such as an Enter
-// that splits a table-cell paragraph in two). That full redecoration tears down and
-// rebuilds the iframe DOM the block-edit modal is live-editing, racing the target site's
-// own async block decoration against the user's still-in-flight edit.
+// Reproduces the actual bug: opening block-edit hands the live view to a modal, but the
+// controller's tracking plugin (editor-utils/prose-diff.js) still watches every dispatch
+// on that view. A doc change whose common ancestor isn't a single heading/paragraph/list —
+// e.g. Enter splitting a table-cell paragraph into two — fails findCommonEditableAncestor
+// and falls back to a full SET_BODY redecoration. That tears down and rebuilds the iframe
+// DOM the block-edit modal is live-editing, racing the target site's own (possibly async)
+// block decoration against the user's still-in-flight edit.
 describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
   let editor;
   let el;
   let tablePos;
+  let cellTextPos;
   let ctx;
+  let postMessageCalls;
 
   beforeEach(async () => {
-    editor = await createTestEditor();
-    ({ tablePos } = buildTableDoc(editor.view));
+    postMessageCalls = [];
+    ctx = { suppressRerender: false, port: { postMessage: (msg) => postMessageCalls.push(msg) } };
+
+    editor = await createTestEditor({
+      additionalPlugins: [createTrackingPlugin(() => updateDocument(ctx))],
+    });
+    ctx.view = editor.view;
+    ({ tablePos, cellTextPos } = buildTableDoc(editor.view));
+    // buildTableDoc's own setup dispatch (a whole-doc replace) also trips the tracking
+    // plugin — clear that noise so counts below reflect only the split under test.
+    postMessageCalls.length = 0;
+
     el = document.createElement('ew-editor-doc');
     el._proseContext = { view: editor.view };
-    ctx = { view: editor.view, suppressRerender: false, port: { postMessage: () => {} } };
     el._controllerCtx = ctx;
   });
 
@@ -179,22 +202,22 @@ describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
     destroyEditor(editor);
   });
 
-  it('suppresses the controller rerender for the duration of block edit', () => {
-    el.enterBlockEdit(tablePos);
+  // Confirms the premise: splitting a table-cell paragraph (what Enter does) really does
+  // produce a doc change findCommonEditableAncestor rejects, which fires a rerender —
+  // this is the trigger the fix has to suppress.
+  it('splitting a table-cell paragraph triggers a rerender outside block edit', () => {
+    editor.view.dispatch(editor.view.state.tr.split(cellTextPos));
 
-    expect(ctx.suppressRerender).to.equal(true);
+    expect(postMessageCalls).to.have.lengthOf(1);
   });
 
-  it('flushes exactly one rerender when block edit exits', () => {
-    const postMessageCalls = [];
-    ctx.port.postMessage = (msg) => postMessageCalls.push(msg);
-
+  it('suppresses that rerender for the duration of block edit, then flushes one on exit', () => {
     el.enterBlockEdit(tablePos);
-    expect(ctx.suppressRerender).to.equal(true);
+
+    editor.view.dispatch(editor.view.state.tr.split(cellTextPos));
+    expect(postMessageCalls).to.have.lengthOf(0);
 
     el.exitBlockEdit();
-
-    expect(ctx.suppressRerender).to.equal(false);
     expect(postMessageCalls).to.have.lengthOf(1);
   });
 });

--- a/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/ew-editor-doc.test.js
@@ -43,7 +43,7 @@ function buildDoc(view) {
 }
 
 // Mirrors blocks.test.js's tableJSON helper — a minimal authored block table.
-function tableJSON(name, contentText = 'content') {
+function tableJSON(name, ...contentTexts) {
   const cell = (text) => ({
     type: 'table_cell',
     content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
@@ -52,7 +52,7 @@ function tableJSON(name, contentText = 'content') {
     type: 'table',
     content: [
       { type: 'table_row', content: [cell(name)] },
-      { type: 'table_row', content: [cell(contentText)] },
+      ...contentTexts.map((text) => ({ type: 'table_row', content: [cell(text)] })),
     ],
   };
 }
@@ -62,7 +62,7 @@ function tableJSON(name, contentText = 'content') {
 // mirroring what pressing Enter mid-cell does.
 function buildTableDoc(view) {
   const { schema } = view.state;
-  const table = schema.nodeFromJSON(tableJSON('grid'));
+  const table = schema.nodeFromJSON(tableJSON('grid', 'content'));
   const { content } = schema.nodes.doc.create(null, [table]);
   view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, content));
 
@@ -219,5 +219,112 @@ describe('EwEditorDoc — block-edit suppresses controller rerenders', () => {
 
     el.exitBlockEdit();
     expect(postMessageCalls).to.have.lengthOf(1);
+  });
+});
+
+// A fake iframe controller that models SET_BODY's asynchronous cost — the real target site's
+// loadPage() rebuilds the DOM and awaits its own (possibly slow/async) block decoration
+// before settling. Each postMessage call opens a "redecoration in flight" that only closes
+// when the test explicitly settles it, so a second SET_BODY arriving before that lets us
+// directly observe the overlap — the actual "overlapping loadPage() calls" shape, not just
+// whether postMessage fired.
+function createFakeIframePort() {
+  const calls = [];
+  let active = 0;
+  let maxActive = 0;
+  return {
+    calls,
+    get active() { return active; },
+    get maxActive() { return maxActive; },
+    postMessage(msg) {
+      calls.push(msg);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+    },
+    settleOldest() {
+      active = Math.max(0, active - 1);
+    },
+    reset() {
+      calls.length = 0;
+      active = 0;
+      maxActive = 0;
+    },
+  };
+}
+
+// Builds a doc with one table containing two independently-splittable paragraphs, so two
+// separate "Enter" edits can be simulated without reusing a position invalidated by the
+// first split.
+function buildTwoCellTableDoc(view) {
+  const { schema } = view.state;
+  const table = schema.nodeFromJSON(tableJSON('grid', 'first cell', 'second cell'));
+  const { content } = schema.nodes.doc.create(null, [table]);
+  view.dispatch(view.state.tr.replaceWith(0, view.state.doc.content.size, content));
+
+  let tablePos = -1;
+  const cellTextPos = {};
+  view.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'table' && tablePos === -1) tablePos = pos;
+    if (node.type.name === 'paragraph' && node.textContent === 'first cell') {
+      cellTextPos.first = pos + 1 + Math.floor(node.textContent.length / 2);
+    }
+    if (node.type.name === 'paragraph' && node.textContent === 'second cell') {
+      cellTextPos.second = pos + 1 + Math.floor(node.textContent.length / 2);
+    }
+  });
+  return { tablePos, cellTextPos };
+}
+
+describe('EwEditorDoc — block-edit prevents overlapping SET_BODY redecorations', () => {
+  let editor;
+  let el;
+  let tablePos;
+  let cellTextPos;
+  let ctx;
+  let port;
+
+  beforeEach(async () => {
+    port = createFakeIframePort();
+    ctx = { suppressRerender: false, port };
+
+    editor = await createTestEditor({
+      additionalPlugins: [createTrackingPlugin(() => updateDocument(ctx))],
+    });
+    ctx.view = editor.view;
+    ({ tablePos, cellTextPos } = buildTwoCellTableDoc(editor.view));
+    port.reset(); // discard the setup dispatch's own trip through the tracking plugin
+
+    el = document.createElement('ew-editor-doc');
+    el._proseContext = { view: editor.view };
+    el._controllerCtx = ctx;
+  });
+
+  afterEach(() => {
+    destroyEditor(editor);
+  });
+
+  it('two edits in quick succession overlap outside block edit', () => {
+    // First "Enter" starts a redecoration that hasn't settled yet (loadPage still running).
+    // (Yjs's sync plugin can echo more than one tracking-plugin trip per dispatch, so assert
+    // on overlap growth rather than a pinned call count.)
+    editor.view.dispatch(editor.view.state.tr.split(cellTextPos.first));
+    const activeAfterFirst = port.active;
+    expect(activeAfterFirst).to.be.above(0, 'first edit should start a redecoration');
+
+    // A second "Enter" arrives before the first redecoration settles — exactly the shape
+    // of the live bug (Enter, then more edits, while the iframe is mid-rebuild).
+    editor.view.dispatch(editor.view.state.tr.split(cellTextPos.second));
+    expect(port.active).to.be.above(activeAfterFirst, 'a second SET_BODY fired while the first was still in flight');
+  });
+
+  it('never starts a redecoration during block edit, so none can overlap', () => {
+    el.enterBlockEdit(tablePos);
+
+    editor.view.dispatch(editor.view.state.tr.split(cellTextPos.first));
+    editor.view.dispatch(editor.view.state.tr.split(cellTextPos.second));
+    expect(port.maxActive).to.equal(0, 'block edit must not start any redecoration at all');
+
+    el.exitBlockEdit();
+    expect(port.active).to.be.above(0, 'exiting flushes a redecoration, once it is safe');
   });
 });


### PR DESCRIPTION
Fix #1293 

tested at https://rerender--da-live--adobe.aem.live/

this issue is reproducible on a customer project. after changes appears to be fixed. THis scenario involved some complex auto blocking logic, which may contribute, but I could this this occuring in a few scenarios.