### PR TITLE
[EW] Link editor: add Title field

### DIFF
--- a/blocks/canvas/editor-utils/command-helpers.js
+++ b/blocks/canvas/editor-utils/command-helpers.js
@@ -219,13 +219,15 @@ export function getLinkInfoInSelection(state) {
 
 /* ---- Link commands ---- */
 
-export function applyLink(view, { href, text }) {
+export function applyLink(view, { href, text, title }) {
   const { state } = view;
   const trimmedHref = href.trim();
 
   if (isImageNodeSelected(state)) {
     const { from } = state.selection;
-    view.dispatch(state.tr.setNodeAttribute(from, 'href', trimmedHref || null));
+    view.dispatch(state.tr
+      .setNodeAttribute(from, 'href', trimmedHref || null)
+      .setNodeAttribute(from, 'title', title?.trim() || null));
     return;
   }
 
@@ -252,7 +254,11 @@ export function applyLink(view, { href, text }) {
     to = from + displayText.length;
   }
 
-  tr = tr.addMark(from, to, linkType.create({ href: trimmedHref }));
+  tr = tr.addMark(
+    from,
+    to,
+    linkType.create({ href: trimmedHref, title: title?.trim() || null }),
+  );
   tr = tr.setSelection(TextSelection.create(tr.doc, to));
   view.dispatch(tr);
 }

--- a/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
+++ b/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.js
@@ -48,6 +48,7 @@ class EwSelectionToolbar extends LitElement {
     _linkDialogOpen: { state: true },
     _linkHref: { state: true },
     _linkText: { state: true },
+    _linkTitle: { state: true },
     _altDialogOpen: { state: true },
     _altText: { state: true },
     _hasAemAssets: { state: true },
@@ -192,10 +193,12 @@ class EwSelectionToolbar extends LitElement {
     if (info) {
       this._linkHref = info.href;
       this._linkText = info.text;
+      this._linkTitle = info.title;
     } else {
       const { from, to } = this.view.state.selection;
       this._linkHref = '';
       this._linkText = from !== to ? this.view.state.doc.textBetween(from, to) : '';
+      this._linkTitle = '';
     }
     this.hide();
     this._linkDialogOpen = true;
@@ -207,9 +210,9 @@ class EwSelectionToolbar extends LitElement {
   }
 
   _onLinkDialogSubmit(e) {
-    const { href, text } = e.detail;
+    const { href, text, title } = e.detail;
     this._closeLinkDialog();
-    applyLink(this.view, { href, text });
+    applyLink(this.view, { href, text, title });
     this.view.focus();
   }
 
@@ -410,8 +413,10 @@ class EwSelectionToolbar extends LitElement {
       </div>
       <da-link-dialog
         ?open=${this.linkDialogOpen}
+        show-title
         .href=${this._linkHref ?? ''}
         .text=${this._linkText ?? ''}
+        .linkTitle=${this._linkTitle ?? ''}
         @da-link-submit=${this._onLinkDialogSubmit}
         @close=${this._closeLinkDialog}
       ></da-link-dialog>

--- a/blocks/shared/da-link-dialog/da-link-dialog.js
+++ b/blocks/shared/da-link-dialog/da-link-dialog.js
@@ -16,6 +16,8 @@ class DaLinkDialog extends LitElement {
     href: { type: String },
     text: { type: String },
     title: { type: String, attribute: 'dialog-title' },
+    showTitle: { type: Boolean, attribute: 'show-title' },
+    linkTitle: { type: String },
     saveLabel: { type: String },
     _urlError: { state: true },
   };
@@ -38,8 +40,12 @@ class DaLinkDialog extends LitElement {
     }
     this._urlError = '';
     const text = form.elements['link-text'].value;
+    const detail = { href, text };
+    if (this.showTitle) {
+      detail.title = form.elements['link-title'].value.trim();
+    }
     this.dispatchEvent(new CustomEvent('da-link-submit', {
-      detail: { href, text },
+      detail,
       bubbles: true,
       composed: true,
     }));
@@ -70,6 +76,12 @@ class DaLinkDialog extends LitElement {
             <input class="da-input" name="link-text" type="text" placeholder="Link text"
                    autocomplete="off" .value=${this.text ?? ''} />
           </label>
+          ${this.showTitle ? html`
+            <label class="da-form-field">
+              <span>Title</span>
+              <input class="da-input" name="link-title" type="text" placeholder="Link title"
+                     autocomplete="off" .value=${this.linkTitle ?? ''} />
+            </label>` : nothing}
         </form>
         <button type="button" slot="actions" class="da-btn-secondary"
           @click=${this._onCancel}>Cancel</button>

--- a/test/unit/blocks/canvas/editor-utils/command-helpers.test.js
+++ b/test/unit/blocks/canvas/editor-utils/command-helpers.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { EditorState, TextSelection } from 'da-y-wrapper';
+import { EditorState, NodeSelection, TextSelection } from 'da-y-wrapper';
 import { getSchema } from 'da-parser';
 import {
+  applyLink,
   getLinkInfoInSelection,
   selectionHasLink,
   canComment,
@@ -78,5 +79,66 @@ describe('canComment', () => {
 
   it('is true for a non-empty text selection', () => {
     expect(canComment(stateWithRange(1, 6))).to.equal(true);
+  });
+});
+
+describe('applyLink - title', () => {
+  function viewFrom(state) {
+    const view = { state };
+    view.dispatch = (tr) => { view.state = view.state.apply(tr); };
+    return view;
+  }
+
+  function stateWithSelection(from, to) {
+    const para = schema.nodes.paragraph.create(null, schema.text('hello'));
+    const doc = schema.nodes.doc.create(null, para);
+    return EditorState.create({ schema, doc, selection: TextSelection.create(doc, from, to) });
+  }
+
+  function linkMarkOf(state) {
+    let mark = null;
+    state.doc.descendants((node) => {
+      const m = schema.marks.link.isInSet(node.marks);
+      if (m) mark = m;
+    });
+    return mark;
+  }
+
+  it('writes a trimmed title onto the link mark', () => {
+    const view = viewFrom(stateWithSelection(1, 6));
+    applyLink(view, { href: 'https://x.com', text: 'hello', title: '  Tip  ' });
+    const mark = linkMarkOf(view.state);
+    expect(mark.attrs.href).to.equal('https://x.com');
+    expect(mark.attrs.title).to.equal('Tip');
+  });
+
+  it('writes null title when the title is empty', () => {
+    const view = viewFrom(stateWithSelection(1, 6));
+    applyLink(view, { href: 'https://x.com', text: 'hello', title: '' });
+    expect(linkMarkOf(view.state).attrs.title).to.equal(null);
+  });
+
+  it('writes null title when the title is omitted (backward compatible)', () => {
+    const view = viewFrom(stateWithSelection(1, 6));
+    applyLink(view, { href: 'https://x.com', text: 'hello' });
+    expect(linkMarkOf(view.state).attrs.title).to.equal(null);
+  });
+
+  it('writes and clears the title on a selected image', () => {
+    const image = schema.nodes.image.create({ src: '/x.png', href: 'https://old.com' });
+    const para = schema.nodes.paragraph.create(null, image);
+    const doc = schema.nodes.doc.create(null, para);
+    const state = EditorState.create({
+      schema,
+      doc,
+      selection: NodeSelection.create(doc, 1),
+    });
+    const view = viewFrom(state);
+
+    applyLink(view, { href: 'https://x.com', title: '  Tip  ' });
+    expect(view.state.selection.node.attrs.title).to.equal('Tip');
+
+    applyLink(view, { href: 'https://x.com', title: '' });
+    expect(view.state.selection.node.attrs.title).to.equal(null);
   });
 });

--- a/test/unit/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.test.js
+++ b/test/unit/blocks/canvas/ew-selection-toolbar/ew-selection-toolbar.test.js
@@ -107,4 +107,54 @@ describe('ew-selection-toolbar buttons', () => {
     expect(imgNode.attrs.alt).to.equal('New alt');
     expect(toolbar.altDialogOpen).to.be.false;
   });
+
+  it('opens the link dialog with show-title enabled', async () => {
+    setText('hello');
+    selectText(1, 6);
+    toolbar.openLinkDialog(editor.view);
+    await toolbar.updateComplete;
+    const dialog = toolbar.shadowRoot.querySelector('da-link-dialog');
+    expect(dialog.showTitle).to.be.true;
+  });
+
+  it('pre-fills the link title from the current selection', async () => {
+    const { state } = editor.view;
+    const linkMark = state.schema.marks.link.create({
+      href: 'https://x.com',
+      title: 'Existing',
+    });
+    const para = state.schema.nodes.paragraph.create(
+      null,
+      state.schema.text('hello', [linkMark]),
+    );
+    editor.view.dispatch(state.tr.replaceWith(0, state.doc.content.size, para));
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(TextSelection.create(editor.view.state.doc, 3)),
+    );
+    toolbar.openLinkDialog(editor.view);
+    await toolbar.updateComplete;
+    const dialog = toolbar.shadowRoot.querySelector('da-link-dialog');
+    expect(dialog.linkTitle).to.equal('Existing');
+  });
+
+  it('writes a submitted link title onto the mark', async () => {
+    setText('hello');
+    selectText(1, 6);
+    toolbar.openLinkDialog(editor.view);
+    await toolbar.updateComplete;
+    toolbar.shadowRoot.querySelector('da-link-dialog').dispatchEvent(
+      new CustomEvent('da-link-submit', {
+        detail: { href: 'https://x.com', text: 'hello', title: 'Tip' },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await toolbar.updateComplete;
+    let mark;
+    editor.view.state.doc.descendants((node) => {
+      const m = editor.view.state.schema.marks.link.isInSet(node.marks);
+      if (m) mark = m;
+    });
+    expect(mark.attrs.title).to.equal('Tip');
+  });
 });

--- a/test/unit/blocks/shared/da-link-dialog/da-link-dialog.test.js
+++ b/test/unit/blocks/shared/da-link-dialog/da-link-dialog.test.js
@@ -42,6 +42,18 @@ describe('da-link-dialog', () => {
     expect(el.shadowRoot.querySelector('input[name="link-text"]')).to.exist;
   });
 
+  it('does not render the Title field by default', async () => {
+    await mount({ open: true });
+    expect(el.shadowRoot.querySelector('input[name="link-title"]')).to.be.null;
+  });
+
+  it('renders and pre-fills the Title field when show-title is set', async () => {
+    await mount({ open: true, showTitle: true, linkTitle: 'My title' });
+    const titleInput = el.shadowRoot.querySelector('input[name="link-title"]');
+    expect(titleInput).to.exist;
+    expect(titleInput.value).to.equal('My title');
+  });
+
   it('pre-fills href and text inputs from properties', async () => {
     await mount({ open: true, href: 'https://example.com', text: 'Example' });
     const hrefInput = el.shadowRoot.querySelector('input[name="link-href"]');
@@ -61,6 +73,18 @@ describe('da-link-dialog', () => {
     await nextFrame();
 
     expect(detail).to.deep.equal({ href: 'https://test.com', text: 'Test' });
+  });
+
+  it('includes trimmed title in da-link-submit when show-title is set', async () => {
+    await mount({ open: true, showTitle: true });
+    let detail = null;
+    el.addEventListener('da-link-submit', (e) => { detail = e.detail; });
+    el.shadowRoot.querySelector('input[name="link-href"]').value = 'https://test.com';
+    el.shadowRoot.querySelector('input[name="link-text"]').value = 'Test';
+    el.shadowRoot.querySelector('input[name="link-title"]').value = '  Tooltip  ';
+    el.shadowRoot.querySelector('.da-btn-primary').click();
+    await nextFrame();
+    expect(detail).to.deep.equal({ href: 'https://test.com', text: 'Test', title: 'Tooltip' });
   });
 
   it('emits da-link-submit with a relative path', async () => {


### PR DESCRIPTION
## Summary

- add an opt-in Title field to the shared link dialog while leaving the create-file flow unchanged
- persist trimmed titles on text and image links, using null when cleared
- prefill and submit link titles through the EW selection toolbar
- add regression coverage for the dialog, toolbar, text links, and image links

## Testing

- npm test: 2,234 passed, 4 skipped
- npm run lint: passed
- npm run test:e2e: attempted, but Playwright setup could not run because browser binaries are not installed and TEST_PASSWORD is unset; 174 browser tests did not run

Fixes #1318