### PR TITLE
fix(canvas): match block variant name case/spacing-insensitively

### DIFF
--- a/blocks/canvas/ew-block-toolbar/ew-block-toolbar.js
+++ b/blocks/canvas/ew-block-toolbar/ew-block-toolbar.js
@@ -122,8 +122,9 @@ class EwBlockToolbar extends LitElement {
     const picker = this._picker;
     if (!picker) return;
     const current = this._currentVariant ?? '';
-    if (current === '' || (this._variantOptions || []).includes(current)) {
-      picker.value = current;
+    const match = (this._variantOptions || []).find((v) => normalizeBlockName(v) === normalizeBlockName(current));
+    if (match) {
+      picker.value = match;
       picker.labelOverride = '';
     } else {
       picker.value = '';

--- a/blocks/canvas/ew-block-toolbar/ew-block-toolbar.js
+++ b/blocks/canvas/ew-block-toolbar/ew-block-toolbar.js
@@ -122,7 +122,8 @@ class EwBlockToolbar extends LitElement {
     const picker = this._picker;
     if (!picker) return;
     const current = this._currentVariant ?? '';
-    const match = (this._variantOptions || []).find((v) => normalizeBlockName(v) === normalizeBlockName(current));
+    const match = (this._variantOptions || [])
+      .find((v) => normalizeBlockName(v) === normalizeBlockName(current));
     if (match) {
       picker.value = match;
       picker.labelOverride = '';

--- a/test/unit/blocks/canvas/ew-block-toolbar/ew-block-toolbar.test.js
+++ b/test/unit/blocks/canvas/ew-block-toolbar/ew-block-toolbar.test.js
@@ -103,6 +103,36 @@ describe('ew-block-toolbar', () => {
     expect(toolbar.shadowRoot.querySelector('nx-picker').value).to.equal('highlight');
   });
 
+  it('selects "No variant" when there is no current variant', async () => {
+    toolbar.show('cards');
+    toolbar._variantOptions = ['wide', 'blue'];
+    await toolbar.updateComplete;
+
+    const picker = toolbar.shadowRoot.querySelector('nx-picker');
+    expect(picker.value).to.equal('');
+    expect(picker.labelOverride).to.equal('');
+  });
+
+  it('matches the current variant case-insensitively', async () => {
+    toolbar.show('cards', 'wide');
+    toolbar._variantOptions = ['Wide'];
+    await toolbar.updateComplete;
+
+    const picker = toolbar.shadowRoot.querySelector('nx-picker');
+    expect(picker.value).to.equal('Wide');
+    expect(picker.labelOverride).to.equal('');
+  });
+
+  it('matches the current variant ignoring spacing differences', async () => {
+    toolbar.show('cards', 'two up');
+    toolbar._variantOptions = ['Two-Up'];
+    await toolbar.updateComplete;
+
+    const picker = toolbar.shadowRoot.querySelector('nx-picker');
+    expect(picker.value).to.equal('Two-Up');
+    expect(picker.labelOverride).to.equal('');
+  });
+
   function editBtn() {
     return toolbar.shadowRoot.querySelector('.block-edit');
   }


### PR DESCRIPTION
## Description

Variant picker checkmark compared doc variant text against library variant names with strict equality, so casing/spacing differences (e.g. "wide" vs "Wide") left the picker unmatched.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

https://varmatch--da-live--adobe.aem.live/

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
