### PR TITLE
fix(e2e): update collab cursor test expected markup

### DIFF
--- a/test/e2e/tests/authenticated/collab.spec.js
+++ b/test/e2e/tests/authenticated/collab.spec.js
@@ -160,6 +160,6 @@ test('Collab cursors in multiple editors', async ({ browser, page, browserName }
   const resp = await page.request.get(sourceUrl, { headers: { Authorization: authHeader } });
   const body = await resp.text();
 
-  const expected = '<main><div><p>From user 2Entered by user 1</p></div></main>';
+  const expected = '<p>From user 2Entered by user 1</p>';
   expect(body).toContain(expected);
 });


### PR DESCRIPTION
## Summary
- Fix the collab cursor e2e test, which expected the saved source to be wrapped in `<main><div>...</div></main>`; the source no longer includes that wrapper.

## Test plan
- [ ] Run `test/e2e/tests/authenticated/collab.spec.js` in CI and confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)