### PR TITLE
fix: strip .html extension when redirecting /edit to /canvas

### DIFF
--- a/blocks/edit/edit.js
+++ b/blocks/edit/edit.js
@@ -44,7 +44,7 @@ async function setUI(el) {
   try {
     const { isEWEnabled } = await getNxEWFlags();
     if (await isEWEnabled({ org: details.org, site: details.site })) {
-      window.location.href = `/canvas#${details.fullpath}`;
+      window.location.href = `/canvas#${details.fullpath.replace(/\.html$/, '')}`;
       return;
     }
   } catch {


### PR DESCRIPTION
## Summary
- `blocks/edit/edit.js` redirects `/edit` to `/canvas` when Experience Workspace is enabled (introduced in #1290), but used `details.fullpath` as-is, which still carries the `.html` suffix added by `getPathDetails`.
- Strips the `.html` suffix before building the `/canvas#...` hash, matching the extensionless-path convention used elsewhere (e.g. `getEditPath` in `blocks/browse/shared.js`, and the same regex already used a few lines below in this file).

## Test plan
- [ ] Enable the Experience Workspace flag, open `/edit#/org/site/page`, confirm redirect lands on `/canvas#/org/site/page` (no `.html` in the hash)