### PR TITLE
fix(canvas): stop hidden doc view reverting remote edits in layout mode

### DIFF
--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.js
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.js
@@ -75,6 +75,9 @@ export class EwEditorDoc extends LitElement {
       port.onmessage = null;
       port.close();
     }
+    if (this._controllerCtx?.reloadTimer) {
+      clearTimeout(this._controllerCtx.reloadTimer);
+    }
     this._controllerCtx = undefined;
   }
 

--- a/blocks/canvas/ew-editor-doc/ew-editor-doc.js
+++ b/blocks/canvas/ew-editor-doc/ew-editor-doc.js
@@ -227,6 +227,9 @@ export class EwEditorDoc extends LitElement {
       path: controllerPathnameFromEditorCtx(this.ctx),
       canWrite: this._canWrite === true,
       getToken: async () => (await loadIms())?.accessToken?.token ?? null,
+      // Relay handlers must not force focus / move the hidden view's caret (see
+      // handleCursorMove) — it makes y-prosemirror clobber incoming remote edits.
+      isDocViewHidden: () => this._editorView === 'layout',
     };
     wireQuickEditControllerPort(this._controllerCtx);
   }
@@ -344,6 +347,9 @@ export class EwEditorDoc extends LitElement {
     this._unsubscribeEditorActive = canvasBus.editorViewState.subscribe(({ view }) => {
       this._editorView = view;
       this.hidden = view === 'layout';
+      // Drop any forced-focus override on the now-hidden doc view; natural
+      // hasFocus() is correct and stops y-prosemirror reconciling against it.
+      if (view === 'layout') delete this._proseContext?.view?.hasFocus;
       hideSelectionToolbar();
     });
     this._unsubscribeWysiwygPortReady = canvasBus.wysiwygPortReady.subscribe(

--- a/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.js
+++ b/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.js
@@ -12,6 +12,18 @@ import { MESSAGE_TYPES } from '../utils/quick-edit-messages.js';
 
 const MUTATING_MESSAGES = new Set(['node-update', 'image-replace', 'history']);
 
+// Coalesce RELOAD bursts (each rebuilds the full body) into one refresh per window;
+// a concurrent remote edit can otherwise fire many in a row and peg the main thread.
+const RELOAD_DEBOUNCE_MS = 150;
+
+function scheduleReload(ctx) {
+  if (ctx.reloadTimer) return;
+  ctx.reloadTimer = setTimeout(() => {
+    ctx.reloadTimer = null;
+    updateDocument(ctx);
+  }, RELOAD_DEBOUNCE_MS);
+}
+
 export function createControllerOnMessage(ctx) {
   return function onMessage(e) {
     const { type, payload = {} } = e.data ?? {};
@@ -21,7 +33,7 @@ export function createControllerOnMessage(ctx) {
     if (type === MESSAGE_TYPES.CURSOR_MOVE) {
       handleCursorMove(payload, ctx);
     } else if (type === MESSAGE_TYPES.RELOAD) {
-      updateDocument(ctx);
+      scheduleReload(ctx);
     } else if (type === MESSAGE_TYPES.IMAGE_REPLACE) {
       handleImageReplace(payload, ctx);
     } else if (type === MESSAGE_TYPES.GET_EDITOR) {

--- a/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
+++ b/blocks/canvas/ew-editor-wysiwyg/utils/handlers.js
@@ -19,6 +19,10 @@ export function handleCursorMove({ cursorOffset, textCursorOffset }, ctx) {
     return;
   }
 
+  // Forcing focus on the hidden doc view makes y-prosemirror reconcile incoming
+  // remote edits against its stale caret and revert them (see commit message).
+  if (ctx.isDocViewHidden?.()) return;
+
   const { state } = view;
   const position = cursorOffset + textCursorOffset;
 

--- a/test/unit/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.test.js
+++ b/test/unit/blocks/canvas/ew-editor-wysiwyg/quick-edit-controller.test.js
@@ -60,3 +60,44 @@ describe('quick-edit-controller message gate', () => {
     expect(ctx._spies.setLocalStateField.calledWith('cursor', null)).to.be.true;
   });
 });
+
+describe('quick-edit-controller RELOAD coalescing', () => {
+  let clock;
+
+  beforeEach(() => { clock = sinon.useFakeTimers(); });
+  afterEach(() => { clock.restore(); });
+
+  // updateDocument only touches view.dom (empty div → no editable elements) and posts
+  // SET_BODY on the port, so a minimal ctx observes each reload run via that spy.
+  function makeReloadCtx() {
+    return {
+      canWrite: true,
+      suppressRerender: false,
+      view: { dom: document.createElement('div') },
+      port: { postMessage: sinon.spy() },
+    };
+  }
+
+  const setBodyCount = (ctx) => ctx.port.postMessage.getCalls()
+    .filter((c) => c.args[0]?.type === 'set-body').length;
+
+  it('coalesces a burst of RELOADs into a single updateDocument', () => {
+    const ctx = makeReloadCtx();
+    const onMessage = createControllerOnMessage(ctx);
+    for (let i = 0; i < 5; i += 1) send(onMessage, { type: 'reload' });
+    // Still inside the debounce window — nothing has fired yet.
+    expect(setBodyCount(ctx)).to.equal(0);
+    clock.tick(200);
+    expect(setBodyCount(ctx)).to.equal(1);
+  });
+
+  it('runs updateDocument again for a RELOAD after the window elapses', () => {
+    const ctx = makeReloadCtx();
+    const onMessage = createControllerOnMessage(ctx);
+    send(onMessage, { type: 'reload' });
+    clock.tick(200);
+    send(onMessage, { type: 'reload' });
+    clock.tick(200);
+    expect(setBodyCount(ctx)).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary

Two collaborative-editing fixes in the Canvas editor, found while debugging "letters vanish / typing blocked" when one user edits in **layout** (quick-edit WYSIWYG) mode while another edits the same document.

**1. Hidden doc view reverting remote edits (root cause of the revert)**
`handleCursorMove` forced `view.hasFocus = () => true` on the live Yjs-bound doc-view ProseMirror even while layout view kept it hidden. That made y-prosemirror's `_isLocalCursorInView()` report `true` for the hidden view, so on every **incoming remote** edit it re-ran its relative-selection restore. The restore dispatch momentarily diverged the PM doc from the Y fragment, and y-prosemirror's `sync-plugin` `update()` hook re-syncs PM→Y unconditionally (it is *not* gated on `isChangeOrigin`) — emitting a spurious delete that reverted the remote peer's just-typed character.

Confirmed signature: user 2 sitting idle in layout mode emitted a ~10-byte delete after every ~18-byte insert received from user 1's typing. Fix: don't force-focus / move the hidden doc view's caret from the `CURSOR_MOVE` relay handler, and drop any lingering forced-focus override when the view becomes hidden. `handleSelectionChange` / `handleNodeSelect` are untouched — they never force `hasFocus`.

**2. RELOAD burst coalescing (defense-in-depth)**
The quick-edit mini-editor posts `RELOAD` (full-body resync) whenever it can't resolve its cached `cursorOffset`; a concurrent remote edit can trigger many in a row. Debounce so a burst collapses into one refresh, and clear the pending timer on port teardown. Pairs with the da-nx drift-tolerant block lookup that removes the primary source of these RELOADs.

## Test

https://collabfx--da-live--adobe.aem.live/canvas?nx=qe-index-drift#/exp-workspace/frescopa/drafts/mhaack/coffee

## Test plan

- [ ] Two users on the same doc: user 1 in doc view typing, user 2 in layout/quick-edit mode → user 1's characters persist (no flash-and-revert).
- [ ] User 2 selecting a block/image or moving the cursor in layout mode does not block or revert user 1's typing.
- [ ] Switching from layout back to doc view lands the caret correctly.
- [ ] No RELOAD storm (main-thread stall) under concurrent editing.
- [ ] Single-user editing, undo/redo, and the selection toolbar behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)