### PR TITLE
fix: keep block-edit focus valid across collaborative undo

### DIFF
--- a/blocks/canvas/ew-editor-doc/prose-plugins/blockFocus.js
+++ b/blocks/canvas/ew-editor-doc/prose-plugins/blockFocus.js
@@ -21,6 +21,46 @@ export function getBlockFocus(state) {
   return blockFocusKey.getState(state)?.pos ?? null;
 }
 
+/** True when `pos` is exactly the start offset of a top-level node. */
+function isTopLevelStart(doc, pos) {
+  if (pos == null || pos < 0 || pos > doc.content.size) return false;
+  let found = false;
+  doc.forEach((node, offset) => { if (offset === pos) found = true; });
+  return found;
+}
+
+/** Start offset of the top-level node that contains `pos`, or null. */
+function topLevelStart(doc, pos) {
+  if (pos == null) return null;
+  const clamped = Math.max(0, Math.min(pos, doc.content.size));
+  let result = null;
+  doc.forEach((node, offset) => {
+    if (result == null && clamped >= offset && clamped < offset + node.nodeSize) {
+      result = offset;
+    }
+  });
+  return result;
+}
+
+/**
+ * Resolve the focus position after a transaction.
+ *
+ * Normally the mapped position still lands on the focused block's start and is used
+ * as-is — the focus tracks the block being edited, independent of where the selection
+ * currently is. But some transactions — notably a collaborative Yjs undo, applied as a
+ * large `y-sync` replace — remap the raw position to a garbage offset that no longer sits
+ * on any top-level node. Left uncorrected, the focus decorations then hide *every* block
+ * (including the one being edited), so the block-edit dialog appears empty and the block
+ * looks deleted even though it is still in the document. Only when the mapped position is
+ * no longer a valid top-level start do we re-resolve it to the top-level block that holds
+ * the current selection (which, during block editing, stays inside the focused block).
+ */
+export function resolveBlockFocusPos(doc, mappedPos, selectionFrom) {
+  if (isTopLevelStart(doc, mappedPos)) return mappedPos;
+  const repaired = topLevelStart(doc, selectionFrom);
+  return repaired ?? mappedPos;
+}
+
 /** True when nothing is focused or the selection still sits inside the focused block. */
 export function isSelectionInFocusedBlock(state) {
   const pos = getBlockFocus(state);
@@ -73,11 +113,12 @@ export default function blockFocus() {
     key: blockFocusKey,
     state: {
       init: () => ({ pos: null }),
-      apply(tr, prev) {
+      apply(tr, prev, _oldState, newState) {
         const meta = tr.getMeta(blockFocusKey);
         if (meta !== undefined) return meta;
         if (prev.pos == null) return prev;
-        return { pos: tr.mapping.map(prev.pos) };
+        const mapped = tr.mapping.map(prev.pos);
+        return { pos: resolveBlockFocusPos(newState.doc, mapped, newState.selection.from) };
       },
     },
     props: {

--- a/blocks/canvas/ew-editor-doc/prose-plugins/blockFocus.js
+++ b/blocks/canvas/ew-editor-doc/prose-plugins/blockFocus.js
@@ -43,17 +43,10 @@ function topLevelStart(doc, pos) {
 }
 
 /**
- * Resolve the focus position after a transaction.
- *
- * Normally the mapped position still lands on the focused block's start and is used
- * as-is — the focus tracks the block being edited, independent of where the selection
- * currently is. But some transactions — notably a collaborative Yjs undo, applied as a
- * large `y-sync` replace — remap the raw position to a garbage offset that no longer sits
- * on any top-level node. Left uncorrected, the focus decorations then hide *every* block
- * (including the one being edited), so the block-edit dialog appears empty and the block
- * looks deleted even though it is still in the document. Only when the mapped position is
- * no longer a valid top-level start do we re-resolve it to the top-level block that holds
- * the current selection (which, during block editing, stays inside the focused block).
+ * Focus position after a transaction. Keep the mapped position while it still lands on a
+ * top-level block start; if a transaction (e.g. a collab Yjs undo) remaps it off any
+ * block — which would hide the block being edited — fall back to the block holding the
+ * selection.
  */
 export function resolveBlockFocusPos(doc, mappedPos, selectionFrom) {
   if (isTopLevelStart(doc, mappedPos)) return mappedPos;

--- a/test/unit/blocks/canvas/ew-editor-doc/block-focus.test.js
+++ b/test/unit/blocks/canvas/ew-editor-doc/block-focus.test.js
@@ -13,6 +13,7 @@ const {
   clearBlockFocus,
   getBlockFocus,
   isSelectionInFocusedBlock,
+  resolveBlockFocusPos,
 } = blockFocusMod;
 
 function setParagraphs(editor, texts) {
@@ -79,5 +80,54 @@ describe('blockFocus plugin', () => {
   it('reports true when nothing is focused', () => {
     setParagraphs(editor, ['aa', 'bb']);
     expect(isSelectionInFocusedBlock(editor.view.state)).to.be.true;
+  });
+
+  // A collab (Yjs) undo is applied as a large y-sync replace that can remap the tracked
+  // focus position to a garbage offset. resolveBlockFocusPos keeps a still-valid mapped
+  // position (so focus tracks the block independent of the selection) and only re-resolves
+  // from the selection when the mapped position is no longer a valid top-level start — so
+  // the block being edited stays focused (and visible) instead of being hidden and
+  // appearing deleted.
+  describe('resolveBlockFocusPos', () => {
+    // Paragraph offsets for ['aa','bb','cc']: aa=0 (0..4), bb=4 (4..8), cc=8 (8..12).
+    function threeParaDoc() {
+      setParagraphs(editor, ['aa', 'bb', 'cc']);
+      return editor.view.state.doc;
+    }
+
+    it('keeps a mapped position that still lands on a top-level block start', () => {
+      const doc = threeParaDoc();
+      // mapped=4 ('bb') is valid; focus stays there regardless of the selection (in 'cc').
+      expect(resolveBlockFocusPos(doc, 4, 9)).to.equal(4);
+    });
+
+    it('repairs an out-of-range mapped position using the selection', () => {
+      const doc = threeParaDoc();
+      // 999 is past the doc; selection sits inside 'bb' (pos 5..7) → repaired to 4.
+      expect(resolveBlockFocusPos(doc, 999, 6)).to.equal(4);
+    });
+
+    it('repairs a mapped position that no longer lands on a block boundary', () => {
+      const doc = threeParaDoc();
+      // 6 is inside 'bb' but not a top-level start; selection in 'cc' → repaired to 8.
+      expect(resolveBlockFocusPos(doc, 6, 9)).to.equal(8);
+    });
+
+    it('falls back to the mapped position when the selection cannot be resolved', () => {
+      const doc = threeParaDoc();
+      expect(resolveBlockFocusPos(doc, 999, null)).to.equal(999);
+    });
+
+    it('keeps focus on the block across a normal edit', () => {
+      setParagraphs(editor, ['aa', 'bb', 'cc']);
+      setBlockFocus(editor.view, 4); // focus 'bb'
+      // Edit inside the focused block; the mapped position stays valid → focus stays 'bb'.
+      const { state } = editor.view;
+      editor.view.dispatch(state.tr.insertText('X', 6));
+      const pos = getBlockFocus(editor.view.state);
+      const node = pos == null ? null : editor.view.state.doc.nodeAt(pos);
+      expect(node, 'focused block still resolves to a node').to.exist;
+      expect(node.textContent).to.equal('bXb');
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Fixes #1296

Supersedes #1316 (that PR was auto-closed when its branch was renamed from `fix/block-edit-undo-removes-block` to `undo1296` to satisfy the E2E branch-name spec — `ims.setup.js` requires `/^[a-zA-Z0-9-]{1,8}$/`).

Cmd+Z in the block-edit dialog (semantic layout mode) made the block appear deleted.
The block is not actually removed: an in-dialog undo is applied as a large Yjs y-sync replace that remaps blockFocus's tracked position to a garbage offset, so the focus decorations hide every top-level block -- including the one being edited -- leaving the dialog empty and the block looking deleted.

Re-resolve the focus position after each transaction: keep the mapped position when it still lands on a top-level block start, and only when it no longer does, fall back to the top-level block that holds the current selection (which stays inside the focused block during editing)

## Test

- https://undo1296--da-live--adobe.aem.live/canvas#/exp-workspace/frescopa/accessories

## Motivation and Context

Noticeable impact on the UX: the block looks deleted after undo operation is requested.

## How Has This Been Tested?

- manually tested in Chrome
- unit-tested

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
