### PR TITLE
fix: Send to Target hangs in /canvas — resolve offer id via active editor view

### DIFF
--- a/blocks/edit/da-prepare/actions/target/utils.js
+++ b/blocks/edit/da-prepare/actions/target/utils.js
@@ -1,6 +1,7 @@
 import { DOMParser as ProseParser } from 'da-y-wrapper';
 import { etcFetch, getAemSiteToken, getFirstSheet } from '../../../../shared/utils.js';
 import { getNx2Api } from '../../../../../scripts/utils.js';
+import { getExtensionsBridge } from '../../../../canvas/editor-utils/extensions-bridge.js';
 import { deleteOffer, getAccessToken, getOffer, saveOffer } from './api.js';
 
 const TARGET_CONFIG_PATH = '/.da/adobe-target.json';
@@ -49,15 +50,22 @@ function findMetadataRow(doc, key) {
   return null;
 }
 
+// `/edit` exposes its ProseMirror view as `window.view`; `/canvas` never sets that
+// global and only exposes its view via the canvas extensions bridge.
+function getActiveView() {
+  return window.view || getExtensionsBridge().view;
+}
+
 function getOfferId() {
-  const { view } = window;
+  const view = getActiveView();
   if (!view) return null;
   const result = findMetadataRow(view.state.doc, 'adobe.target.offerId');
   return result?.value || null;
 }
 
 function setOfferId(offerId) {
-  const { view } = window;
+  const view = getActiveView();
+  if (!view) return;
   const { state } = view;
   const { schema, tr } = state;
 
@@ -95,7 +103,8 @@ function setOfferId(offerId) {
 }
 
 export function removeOfferId() {
-  const { view } = window;
+  const view = getActiveView();
+  if (!view) return;
   const { state } = view;
   const { tr } = state;
 

--- a/test/unit/blocks/edit/da-prepare/actions/target/utils.test.js
+++ b/test/unit/blocks/edit/da-prepare/actions/target/utils.test.js
@@ -3,7 +3,9 @@ import { setNx, getNx2Api } from '../../../../../../../scripts/utils.js';
 
 setNx('/test/fixtures/nx', { hostname: 'example.com' });
 
-const { savePreview, sendToTarget } = await import('../../../../../../../blocks/edit/da-prepare/actions/target/utils.js');
+const { savePreview, sendToTarget, removeOfferId } = await import('../../../../../../../blocks/edit/da-prepare/actions/target/utils.js');
+const { getExtensionsBridge } = await import('../../../../../../../blocks/canvas/editor-utils/extensions-bridge.js');
+const { makeView } = await import('../../../../canvas/test-helpers.js');
 
 describe('target/utils savePreview', () => {
   it('Strips the .html extension before previewing', async () => {
@@ -95,5 +97,62 @@ describe('target/utils sendToTarget', () => {
     // No Authorization header was attached (token exchange failed → fallback).
     expect(captured.opts?.headers?.Authorization).to.equal(undefined);
     expect(result).to.deep.equal({ error: 'Could not fetch from AEM.' });
+  });
+});
+
+const docWithOfferId = {
+  type: 'doc',
+  content: [
+    {
+      type: 'table',
+      content: [
+        {
+          type: 'table_row',
+          content: [
+            { type: 'table_cell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'metadata' }] }] },
+          ],
+        },
+        {
+          type: 'table_row',
+          content: [
+            { type: 'table_cell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'adobe.target.offerId' }] }] },
+            { type: 'table_cell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'existing-offer-123' }] }] },
+          ],
+        },
+        {
+          type: 'table_row',
+          content: [
+            { type: 'table_cell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'description' }] }] },
+            { type: 'table_cell', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A test page' }] }] },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function hasOfferIdRow(view) {
+  let found = false;
+  view.state.doc.descendants((node) => {
+    if (node.isText && node.text === 'adobe.target.offerId') found = true;
+  });
+  return found;
+}
+
+describe('removeOfferId in the /canvas experience (no window.view)', () => {
+  afterEach(() => {
+    delete window.view;
+    getExtensionsBridge().view = null;
+  });
+
+  it('removes the offer id from the canvas ProseMirror doc instead of throwing', () => {
+    // /canvas never assigns window.view — the doc's live EditorView is only
+    // reachable via the canvas extensions bridge.
+    delete window.view;
+    const view = makeView(docWithOfferId);
+    getExtensionsBridge().view = view;
+
+    expect(() => removeOfferId()).to.not.throw();
+    expect(hasOfferIdRow(view)).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary
- "Send to Target" in the preflight menu creates/updates the Adobe Target offer successfully in both `/edit` and `/canvas`, but in `/canvas` the dialog hangs on "Sending to Target..." and never writes the offer id back into the page metadata.
- Root cause: `blocks/edit/da-prepare/actions/target/utils.js` (shared by both `/edit`'s `da-prepare.js` and `/canvas`'s `prepare-menu.js`) reads/writes the offer id by destructuring the global `window.view` ProseMirror view. That global is only set by `/edit`'s classic editor (`blocks/edit/prose/index.js`). `/canvas`'s document editor exposes its view instead via `getExtensionsBridge()` (`blocks/canvas/editor-utils/extensions-bridge.js`) — the same accessor already used by `ew-canvas-versions.js` and `ew-page-outline.js`.
- Because the crash happens on `setOfferId()` *after* the Target API call already succeeded, `/canvas` was silently creating offers in Target without recording the offer id in the page — leaving orphaned offers, duplicate offers on re-send (no `existingOfferId` to update), and a dialog stuck on "Sending to Target...".
- Fix: add a small `getActiveView()` helper that falls back from `window.view` to `getExtensionsBridge().view`, and use it in `getOfferId`, `setOfferId`, and `removeOfferId`, guarding against a missing view instead of throwing. This restores the metadata write-back (the marker that the page was sent, and the basis for update-vs-create) in `/canvas`.

## Test plan
- [x] Added a unit test (`test/unit/blocks/edit/da-prepare/actions/target/utils.test.js`) reproducing the crash: `removeOfferId()` with `window.view` unset and the offer id only reachable via the canvas extensions bridge (fails before the fix, passes after).
- [x] `npm test` — full suite passes (2039 passed, 0 failed).
- [x] `npx eslint` clean on changed files.