### PR TITLE
fix(ew): identify comment authors by email, not IMS userId

### DIFF
--- a/blocks/canvas/comments/comments-panel.js
+++ b/blocks/canvas/comments/comments-panel.js
@@ -4,6 +4,7 @@ import getSheet from '../../shared/sheet.js';
 import { openCommentsPanel, getCommentsBridge } from '../editor-utils/comments-bridge.js';
 import { canvasBus } from '../utils/canvas-bus.js';
 import { buildDeepLinkUrl, parseDeepLink } from './helpers/deep-link.js';
+import { authorKey } from './helpers/author-colors.js';
 import {
   DRAFT_MODES,
   makeNewDraft,
@@ -350,7 +351,8 @@ export class CommentsPanel extends LitElement {
 
   canEditComment(comment) {
     if (!comment || !this.currentUser) return false;
-    return this.currentUser.id === comment.author?.id;
+    const me = authorKey(this.currentUser);
+    return Boolean(me) && me === authorKey(comment.author);
   }
 
   copyThreadLink(threadId = this.controller?.selectedThreadId) {

--- a/blocks/canvas/comments/helpers/format-utils.js
+++ b/blocks/canvas/comments/helpers/format-utils.js
@@ -1,3 +1,5 @@
+import { authorKey } from './author-colors.js';
+
 export function formatTimestamp(timestamp) {
   const date = new Date(timestamp);
   const now = new Date();
@@ -56,9 +58,9 @@ export function getReplySummary({ rootComment, replies }) {
   const seen = new Set();
 
   replies.forEach((reply) => {
-    const authorId = reply.author?.id;
-    if (!authorId || authorId === rootComment.author?.id || seen.has(authorId)) return;
-    seen.add(authorId);
+    const key = authorKey(reply.author);
+    if (!key || key === authorKey(rootComment.author) || seen.has(key)) return;
+    seen.add(key);
     uniqueAuthors.push(reply.author.name);
   });
 

--- a/blocks/canvas/ew-editor-doc/prose.js
+++ b/blocks/canvas/ew-editor-doc/prose.js
@@ -154,6 +154,7 @@ export default async function initProse({
       color: generateColor(identity.colorSeed),
       name: identity.name,
       id: identity.id,
+      email: identity.email,
     });
   } else {
     wsProvider.awareness.setLocalStateField('user', {

--- a/blocks/canvas/ew-editor-doc/utils/collab.js
+++ b/blocks/canvas/ew-editor-doc/utils/collab.js
@@ -5,12 +5,14 @@ export async function getCollabIdentity() {
     const ims = await loadIms();
     if (ims?.anonymous) return null;
     const name = (ims?.displayName || ims?.name || '').trim();
-    const id = ims?.userId || ims?.email || '';
+    const email = ims?.email || '';
+    const id = ims?.userId || email;
     if (name && id) {
       return {
         name,
         id,
-        colorSeed: ims?.email || ims?.userId || name,
+        email,
+        colorSeed: email || ims?.userId || name,
       };
     }
   } catch {

--- a/test/unit/blocks/canvas/comments/helpers/author-colors.test.js
+++ b/test/unit/blocks/canvas/comments/helpers/author-colors.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { buildAuthorColorMap, authorColorSet } from '../../../../../../blocks/canvas/comments/helpers/author-colors.js';
+import { buildAuthorColorMap, authorColorSet, authorKey } from '../../../../../../blocks/canvas/comments/helpers/author-colors.js';
 import { slotColorSet } from '../../../../../../blocks/canvas/editor-utils/author-color.js';
 
 const makeStore = (comments) => ({ forEach: (cb) => comments.forEach((c) => cb(c)) });
@@ -48,5 +48,27 @@ describe('author-colors', () => {
     const store = makeStore([{ author: { email: 'x@y.com' }, createdAt: 1 }]);
     const map = buildAuthorColorMap(store);
     expect(authorColorSet(store, { email: 'x@y.com' }, map)).to.deep.equal(slotColorSet(0));
+  });
+});
+
+describe('authorKey', () => {
+  it('is stable across IMS org profiles, which vary userId but not email', () => {
+    expect(authorKey({ id: 'user-org-a', email: 'me@adobe.com' }))
+      .to.equal(authorKey({ id: 'user-org-b', email: 'me@adobe.com' }));
+  });
+
+  it('separates different emails that share an id', () => {
+    expect(authorKey({ id: 'x', email: 'a@adobe.com' }))
+      .to.not.equal(authorKey({ id: 'x', email: 'b@adobe.com' }));
+  });
+
+  it('falls back to id so email-less authors never collide on empty string', () => {
+    expect(authorKey({ id: 'a' })).to.equal('a');
+    expect(authorKey({ id: 'a' })).to.not.equal(authorKey({ id: 'b' }));
+  });
+
+  it('is empty for a missing or identity-less author', () => {
+    expect(authorKey(null)).to.equal('');
+    expect(authorKey({})).to.equal('');
   });
 });


### PR DESCRIPTION
With #1073, if a user has access to content via e-mail and they switch orgs, they are treated as two separate users (different avatars, and they can't delete the comments added while they were on another IMS org).

Key off email instead of `userId`. 
